### PR TITLE
feat(analytics): add Vercel Analytics integration

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,16 +1,17 @@
 {
   "name": "animalcrossingwebapp",
-  "version": "1.0.0",
+  "version": "0.4.0-alpha",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "animalcrossingwebapp",
-      "version": "1.0.0",
+      "version": "0.4.0-alpha",
       "license": "ISC",
       "dependencies": {
         "@types/react": "^19.1.10",
         "@types/react-dom": "^19.1.7",
+        "@vercel/analytics": "^2.0.1",
         "@vitejs/plugin-react": "^5.0.0",
         "autoprefixer": "^10.4.21",
         "class-variance-authority": "^0.7.1",
@@ -1978,6 +1979,48 @@
       },
       "funding": {
         "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/@vercel/analytics": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@vercel/analytics/-/analytics-2.0.1.tgz",
+      "integrity": "sha512-MTQG6V9qQrt1tsDeF+2Uoo5aPjqbVPys1xvnIftXSJYG2SrwXRHnqEvVoYID7BTruDz4lCd2Z7rM1BdkUehk2g==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@remix-run/react": "^2",
+        "@sveltejs/kit": "^1 || ^2",
+        "next": ">= 13",
+        "nuxt": ">= 3",
+        "react": "^18 || ^19 || ^19.0.0-rc",
+        "svelte": ">= 4",
+        "vue": "^3",
+        "vue-router": "^4"
+      },
+      "peerDependenciesMeta": {
+        "@remix-run/react": {
+          "optional": true
+        },
+        "@sveltejs/kit": {
+          "optional": true
+        },
+        "next": {
+          "optional": true
+        },
+        "nuxt": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "svelte": {
+          "optional": true
+        },
+        "vue": {
+          "optional": true
+        },
+        "vue-router": {
+          "optional": true
+        }
       }
     },
     "node_modules/@vitejs/plugin-react": {

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
   "dependencies": {
     "@types/react": "^19.1.10",
     "@types/react-dom": "^19.1.7",
+    "@vercel/analytics": "^2.0.1",
     "@vitejs/plugin-react": "^5.0.0",
     "autoprefixer": "^10.4.21",
     "class-variance-authority": "^0.7.1",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,7 +1,13 @@
+import { Analytics } from '@vercel/analytics/react';
 import ACCanvas from './components/ACCanvas';
 
 function App() {
-  return <ACCanvas />;
+  return (
+    <>
+      <ACCanvas />
+      <Analytics />
+    </>
+  );
 }
 
 export default App;


### PR DESCRIPTION
## Changes

- Add `@vercel/analytics` package (v2.0.1) as a dependency
- Initialize Vercel Analytics component in the main App component to enable visitor and page view tracking
- Update package version to 0.4.0-alpha

## Files Modified

- `package.json`: Added `@vercel/analytics` dependency
- `package-lock.json`: Updated lock file with new dependency
- `src/App.tsx`: Imported and integrated Analytics component for tracking support