### PR TITLE
feat(home): add home screen with seasonal availability and progress overview

### DIFF
--- a/src/components/ACCanvas.tsx
+++ b/src/components/ACCanvas.tsx
@@ -13,8 +13,10 @@ import {
   Clock,
   BarChart2,
   Download,
+  Home,
 } from 'lucide-react';
 import { useAppStore } from '../lib/store';
+import HomeTab from './HomeTab';
 import { downloadCSV } from '../lib/csvExport';
 import ErrorBanner, { type AppErrorKind } from './ErrorBanner';
 import ErrorState from './ErrorState';
@@ -65,7 +67,7 @@ const EMPTY_DONATED_AT: Record<string, string> = {};
 
 // ─── Types ────────────────────────────────────────────────────────────────────
 
-type ViewId = CategoryId | 'activity' | 'search' | 'analytics';
+type ViewId = CategoryId | 'home' | 'activity' | 'search' | 'analytics';
 
 interface AllData {
   fish: FishType[];
@@ -328,6 +330,20 @@ function TabBar({
       className="flex rounded-[14px] overflow-hidden border"
       style={{ borderColor: '#E7DAC4', backgroundColor: '#F5E9D4' }}
     >
+      {/* Home tab */}
+      <button
+        onClick={() => onChange('home')}
+        className="flex-1 flex flex-col items-center gap-0.5 py-2.5 text-[11px] font-medium transition-colors"
+        style={{
+          backgroundColor: active === 'home' ? '#7B5E3B' : 'transparent',
+          color: active === 'home' ? '#F5E9D4' : '#7B5E3B',
+          borderRight: '1px solid #E7DAC4',
+        }}
+      >
+        <Home className="w-4 h-4" />
+        <span>Home</span>
+        <span className="opacity-0" style={{ fontSize: '10px' }}>·</span>
+      </button>
       {CATEGORY_ORDER.map((cat) => {
         const { label, Icon } = CATEGORY_META[cat];
         const isActive = cat === active;
@@ -1230,7 +1246,7 @@ function GlobalSearchResults({
 // ─── ACCanvas (root) ──────────────────────────────────────────────────────────
 
 export default function ACCanvas() {
-  const [activeTab, setActiveTab] = useState<ViewId>('fish');
+  const [activeTab, setActiveTab] = useState<ViewId>('home');
   const [query, setQuery] = useState('');
   const [globalQuery, setGlobalQuery] = useState('');
   const [recentSearches, setRecentSearches] = useState<string[]>([]);
@@ -1283,7 +1299,7 @@ export default function ACCanvas() {
     loadMuseumData();
   }, []);
 
-  const activeCat: CategoryId | null = (activeTab !== 'activity' && activeTab !== 'search' && activeTab !== 'analytics') ? activeTab : null;
+  const activeCat: CategoryId | null = (activeTab !== 'home' && activeTab !== 'activity' && activeTab !== 'search' && activeTab !== 'analytics') ? activeTab : null;
   const activeItems = activeCat ? data[activeCat] as AnyItem[] : [];
 
   const filtered = useMemo(() => {
@@ -1405,7 +1421,15 @@ export default function ACCanvas() {
               data={data}
             />
 
-            {activeTab === 'analytics' ? (
+            {activeTab === 'home' ? (
+              <HomeTab
+                data={data}
+                donated={activeTownDonated}
+                donatedAt={activeTownDonatedAt}
+                catCounts={catCounts}
+                onNavigate={(v) => handleTabChange(v)}
+              />
+            ) : activeTab === 'analytics' ? (
               <AnalyticsView
                 data={data}
                 catCounts={catCounts}

--- a/src/components/HomeTab.tsx
+++ b/src/components/HomeTab.tsx
@@ -1,0 +1,273 @@
+import { useMemo } from 'react';
+import {
+  Fish as FishIcon,
+  Bug,
+  Bone,
+  Palette,
+  BarChart2,
+  Clock,
+  AlertTriangle,
+  Sparkles,
+} from 'lucide-react';
+import type { Fish as FishType, BugItem, FossilItem, ArtPiece, CategoryId } from '../lib/types';
+import { displayName, formatRelativeDate } from '../lib/utils';
+
+const MONTH_FULL = [
+  'January', 'February', 'March', 'April', 'May', 'June',
+  'July', 'August', 'September', 'October', 'November', 'December',
+];
+
+const CAT_ICON: Record<CategoryId, React.ElementType> = {
+  fish: FishIcon,
+  bugs: Bug,
+  fossils: Bone,
+  art: Palette,
+};
+
+const CAT_LABEL: Record<CategoryId, string> = {
+  fish: 'Fish',
+  bugs: 'Bugs',
+  fossils: 'Fossils',
+  art: 'Art',
+};
+
+export interface HomeTabProps {
+  data: {
+    fish: FishType[];
+    bugs: BugItem[];
+    fossils: FossilItem[];
+    art: ArtPiece[];
+  };
+  donated: Record<string, boolean>;
+  donatedAt: Record<string, string>;
+  catCounts: Record<CategoryId, number>;
+  onNavigate: (view: CategoryId | 'activity' | 'analytics') => void;
+}
+
+interface AvailItem {
+  id: string;
+  name: string;
+  category: 'fish' | 'bugs';
+  leavingSoon: boolean;
+}
+
+export default function HomeTab({ data, donated, donatedAt, catCounts, onNavigate }: HomeTabProps) {
+  const now = new Date();
+  const currentMonth = now.getMonth() + 1;
+  const nextMonth = currentMonth === 12 ? 1 : currentMonth + 1;
+  const monthName = MONTH_FULL[currentMonth - 1];
+
+  const available: AvailItem[] = useMemo(() => {
+    const out: AvailItem[] = [];
+    const push = (items: (FishType | BugItem)[], category: 'fish' | 'bugs') => {
+      for (const item of items) {
+        if (!item.months?.includes(currentMonth)) continue;
+        if (donated[item.id]) continue;
+        out.push({
+          id: item.id,
+          name: displayName(item, category),
+          category,
+          leavingSoon: !item.months.includes(nextMonth),
+        });
+      }
+    };
+    push(data.fish, 'fish');
+    push(data.bugs, 'bugs');
+    return out.sort((a, b) => Number(b.leavingSoon) - Number(a.leavingSoon) || a.name.localeCompare(b.name));
+  }, [data.fish, data.bugs, donated, currentMonth, nextMonth]);
+
+  const fishCount = available.filter(a => a.category === 'fish').length;
+  const bugsCount = available.filter(a => a.category === 'bugs').length;
+  const leavingCount = available.filter(a => a.leavingSoon).length;
+
+  const recent = useMemo(() => {
+    const nameMap: Record<string, { name: string; category: CategoryId }> = {};
+    (['fish', 'bugs', 'fossils', 'art'] as CategoryId[]).forEach(cat => {
+      for (const item of data[cat]) {
+        nameMap[item.id] = { name: displayName(item as any, cat), category: cat };
+      }
+    });
+    return Object.entries(donatedAt)
+      .map(([id, ts]) => ({ id, ts, ...nameMap[id] }))
+      .filter(e => e.name)
+      .sort((a, b) => new Date(b.ts).getTime() - new Date(a.ts).getTime())
+      .slice(0, 3);
+  }, [donatedAt, data]);
+
+  const totals: Record<CategoryId, number> = {
+    fish: data.fish.length,
+    bugs: data.bugs.length,
+    fossils: data.fossils.length,
+    art: data.art.length,
+  };
+
+  return (
+    <div className="space-y-4">
+      {/* Hero: Available this month */}
+      <div
+        className="rounded-[16px] border overflow-hidden"
+        style={{ borderColor: '#E7DAC4', backgroundColor: '#FFFDF6' }}
+      >
+        <div
+          className="px-4 py-3 flex items-center gap-2"
+          style={{ background: 'linear-gradient(180deg, #7B5E3B 0%, #6e5234 100%)', color: '#F5E9D4' }}
+        >
+          <Sparkles className="w-4 h-4" />
+          <div className="text-sm font-semibold">Available in {monthName}</div>
+        </div>
+        <div className="px-4 py-4">
+          {available.length === 0 ? (
+            <div className="text-center py-4">
+              <div className="text-2xl mb-1">🎉</div>
+              <div className="text-sm font-medium" style={{ color: '#2A7A52' }}>
+                You're all caught up for {monthName}!
+              </div>
+              <div className="text-xs mt-1" style={{ color: '#5a4a35', opacity: 0.75 }}>
+                Every fish and bug available this month is already in your museum.
+              </div>
+            </div>
+          ) : (
+            <>
+              <div className="text-sm mb-3" style={{ color: '#2A2A2A' }}>
+                <span className="font-semibold">{fishCount}</span> fish and{' '}
+                <span className="font-semibold">{bugsCount}</span> bugs still to donate this month
+                {leavingCount > 0 && (
+                  <>
+                    {' · '}
+                    <span style={{ color: '#b85c2e' }} className="font-medium">
+                      {leavingCount} leaving soon
+                    </span>
+                  </>
+                )}
+                .
+              </div>
+              <div className="space-y-1.5 max-h-72 overflow-y-auto">
+                {available.map(a => {
+                  const Icon = CAT_ICON[a.category];
+                  return (
+                    <div
+                      key={a.id}
+                      className="flex items-center gap-2.5 rounded-[10px] border px-3 py-2"
+                      style={{
+                        borderColor: a.leavingSoon ? '#f0c8a4' : '#E7DAC4',
+                        backgroundColor: a.leavingSoon ? '#fdf3e8' : '#FDF9F1',
+                      }}
+                    >
+                      <Icon className="w-4 h-4 shrink-0" style={{ color: '#7B5E3B' }} />
+                      <div className="flex-1 min-w-0 text-sm truncate" style={{ color: '#2A2A2A' }}>
+                        {a.name}
+                      </div>
+                      {a.leavingSoon && (
+                        <div
+                          className="flex items-center gap-1 text-[11px] font-medium shrink-0"
+                          style={{ color: '#b85c2e' }}
+                        >
+                          <AlertTriangle className="w-3 h-3" />
+                          Leaving after {monthName}
+                        </div>
+                      )}
+                    </div>
+                  );
+                })}
+              </div>
+            </>
+          )}
+        </div>
+      </div>
+
+      {/* Per-category progress grid */}
+      <div className="grid grid-cols-2 gap-3">
+        {(['fish', 'bugs', 'fossils', 'art'] as CategoryId[]).map(cat => {
+          const Icon = CAT_ICON[cat];
+          const done = catCounts[cat];
+          const total = totals[cat];
+          const pct = total ? Math.round((done / total) * 100) : 0;
+          return (
+            <button
+              key={cat}
+              onClick={() => onNavigate(cat)}
+              className="text-left rounded-[14px] border px-4 py-3 transition-colors hover:bg-[#FDF9F1]"
+              style={{ borderColor: '#E7DAC4', backgroundColor: '#FFFDF6' }}
+            >
+              <div className="flex items-center gap-2 mb-1.5">
+                <Icon className="w-4 h-4" style={{ color: '#7B5E3B' }} />
+                <div className="text-sm font-semibold" style={{ color: '#2A2A2A' }}>
+                  {CAT_LABEL[cat]}
+                </div>
+              </div>
+              <div className="text-xs mb-1.5" style={{ color: '#5a4a35' }}>
+                {done} / {total} donated
+              </div>
+              <div className="h-1.5 w-full rounded-full overflow-hidden" style={{ backgroundColor: '#e9dcc3' }}>
+                <div className="h-full transition-all duration-500" style={{ width: `${pct}%`, backgroundColor: '#3CA370' }} />
+              </div>
+            </button>
+          );
+        })}
+      </div>
+
+      {/* Recent activity */}
+      <div
+        className="rounded-[14px] border overflow-hidden"
+        style={{ borderColor: '#E7DAC4', backgroundColor: '#FFFDF6' }}
+      >
+        <div className="px-4 py-2.5 flex items-center justify-between border-b" style={{ borderColor: '#E7DAC4' }}>
+          <div className="flex items-center gap-2">
+            <Clock className="w-4 h-4" style={{ color: '#7B5E3B' }} />
+            <div className="text-sm font-semibold" style={{ color: '#2A2A2A' }}>Recent donations</div>
+          </div>
+          <button
+            onClick={() => onNavigate('activity')}
+            className="text-xs font-medium"
+            style={{ color: '#7B5E3B' }}
+          >
+            View all →
+          </button>
+        </div>
+        {recent.length === 0 ? (
+          <div className="px-4 py-5 text-center text-sm" style={{ color: '#5a4a35', opacity: 0.75 }}>
+            No donations yet.
+          </div>
+        ) : (
+          <div className="divide-y" style={{ borderColor: '#E7DAC4' }}>
+            {recent.map(r => {
+              const Icon = CAT_ICON[r.category];
+              return (
+                <div key={r.id} className="px-4 py-2.5 flex items-center gap-3">
+                  <Icon className="w-4 h-4 shrink-0" style={{ color: '#7B5E3B' }} />
+                  <div className="flex-1 min-w-0 text-sm truncate" style={{ color: '#2A2A2A' }}>
+                    {r.name}
+                  </div>
+                  <div className="text-xs shrink-0" style={{ color: '#5a4a35', opacity: 0.75 }}>
+                    {formatRelativeDate(r.ts)}
+                  </div>
+                </div>
+              );
+            })}
+          </div>
+        )}
+      </div>
+
+      {/* Stats shortcut */}
+      <button
+        onClick={() => onNavigate('analytics')}
+        className="w-full flex items-center gap-3 rounded-[14px] border px-4 py-3 transition-colors hover:bg-[#FDF9F1]"
+        style={{ borderColor: '#E7DAC4', backgroundColor: '#FFFDF6' }}
+      >
+        <div
+          className="shrink-0 rounded-xl p-2"
+          style={{ backgroundColor: '#EDE3D0', border: '1px solid #E7DAC4' }}
+        >
+          <BarChart2 className="w-4 h-4" style={{ color: '#2A7A52' }} />
+        </div>
+        <div className="flex-1 text-left">
+          <div className="text-sm font-semibold" style={{ color: '#2A2A2A' }}>View full stats</div>
+          <div className="text-xs" style={{ color: '#5a4a35', opacity: 0.75 }}>
+            Progress charts and monthly availability
+          </div>
+        </div>
+        <div className="text-sm" style={{ color: '#7B5E3B' }}>→</div>
+      </button>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- Adds home screen as the default tab on launch
- "Available This Month" — fish and bugs catchable right now that haven't been donated
- "Leaving Soon" flag — items not available next month
- Per-category progress cards with progress bars (Fish, Bugs, Fossils, Art)
- Recent donations — last 3 donations front and center
- Stats shortcut to analytics dashboard

## Part of v0.6.0 release