### PR TITLE
docs: v0.7 codebase audit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project are documented here.
 
+## [Unreleased — v0.7.0]
+
+### Added
+- `docs/v0.7-audit.md` — comprehensive codebase audit covering component modularity, type safety, state management, latent bugs, and multi-game architectural readiness
+
+---
+
 ## [v0.6.1] — April 15th, 2026 (Hotfix)
 
 ### Fixed

--- a/docs/v0.7-audit.md
+++ b/docs/v0.7-audit.md
@@ -1,0 +1,265 @@
+# v0.7 Codebase Audit
+
+**Date:** 2026-04-16  
+**Scope:** Full read-only audit ahead of v0.7 architecture work. Covers component modularity, code inconsistencies, latent bugs, state management, TypeScript safety, and multi-game architectural readiness.  
+**Out of scope:** Bug #1 (seasonal analytics) and edit-town modal polish — handled by a parallel session.
+
+---
+
+## Priority Definitions
+
+- **P0 — Blocker:** Will break functionality now or immediately blocks multi-game work.
+- **P1 — High:** Significant tech debt, latent bugs, or architectural issues that compound over time.
+- **P2 — Medium:** Code quality, duplication, or tooling gaps with clear upside to fix.
+
+---
+
+## P0 — Blockers
+
+### P0-1: `@vercel/analytics` package not installed
+**File:** `package.json:34`, `src/App.tsx:1`  
+**Issue:** `@vercel/analytics` is listed in `dependencies` but is missing from `node_modules`. This causes `error TS2307: Cannot find module '@vercel/analytics/react'` on every build. CI will fail whenever the module cache is cold.  
+**Fix:** Run `npm install` to sync the lockfile, or explicitly add/remove the dependency.
+
+### P0-2: Zustand donation schema is 2-level — blocks multi-game
+**File:** `src/lib/store.ts:14-17`  
+```typescript
+donated: Record<string, Record<string, boolean>>;      // [townId][itemId]
+donatedAt: Record<string, Record<string, string>>;     // [townId][itemId]
+```
+**Issue:** Adding a second game immediately creates itemId collisions between games. A Sea Bass in ACGCN and a Sea Bass in ACWW share the same `itemId` key.  
+**Fix:** Expand to 3-level nesting: `Record<townId, Record<gameId, Record<itemId, boolean>>>`. Requires a v2 storage migration (storage key bump from `ac-web:v1`).
+
+### P0-3: `GameId` type is a single-value literal
+**File:** `src/lib/types.ts:1`  
+```typescript
+export type GameId = 'ACGCN';
+```
+**Issue:** No other game can be added without changing this type, and no mechanism exists to route data or UI by game. This is a compile-time blocker for multi-game.  
+**Fix:** Expand to union: `'ACGCN' | 'ACWW' | 'ACCF' | 'ACNL' | 'ACNH'`. Add a `Game` interface for metadata (name, year, regions, hemisphere). Add `gameId: GameId` to `Town` interface.
+
+### P0-4: No store hydration guard — flash of wrong state
+**File:** `src/App.tsx`, `src/lib/store.ts`  
+**Issue:** Zustand's `persist` middleware hydrates asynchronously from localStorage. On first render, `activeTownId` is `null` and `towns` is `[]`. The UI flashes "Create a town" for returning users before hydration completes. There is no loading gate or hydration check.  
+**Fix:** Use Zustand's `onRehydrateStorage` or `useHydration` pattern to defer rendering until hydration completes.
+
+---
+
+## P1 — High Priority
+
+### P1-1: `ACCanvas.tsx` is 1,500+ lines with mixed concerns
+**File:** `src/components/ACCanvas.tsx:1–1628`  
+**Issue:** The root component contains: data fetching, filtering logic, search state, category stats computation, modal orchestration, and rendering for 5+ views. It has 11 local `useState`/`useRef` hooks and 4 separate `useAppStore` calls. This is the primary maintenance burden and conflict surface.  
+**Proposed split:** See [Component Split Plan](#component-split-plan) below. Target is ~350 lines remaining in `ACCanvas.tsx` after extraction.
+
+### P1-2: `Town` interface missing `gameId`
+**File:** `src/lib/store.ts:4-9`  
+```typescript
+interface Town {
+  id: string;
+  name: string;
+  playerName: string;
+  createdAt: string;
+  // missing: gameId: GameId
+}
+```
+**Issue:** There is no way to know which game a town belongs to. Multi-game UI (game switcher, data loading) cannot work without this field. Adding it later requires a store migration.  
+**Fix:** Add `gameId: GameId` to `Town`. Update `createTown` action to accept and persist it.
+
+### P1-3: Unsafe `as` casts in `utils.ts` — no type guards
+**File:** `src/lib/utils.ts:14, 25-27, 31`  
+```typescript
+(item as FishType).notes      // line 31 — BugItem/FossilItem/ArtPiece will silently return undefined
+(item as FishType | BugItem).months  // line 27 — FossilItem/ArtPiece have no months
+```
+**Issue:** These casts bypass TypeScript's protection. `itemNotes()` is called from `ACCanvas.tsx:615` without a category guard — it silently returns `undefined` for non-fish items. If the call site ever passes the wrong category, there is no error.  
+**Fix:** Replace `as` casts with type guards using `'habitat' in item` (fish), `'part' in item` (fossil), `'basedOn' in item` (art). Use a discriminated union with a `category` field on items.
+
+### P1-4: `HomeTab.tsx` has no test coverage and hardcoded month logic
+**File:** `src/components/HomeTab.tsx:55-81`, `HomeTab.tsx:87`  
+**Issue 1:** `const currentMonth = now.getMonth() + 1` and `nextMonth` logic is hardcoded inline and untested. The "leaving soon" and "available now" logic is the HomeTab's core value — if it regresses, no test will catch it.  
+**Issue 2:** Line 87: `displayName(item as any, cat)` — the `any` cast discards all type safety.  
+**Fix:** Add Vitest tests for the availability/leaving-soon memoized logic. Replace `as any` with a proper `AnyItem` union type.
+
+### P1-5: `CreateTownModal` and `EditTownModal` are ~95% identical
+**File:** `src/components/ACCanvas.tsx:82-169` (CreateTownModal), `173-256` (EditTownModal)  
+**Issue:** ~85 lines of nearly identical JSX (gradient header, input fields, button styling). Any UI change must be made twice.  
+**Fix:** Extract a shared `TownModalFrame` wrapper. Both modals become ~30-line wrappers over it.
+
+### P1-6: `ErrorState` and `ErrorBanner` use incompatible error type unions
+**File:** `src/components/ErrorState.tsx:6`, `src/components/ErrorBanner.tsx:6`  
+**Issue:** `ErrorState` handles `'dataLoadFailed' | 'networkError'` (a string union called `LoadErrorKind`). `ErrorBanner` handles a discriminated union `AppErrorKind` that includes `operationFailed` and `validationFailed`. These are different types — you cannot pass an `AppErrorKind` to `ErrorState` without type errors, nor vice versa.  
+**Fix:** Unify under a single discriminated union exported from `types.ts`. `ErrorState` should accept the full `AppErrorKind`.
+
+### P1-7: No top-level error boundary
+**File:** `src/App.tsx`, `src/main.tsx`  
+**Issue:** If `ACCanvas` throws (e.g., corrupted localStorage state, JSON parse failure), the entire app becomes a blank page. There are no React error boundaries anywhere in the tree.  
+**Fix:** Wrap `<App />` (or `<ACCanvas />`) in an error boundary that renders `<ErrorState />`.
+
+### P1-8: `filterByQuery()` utility is not used in ACCanvas filtering
+**File:** `src/components/ACCanvas.tsx:1409-1416`, `src/lib/utils.ts:63-67`  
+**Issue:** `filterByQuery()` exists in utils and is tested, but `ACCanvas` reimplements the same filtering inline at line 1409. The implementations may diverge.  
+**Fix:** Replace the inline filter with the `filterByQuery()` utility call.
+
+### P1-9: FossilItem `part` field should be required
+**File:** `src/lib/types.ts:25-30`, `public/data/acgcn/fossils.json`  
+**Issue:** The TypeScript interface marks `part` as optional (`part?: string`), but every fossil in the JSON has a `part` field. The `displayName()` utility in `utils.ts:5-11` has a code path for missing `part` that is never exercised. If a future JSON accidentally omits `part`, the UI silently renders a wrong name.  
+**Fix:** Mark `part: string` as required in the interface. Add a runtime validation check for the data file.
+
+---
+
+## P2 — Medium Priority
+
+### P2-1: `MONTH_NAMES` / `MONTH_FULL` duplicated across files
+**Files:** `src/components/ACCanvas.tsx:46-49`, `src/components/HomeTab.tsx:15-18`  
+**Issue:** Two separate definitions of the same 12-month array with different variable names.  
+**Fix:** Extract to `src/lib/constants.ts` and import everywhere.
+
+### P2-2: `CATEGORY_META` / `CAT_ICON` / `CAT_LABEL` defined in 3 places
+**Files:** `src/components/ACCanvas.tsx:51-60`, `src/components/HomeTab.tsx:20-32`, `src/lib/csvExport.ts` (hardcoded strings)  
+**Issue:** Category icons, labels, and data-file paths are redefined per-file. Changes to a category label require 3 edits.  
+**Fix:** Export from `src/lib/constants.ts` (or `src/lib/categoryMeta.ts`), import in all consumers.
+
+### P2-3: Inline hex color values repeated ~100+ times
+**Files:** `ACCanvas.tsx`, `HomeTab.tsx`, `ErrorBanner.tsx`, all components  
+**Issue:** `#7B5E3B`, `#F5E9D4`, `#E7DAC4`, `#3CA370`, `#2A2A2A`, `#5a4a35` appear inline in style objects throughout the codebase. Any rebrand or accessibility fix requires a global find-replace.  
+**Fix:** Export a `COLORS` constant from `src/lib/colors.ts`. Use in all style objects.
+
+### P2-4: `fossilDisplayName()` in csvExport duplicates `displayName()` in utils
+**Files:** `src/lib/csvExport.ts:33-35`, `src/lib/utils.ts:5-11`  
+**Issue:** Two implementations of the same logic. If fossil display format changes, both must be updated.  
+**Fix:** Import and call `displayName()` from utils in csvExport.
+
+### P2-5: 4 separate `useAppStore` calls in ACCanvas
+**File:** `src/components/ACCanvas.tsx:1366-1370`  
+**Issue:** Each separate `useAppStore(selector)` subscribes independently. While Zustand batches renders, this is verbose and fragile — adding a fifth selector creates a fifth subscription.  
+**Fix:** Combine into a single selector returning an object, or use shallow equality.
+
+### P2-6: `csvExport.ts` month key parsing lacks validation
+**File:** `src/lib/csvExport.ts:188-189`  
+```typescript
+const [year, month] = key.split('-');
+```
+**Issue:** If a key is ever malformed, `year` and `month` will be `undefined`, leading to a NaN month in the output.  
+**Fix:** Add a guard: `if (parts.length !== 2) continue;`
+
+### P2-7: `eslint-plugin-react` installed but not configured
+**File:** `eslint.config.js`, `package.json:55`  
+**Issue:** The package is in devDependencies and installed, but not imported or used in `eslint.config.js`. It provides valuable rules like `jsx-key`, `no-children-prop`, and `no-array-index-key`.  
+**Fix:** Either add it to the ESLint config or remove it from devDependencies.
+
+### P2-8: No pre-commit hooks
+**Issue:** No Husky or lint-staged configuration. Developers can commit code that fails `npm run lint` or `npm run format:check`. Given CI has `--max-warnings 0`, broken linting is only caught at CI time.  
+**Fix:** Add Husky + lint-staged to run ESLint and Prettier on staged files pre-commit.
+
+### P2-9: No `Game` interface or data loader abstraction
+**File:** `src/lib/types.ts`, `src/components/ACCanvas.tsx:1382-1400`  
+**Issue:** Data loading is hardcoded to `/data/acgcn/` paths in ACCanvas. There is no `Game` metadata type, no data loader function, and no abstraction to swap games. This is the minimum viable addition before Wild World data can be added.  
+**Fix:** Add a `Game` interface and a `loadGameData(gameId: GameId)` function in `src/lib/data.ts`.
+
+### P2-10: Zustand store missing selectors needed for v0.7+ features
+**File:** `src/lib/store.ts`  
+**Issue:** No selectors for: `getCompletionStats(townId)`, `getMissingItems(category)`, `getLastDonationDate(itemId)`. Home tab and analytics recompute these inline, making them untestable.  
+**Fix:** Add computed selectors or expose these as store actions/getters.
+
+### P2-11: No JSON schema validation at load time
+**File:** `src/components/ACCanvas.tsx:1382-1400`  
+**Issue:** All 4 data files are fetched with `fetch().then(r => r.json())` and immediately used as typed arrays. If any file is malformed (e.g., a future game adds new fields, or a data entry has a typo), the error manifests as a UI rendering crash, not a validation error.  
+**Fix:** Add Zod schemas for each category and validate at load time. Surface validation errors via the existing `ErrorBanner`.
+
+### P2-12: Store persistence key `ac-web:v1` has no migration path
+**File:** `src/lib/store.ts:110`  
+**Issue:** When the donation schema changes (P0-2), the persisted v1 data must be migrated to v2 format. Zustand `persist` supports `migrate` and `version` options, but they are not configured. Without a migration, users will lose all donation data on their next visit after the schema change.  
+**Fix:** Add `version: 1` and a `migrate` function to the `persist` options before shipping the schema change from P0-2.
+
+---
+
+## Component Split Plan
+
+Target state for v0.7: `ACCanvas.tsx` shrinks from ~1,500 lines to ~350 lines. The remainder moves to focused files.
+
+### New file structure
+
+```
+src/
+├── components/
+│   ├── ACCanvas.tsx                     (~350 lines — orchestration only)
+│   ├── HomeTab.tsx                      (existing, untouched)
+│   ├── ErrorBanner.tsx                  (existing, untouched)
+│   ├── ErrorState.tsx                   (existing, untouched)
+│   ├── MuseumHeader.tsx                 (NEW — header + TownSwitcher)
+│   ├── TabBar.tsx                       (NEW — extracted from ACCanvas:421-519)
+│   ├── CollectibleRow.tsx               (NEW — extracted from ACCanvas:605-655)
+│   ├── shared/
+│   │   ├── HabitatChip.tsx              (NEW — ACCanvas:571-580)
+│   │   ├── DonateToggle.tsx             (NEW — ACCanvas:584-601)
+│   │   ├── CategoryProgress.tsx         (NEW — ACCanvas:523-542)
+│   │   ├── SearchBar.tsx                (NEW — ACCanvas:546-567)
+│   │   ├── EmptyState.tsx               (NEW — ACCanvas:1154-1163)
+│   │   └── MonthGrid.tsx                (NEW — ACCanvas:659-678)
+│   ├── modals/
+│   │   ├── TownModalFrame.tsx           (NEW — shared structure for both town modals)
+│   │   ├── CreateTownModal.tsx          (NEW — ACCanvas:82-169)
+│   │   ├── EditTownModal.tsx            (NEW — ACCanvas:173-256)
+│   │   └── DetailModal.tsx              (NEW — ACCanvas:682-786)
+│   ├── views/
+│   │   ├── AnalyticsView.tsx            (NEW — ACCanvas:895-1150)
+│   │   ├── ActivityFeed.tsx             (NEW — ACCanvas:790-891)
+│   │   └── SectionCard.tsx              (NEW — ACCanvas:895-918)
+│   └── search/
+│       ├── GlobalSearchBar.tsx          (NEW — ACCanvas:1219-1279)
+│       ├── GlobalSearchResults.tsx      (NEW — ACCanvas:1283-1348)
+│       └── SearchHistoryPopover.tsx     (NEW — ACCanvas:1167-1215)
+├── hooks/
+│   ├── useMuseumData.ts                 (NEW — data fetching, ACCanvas:1382-1404)
+│   ├── useSearch.ts                     (NEW — search history + click-outside)
+│   ├── useCategoryFilter.ts             (NEW — per-category filtering)
+│   └── useCategoryStats.ts             (NEW — donated counts computation)
+└── lib/
+    ├── constants.ts                     (NEW — MONTH_NAMES, CATEGORY_META, COLORS)
+    ├── colors.ts                        (NEW — design token hex values)
+    ├── data.ts                          (NEW — loadGameData(), game registry)
+    ├── store.ts                         (existing — update schema for multi-game)
+    ├── types.ts                         (existing — expand GameId, add Game)
+    ├── utils.ts                         (existing — replace `as` casts with type guards)
+    └── csvExport.ts                     (existing — deduplicate displayName)
+```
+
+### Extraction order (risk-ordered)
+
+1. **Custom hooks first** (`useMuseumData`, `useSearch`) — decouples data/search from rendering
+2. **Shared atomic components** (`HabitatChip`, `DonateToggle`, `MonthGrid`, etc.) — zero coupling, zero risk
+3. **Modals** (`CreateTownModal`, `EditTownModal`, `DetailModal`) — self-contained, props-driven
+4. **Views** (`AnalyticsView`, `ActivityFeed`) — already well-encapsulated
+5. **Search cluster** (`GlobalSearchBar`, `GlobalSearchResults`, `SearchHistoryPopover`)
+6. **`MuseumHeader` + `TownSwitcher`** — medium coupling to store, but manageable
+7. **Refactor root `ACCanvas`** — final step, after everything else is extracted
+
+---
+
+## Multi-Game Architectural Readiness Summary
+
+| Layer | Current State | Blocker? | Minimum change for v0.8 |
+|-------|--------------|----------|------------------------|
+| `GameId` type | Single-value literal | Yes (P0-3) | Expand to union |
+| `Town.gameId` | Missing | Yes (P1-2) | Add field + migration |
+| Donation schema | 2-level | Yes (P0-2) | Add gameId level + migration |
+| Data loading | Hardcoded ACGCN path | Yes (P2-9) | `loadGameData(gameId)` |
+| Item types | No `gameId` on items | Partial | Add `gameId` field |
+| Routing | None (no React Router) | Partial | Add Router for game URLs |
+| JSON validation | None | No | Add Zod before adding new data |
+| Store migration | Not configured | Yes (P0-2 dep) | Add `version`+`migrate` to persist |
+
+---
+
+## Quick Win Checklist
+
+These can be done in isolation with low risk:
+
+- [ ] Extract `MONTH_NAMES` and `CATEGORY_META` to `src/lib/constants.ts` (P2-1, P2-2)
+- [ ] Add `src/lib/colors.ts` with all design token hex values (P2-3)
+- [ ] Deduplicate `fossilDisplayName()` in csvExport (P2-4)
+- [ ] Add month key validation guard in csvExport (P2-6)
+- [ ] Replace `as any` in `HomeTab.tsx:87` with proper type (P1-4)
+- [ ] Add `eslint-plugin-react` to ESLint config or remove from deps (P2-7)
+- [ ] Replace inline ACCanvas filter with `filterByQuery()` from utils (P1-8)


### PR DESCRIPTION
## Summary

- Adds `docs/v0.7-audit.md` — full read-only audit run by 4 parallel subagents covering all major concern areas
- Updates CHANGELOG with unreleased v0.7.0 entry

## What the audit covers

**P0 blockers (4 items)**
- `@vercel/analytics` not installed → breaks every cold build
- Zustand donation schema is 2-level; needs 3-level for multi-game (itemId collisions)
- `GameId` is a single-value literal — compile-time blocker for any second game
- No Zustand hydration guard → returning users see flash of "Create a town"

**P1 high-priority (9 items)**
- ACCanvas.tsx is 1,500+ lines — includes full split plan with 20 target files + 4 custom hooks, ordered by risk
- `Town` missing `gameId` field
- Unsafe `as` casts in utils.ts with no type guards
- HomeTab has zero test coverage and an `as any` cast
- CreateTownModal / EditTownModal are 95% identical
- ErrorBanner and ErrorState use incompatible error type unions
- No top-level error boundary
- `filterByQuery()` utility exists but ACCanvas doesn't use it (reimplements inline)
- FossilItem.part should be required, not optional

**P2 medium (12 items)**
- MONTH_NAMES / CATEGORY_META / color tokens duplicated across 3+ files
- fossilDisplayName() duplicates displayName() from utils
- No pre-commit hooks
- No JSON schema validation at data load time
- No store persistence migration path configured
- …and more (see audit doc for full list)

## Out of scope
Bug #1 (seasonal analytics) and edit-town modal polish are handled by a parallel session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)