### PR TITLE
fix(v0.6.1): restore source files deleted by bad v0.6.0 merge

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "animalcrossingwebapp",
-  "version": "0.5.0-alpha",
+  "version": "0.6.1",
   "description": "",
   "type": "module",
   "main": "index.js",


### PR DESCRIPTION
## Summary
- The v0.6.0 release merge (`7263cca`) accidentally deleted all source files from `main`, breaking the deployed app
- This branch is based off `affbddb` (the correct post-home-screen state on `development`) with the version bumped to 0.6.1
- HomeTab renders correctly — verified locally with dev server

## What happened
The v0.6.0 merge commit merged `development` into `main` but chose the `development` side's deletions, wiping every file in `src/`, `public/`, `index.html`, etc. from `main`.

## Fix
- Branch off the good `affbddb` commit (development with HomeTab intact)
- Bump version to 0.6.1
- PR this → development → main restores the app

## Test plan
- [ ] `npm run build` passes (clean, no TS errors)
- [ ] Home tab shows "Available in [month]" list, category progress grid, recent donations
- [ ] Home tab is the default active tab on load

🤖 Generated with [Claude Code](https://claude.com/claude-code)