### PR TITLE
feat: edit/rename town (v0.7)

### DIFF
--- a/src/components/ACCanvas.tsx
+++ b/src/components/ACCanvas.tsx
@@ -10,6 +10,7 @@ import {
   X,
   ChevronDown,
   Plus,
+  Pencil,
   Clock,
   BarChart2,
   Download,
@@ -167,6 +168,93 @@ function CreateTownModal({
   );
 }
 
+// ─── EditTownModal ────────────────────────────────────────────────────────────
+
+function EditTownModal({
+  town,
+  onClose,
+}: {
+  town: { id: string; name: string; playerName: string };
+  onClose: () => void;
+}) {
+  const updateTown = useAppStore(s => s.updateTown);
+  const [name, setName] = useState(town.name);
+  const [playerName, setPlayerName] = useState(town.playerName);
+
+  function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    if (!name.trim() || !playerName.trim()) return;
+    updateTown(town.id, name.trim(), playerName.trim());
+    onClose();
+  }
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center"
+      style={{ backgroundColor: 'rgba(42,32,20,0.55)' }}
+      onClick={onClose}
+    >
+      <div
+        className="w-full max-w-sm mx-4 rounded-[20px] overflow-hidden"
+        style={{ backgroundColor: '#FDF9F1', border: '1px solid #E7DAC4' }}
+        onClick={e => e.stopPropagation()}
+      >
+        {/* Header */}
+        <div
+          className="px-6 py-4 flex items-center justify-between"
+          style={{ background: 'linear-gradient(180deg, #7B5E3B 0%, #6e5234 100%)' }}
+        >
+          <h2 className="text-base font-semibold" style={{ color: '#F5E9D4' }}>
+            Edit Town
+          </h2>
+          <button onClick={onClose} style={{ color: '#F5E9D4', opacity: 0.7 }}>
+            <X className="w-4 h-4" />
+          </button>
+        </div>
+
+        <form onSubmit={handleSubmit} className="px-6 py-5 space-y-4">
+          <div>
+            <label className="block text-xs font-medium mb-1.5" style={{ color: '#5a4a35' }}>
+              Town Name
+            </label>
+            <input
+              autoFocus
+              type="text"
+              value={name}
+              onChange={e => setName(e.target.value)}
+              className="w-full rounded-[10px] border px-3 py-2 text-sm outline-none"
+              style={{ borderColor: '#E7DAC4', backgroundColor: '#FFFDF6', color: '#2A2A2A' }}
+            />
+          </div>
+          <div>
+            <label className="block text-xs font-medium mb-1.5" style={{ color: '#5a4a35' }}>
+              Your Name
+            </label>
+            <input
+              type="text"
+              value={playerName}
+              onChange={e => setPlayerName(e.target.value)}
+              className="w-full rounded-[10px] border px-3 py-2 text-sm outline-none"
+              style={{ borderColor: '#E7DAC4', backgroundColor: '#FFFDF6', color: '#2A2A2A' }}
+            />
+          </div>
+          <button
+            type="submit"
+            disabled={!name.trim() || !playerName.trim()}
+            className="w-full py-3 rounded-[12px] text-sm font-semibold transition"
+            style={{
+              backgroundColor: name.trim() && playerName.trim() ? '#3CA370' : '#D9CCBA',
+              color: '#fff',
+            }}
+          >
+            Save Changes
+          </button>
+        </form>
+      </div>
+    </div>
+  );
+}
+
 // ─── TownSwitcher ─────────────────────────────────────────────────────────────
 
 function TownSwitcher({ onCreateNew }: { onCreateNew: () => void }) {
@@ -174,11 +262,13 @@ function TownSwitcher({ onCreateNew }: { onCreateNew: () => void }) {
   const activeTownId = useAppStore(s => s.activeTownId);
   const setActiveTown = useAppStore(s => s.setActiveTown);
   const [open, setOpen] = useState(false);
+  const [editing, setEditing] = useState(false);
 
   const activeTown = towns.find(t => t.id === activeTownId);
   if (!activeTown) return null;
 
   return (
+    <>
     <div className="relative">
       <div className="flex items-center gap-2">
         {/* Town name button — only tappable if multiple towns */}
@@ -196,6 +286,16 @@ function TownSwitcher({ onCreateNew }: { onCreateNew: () => void }) {
             {activeTown.name}
           </span>
         )}
+
+        {/* Edit town button */}
+        <button
+          onClick={() => setEditing(true)}
+          className="flex items-center justify-center rounded-[10px] p-1.5 transition"
+          style={{ backgroundColor: '#EDE3D0', border: '1px solid #E7DAC4' }}
+          aria-label="Edit town"
+        >
+          <Pencil className="w-3.5 h-3.5" style={{ color: '#5a4a35' }} />
+        </button>
 
         {/* New town button */}
         <button
@@ -236,6 +336,10 @@ function TownSwitcher({ onCreateNew }: { onCreateNew: () => void }) {
         </>
       )}
     </div>
+    {editing && (
+      <EditTownModal town={activeTown} onClose={() => setEditing(false)} />
+    )}
+    </>
   );
 }
 

--- a/src/lib/store.ts
+++ b/src/lib/store.ts
@@ -17,6 +17,7 @@ interface AppState {
   donatedAt: Record<string, Record<string, string>>;
 
   createTown: (name: string, playerName: string) => Town;
+  updateTown: (id: string, name: string, playerName: string) => void;
   setActiveTown: (id: string) => void;
   deleteTown: (id: string) => void;
   toggle: (itemId: string) => void;
@@ -47,6 +48,13 @@ export const useAppStore = create<AppState>()(
         set(state => ({ towns: [...state.towns, town], activeTownId: town.id }));
         return town;
       },
+
+      updateTown: (id, name, playerName) =>
+        set(state => ({
+          towns: state.towns.map(t =>
+            t.id === id ? { ...t, name, playerName } : t
+          ),
+        })),
 
       setActiveTown: (id) => set({ activeTownId: id }),
 


### PR DESCRIPTION
## Summary

- Adds `updateTown(id, name, playerName)` action to the Zustand store — updates the matching town in-place; persists automatically via the existing localStorage middleware
- Adds `EditTownModal` component — mirrors the `CreateTownModal` style (wood-gradient header, parchment card, warm earth tones); pre-populated with the current town and player name
- Adds a pencil icon button (`Pencil` from lucide-react) in `TownSwitcher` between the town name and the `+` button; opens the edit modal for the active town

## Test plan

- [ ] Click the pencil button next to the town name in the header
- [ ] Verify modal opens pre-filled with current town name and player name
- [ ] Edit both fields and save — confirm header updates immediately
- [ ] Reload page — confirm changes persisted in localStorage
- [ ] Verify modal dismisses on backdrop click and on the X button
- [ ] Verify no regression to town switching, create-town flow, or donation tracking

🤖 Generated with [Claude Code](https://claude.com/claude-code)