### PR TITLE
docs: v0.7 architecture proposal (multi-game foundation)

### DIFF
--- a/docs/v0.7-architecture-proposal.md
+++ b/docs/v0.7-architecture-proposal.md
@@ -1,0 +1,660 @@
+# v0.7 Architecture Proposal
+
+**Author:** Claude (zen-lewin session)  
+**Date:** 2026-04-16  
+**Status:** Awaiting Dispatch review  
+**Targets:** development branch
+
+---
+
+## Overview
+
+This document is a pre-implementation review artifact. No code should be written until Dispatch approves. It addresses all four P0 blockers and the two key P1s (ACCanvas decomposition, shared modal) from the v0.7 audit, and proposes a total migration ordering with explicit dependency edges.
+
+---
+
+## 1. Multi-Game Data Model
+
+### 1.1 GameId — from literal to union
+
+**Current (`src/lib/types.ts:1`):**
+```typescript
+export type GameId = 'ACGCN';
+```
+
+**Proposed:**
+```typescript
+export type GameId = 'ACGCN' | 'ACWW' | 'ACCF' | 'ACNL' | 'ACNH';
+
+export interface Game {
+  id: GameId;
+  name: string;            // "Animal Crossing (GameCube)"
+  shortName: string;       // "Animal Crossing"
+  year: number;            // 2001
+  platform: string;        // "Nintendo GameCube"
+  /** Whether this game has hemisphere-specific availability (NL, NH only) */
+  hasHemispheres: boolean;
+}
+
+export const GAMES: Record<GameId, Game> = {
+  ACGCN: { id: 'ACGCN', name: 'Animal Crossing (GameCube)', shortName: 'Animal Crossing', year: 2001, platform: 'Nintendo GameCube', hasHemispheres: false },
+  ACWW:  { id: 'ACWW',  name: 'Animal Crossing: Wild World',  shortName: 'Wild World',     year: 2005, platform: 'Nintendo DS',       hasHemispheres: false },
+  ACCF:  { id: 'ACCF',  name: 'Animal Crossing: City Folk',   shortName: 'City Folk',      year: 2008, platform: 'Nintendo Wii',      hasHemispheres: false },
+  ACNL:  { id: 'ACNL',  name: 'Animal Crossing: New Leaf',    shortName: 'New Leaf',       year: 2012, platform: 'Nintendo 3DS',      hasHemispheres: true  },
+  ACNH:  { id: 'ACNH',  name: 'Animal Crossing: New Horizons',shortName: 'New Horizons',   year: 2020, platform: 'Nintendo Switch',   hasHemispheres: true  },
+};
+```
+
+`GAMES` lives in `src/lib/types.ts` (or a new `src/lib/games.ts` if the file grows). It is the single source of truth for game metadata. The UI reads from it — no hardcoded strings scattered in components.
+
+---
+
+### 1.2 Town — adding gameId
+
+**Current (`src/lib/store.ts:4-9`):**
+```typescript
+export interface Town {
+  id: string;
+  name: string;
+  playerName: string;
+  createdAt: string;
+}
+```
+
+**Proposed:**
+```typescript
+export interface Town {
+  id: string;
+  name: string;
+  playerName: string;
+  gameId: GameId;    // new — which game this town is from
+  createdAt: string;
+}
+```
+
+`createTown` action signature changes from `(name, playerName)` to `(name, playerName, gameId)`.
+
+Existing towns in localStorage will have no `gameId`. The migration (§2) backfills `'ACGCN'` as the default — there are no other towns that could exist in the current schema.
+
+---
+
+### 1.3 Donation schema — 2-level → 3-level
+
+**Current:**
+```typescript
+// [townId][itemId] = true
+donated:   Record<string, Record<string, boolean>>;
+donatedAt: Record<string, Record<string, string>>;
+```
+
+**Problem:** If ACGCN fish `sea-bass` and ACWW fish `sea-bass` share the same `itemId`, they collide in the same town's namespace. Even if per-game item IDs are kept unique within a game, the current structure provides no structural separation.
+
+**Proposed:**
+```typescript
+// [townId][gameId][itemId] = true
+donated:   Record<string, Record<string, Record<string, boolean>>>;
+donatedAt: Record<string, Record<string, Record<string, string>>>;
+```
+
+**Before/after read example:**
+
+```typescript
+// Before
+const isDonated = donated[townId]?.[itemId] ?? false;
+
+// After
+const isDonated = donated[townId]?.[gameId]?.[itemId] ?? false;
+```
+
+Because each `Town` now carries `gameId`, the store can derive the game from the active town rather than requiring callers to pass it. The `toggle`, `isDonated`, and `getDonatedAt` actions look up `getActiveTown().gameId` internally:
+
+```typescript
+toggle: (itemId) =>
+  set(state => {
+    const { activeTownId } = state;
+    if (!activeTownId) return state;
+    const activeTown = state.towns.find(t => t.id === activeTownId);
+    if (!activeTown) return state;
+    const { gameId } = activeTown;
+
+    const townDonated   = { ...(state.donated[activeTownId]   ?? {}) };
+    const townDonatedAt = { ...(state.donatedAt[activeTownId] ?? {}) };
+    const gameDonated   = { ...(townDonated[gameId]   ?? {}) };
+    const gameDonatedAt = { ...(townDonatedAt[gameId] ?? {}) };
+
+    const nowDonated = !gameDonated[itemId];
+    if (nowDonated) {
+      gameDonated[itemId]   = true;
+      gameDonatedAt[itemId] = new Date().toISOString();
+    } else {
+      delete gameDonated[itemId];
+      delete gameDonatedAt[itemId];
+    }
+
+    return {
+      donated:   { ...state.donated,   [activeTownId]: { ...townDonated,   [gameId]: gameDonated   } },
+      donatedAt: { ...state.donatedAt, [activeTownId]: { ...townDonatedAt, [gameId]: gameDonatedAt } },
+    };
+  }),
+```
+
+Public API (`isDonated`, `getDonatedAt`, `toggle`) remains single-argument — callers never need to pass `gameId`. This is the key design decision: **callers are game-unaware, the store is game-aware via the active town**.
+
+---
+
+### 1.4 Item types — shared vs. per-game availability
+
+Many items exist across multiple games (Sea Bass appears in all five). The proposed model separates the _item identity_ from its _per-game availability_:
+
+```typescript
+/** Core identity of a collectible — game-independent */
+export interface BaseItem {
+  id: string;           // e.g. "sea-bass" — stable across games
+  name: string;
+  category: CategoryId;
+  value: number | null;
+}
+
+/** Per-game availability overlay, keyed by GameId in each data file */
+export interface FishAvailability {
+  months?: number[];    // 1-indexed
+  hours?: number[];
+  habitat: Habitat;
+  notes?: string;
+}
+
+/** A fish item as it appears in a specific game's data file */
+export interface Fish extends BaseItem {
+  category: 'fish';
+  availability: FishAvailability;  // game-specific, loaded from /data/<gameId>/fish.json
+}
+```
+
+**Note:** The JSON data files at `public/data/acgcn/` do not need to be restructured immediately. The data loader (`src/lib/data.ts`, see §2) abstracts the path. When new game data is added, each game gets its own folder (`public/data/acww/`). The `BaseItem.id` values will be kept consistent across games where possible, but the 3-level donation schema prevents any collision regardless.
+
+---
+
+## 2. Store Migration Strategy
+
+### 2.1 Zustand persist configuration
+
+**Current (`src/lib/store.ts:110`):**
+```typescript
+{ name: 'ac-web:v1' }
+```
+
+**Proposed:**
+```typescript
+persist(
+  // ... store implementation ...
+  {
+    name: 'ac-web',          // stable key — version is tracked internally by Zustand
+    version: 2,              // bump from implied v1
+    migrate: (persistedState: unknown, fromVersion: number) => {
+      return migrateStore(persistedState, fromVersion);
+    },
+  }
+)
+```
+
+Using `name: 'ac-web'` (no version suffix) with Zustand's built-in `version` field is preferred over renaming the key. Renaming the key orphans old data entirely — Zustand's `migrate` function receives the old state, allowing a lossless upgrade.
+
+### 2.2 Migration function
+
+```typescript
+function migrateStore(persisted: unknown, fromVersion: number): AppState {
+  let state = persisted as Record<string, unknown>;
+
+  if (fromVersion < 2) {
+    // v1 → v2:
+    // 1. Backfill Town.gameId = 'ACGCN' for all existing towns
+    // 2. Lift donated/donatedAt from [townId][itemId] to [townId][gameId][itemId]
+
+    const towns = (state.towns as Town[] | undefined) ?? [];
+    const migratedTowns = towns.map(t => ({ ...t, gameId: t.gameId ?? 'ACGCN' }));
+
+    const oldDonated   = (state.donated   as Record<string, Record<string, boolean>> | undefined) ?? {};
+    const oldDonatedAt = (state.donatedAt as Record<string, Record<string, string>>  | undefined) ?? {};
+
+    const newDonated:   Record<string, Record<string, Record<string, boolean>>> = {};
+    const newDonatedAt: Record<string, Record<string, Record<string, string>>>  = {};
+
+    for (const townId of Object.keys(oldDonated)) {
+      newDonated[townId]   = { ACGCN: oldDonated[townId] };
+    }
+    for (const townId of Object.keys(oldDonatedAt)) {
+      newDonatedAt[townId] = { ACGCN: oldDonatedAt[townId] };
+    }
+
+    state = {
+      ...state,
+      towns:     migratedTowns,
+      donated:   newDonated,
+      donatedAt: newDonatedAt,
+    };
+  }
+
+  // Future: if (fromVersion < 3) { ... }
+
+  return state as AppState;
+}
+```
+
+**Key properties:**
+- Idempotent: towns that already have `gameId` are not overwritten (due to `?? 'ACGCN'`).
+- Zero data loss: all existing donations are preserved under the `ACGCN` game key.
+- Extensible: `fromVersion < 3` block can be added for subsequent schema changes.
+- The function lives in `src/lib/store.ts` or a new `src/lib/storeMigrations.ts` if it grows.
+
+### 2.3 Storage key change
+
+The current key is `'ac-web:v1'`. Moving to `'ac-web'` with Zustand's `version` field is the right call, but it means old `localStorage['ac-web:v1']` data will not be migrated automatically — Zustand only calls `migrate` when it finds data under the configured `name`.
+
+**Two options:**
+
+**Option A — One-time bootstrap migration (recommended):**  
+On app startup (before the store initializes), check if `localStorage['ac-web:v1']` exists. If so, copy it to `localStorage['ac-web']` and remove the old key. This runs once, then Zustand's `migrate` handles subsequent upgrades.
+
+```typescript
+// src/lib/bootstrapMigration.ts — called from main.tsx before React mounts
+export function bootstrapLocalStorageMigration(): void {
+  const OLD_KEY = 'ac-web:v1';
+  const NEW_KEY = 'ac-web';
+  const old = localStorage.getItem(OLD_KEY);
+  if (old && !localStorage.getItem(NEW_KEY)) {
+    localStorage.setItem(NEW_KEY, old);
+  }
+  // Always clean up the old key after migration is confirmed
+  if (localStorage.getItem(NEW_KEY)) {
+    localStorage.removeItem(OLD_KEY);
+  }
+}
+```
+
+**Option B — Keep the `:v1` suffix, bump to `:v2`:**  
+Rename the key to `'ac-web:v2'` and manually copy data in `main.tsx`. Simpler, but doesn't use Zustand's `migrate` machinery for future bumps.
+
+**Recommendation: Option A.** It unblocks future schema changes using Zustand's built-in migration path.
+
+---
+
+## 3. Hydration Guard
+
+**Problem:** Zustand `persist` rehydrates asynchronously. On first render, `towns: []` and `activeTownId: null`. Returning users see "Create a town" for ~50ms before the real state loads.
+
+**Proposed approach — `useHydration` hook:**
+
+```typescript
+// src/hooks/useHydration.ts
+import { useEffect, useState } from 'react';
+import { useAppStore } from '../lib/store';
+
+export function useHydration(): boolean {
+  const [hydrated, setHydrated] = useState(false);
+
+  useEffect(() => {
+    // Zustand sets _hasHydrated once rehydration completes
+    const unsub = useAppStore.persist.onFinishHydration(() => setHydrated(true));
+    // In case hydration already finished before this effect ran:
+    setHydrated(useAppStore.persist.hasHydrated());
+    return unsub;
+  }, []);
+
+  return hydrated;
+}
+```
+
+**Usage in `App.tsx`:**
+```tsx
+function App() {
+  const hydrated = useHydration();
+
+  if (!hydrated) {
+    return (
+      <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'center', height: '100vh', background: '#F5E9D4' }}>
+        {/* Skeleton or spinner — keeps parchment background visible, no flash */}
+        <span style={{ color: '#7B5E3B', fontFamily: 'Varela Round, sans-serif' }}>Loading museum…</span>
+      </div>
+    );
+  }
+
+  return <ACCanvas />;
+}
+```
+
+**Why not suspense?** Zustand `persist` does not integrate with React Suspense. The `onFinishHydration` callback is the canonical Zustand v5 approach.
+
+**Alternative — `skipHydration` + manual rehydrate:**  
+Zustand supports `skipHydration: true` in persist options, with a manual `useAppStore.persist.rehydrate()` call in `useEffect`. This gives explicit control but is more complex. Recommended only if the loading state needs to be coordinated with other async work (e.g., fetching game data). For now, the `onFinishHydration` pattern is sufficient.
+
+---
+
+## 4. ACCanvas Decomposition Plan
+
+The audit's split plan is confirmed with minor adjustments noted below.
+
+### 4.1 Target file structure
+
+```
+src/
+├── components/
+│   ├── ACCanvas.tsx                     (~350 lines — orchestration shell only)
+│   ├── HomeTab.tsx                      (existing, untouched)
+│   ├── ErrorBanner.tsx                  (existing, untouched)
+│   ├── ErrorState.tsx                   (existing, untouched)
+│   ├── MuseumHeader.tsx                 (NEW — header bar + TownSwitcher dropdown)
+│   ├── TabBar.tsx                       (NEW — tab navigation strip)
+│   ├── CollectibleRow.tsx               (NEW — single item row with donate toggle)
+│   ├── shared/
+│   │   ├── HabitatChip.tsx              (NEW — fish habitat badge)
+│   │   ├── DonateToggle.tsx             (NEW — checkbox/button to mark donated)
+│   │   ├── CategoryProgress.tsx         (NEW — "X / Y donated" bar)
+│   │   ├── SearchBar.tsx                (NEW — per-tab inline search)
+│   │   ├── EmptyState.tsx               (NEW — "Nothing here yet" placeholder)
+│   │   └── MonthGrid.tsx                (NEW — 12-cell month availability grid)
+│   ├── modals/
+│   │   ├── TownModalFrame.tsx           (NEW — see §5)
+│   │   ├── CreateTownModal.tsx          (NEW — wraps TownModalFrame)
+│   │   ├── EditTownModal.tsx            (NEW — wraps TownModalFrame)
+│   │   └── DetailModal.tsx              (NEW — item detail sheet)
+│   ├── views/
+│   │   ├── AnalyticsView.tsx            (NEW — charts + stats)
+│   │   ├── ActivityFeed.tsx             (NEW — recent donations list)
+│   │   └── SectionCard.tsx              (NEW — reusable card wrapper)
+│   └── search/
+│       ├── GlobalSearchBar.tsx          (NEW)
+│       ├── GlobalSearchResults.tsx      (NEW)
+│       └── SearchHistoryPopover.tsx     (NEW)
+├── hooks/
+│   ├── useMuseumData.ts                 (NEW — fetches and caches all 4 category JSONs)
+│   ├── useSearch.ts                     (NEW — search history, click-outside, debounce)
+│   ├── useCategoryFilter.ts             (NEW — donated/undonated/all filter + query)
+│   └── useCategoryStats.ts             (NEW — memoized donated counts per category)
+└── lib/
+    ├── constants.ts                     (NEW — MONTH_NAMES, CATEGORY_META)
+    ├── colors.ts                        (NEW — design token hex values)
+    ├── data.ts                          (NEW — loadGameData, game registry)
+    ├── storeMigrations.ts               (NEW — migrateStore function)
+    ├── store.ts                         (updated schema + migration wiring)
+    ├── types.ts                         (updated — GameId union, Game, Town.gameId)
+    ├── utils.ts                         (updated — replace `as` casts with type guards)
+    └── csvExport.ts                     (updated — dedup displayName)
+```
+
+### 4.2 Dependency graph
+
+The arrows below show "depends on" (must exist before its dependent is extracted):
+
+```
+lib/constants.ts ──────────────────────────────────────────────────────┐
+lib/colors.ts ─────────────────────────────────────────────────────────┤
+lib/types.ts (expanded) ───────────────────────────────────────────────┤
+lib/store.ts (v2 schema) ──────────────────────────────────────────────┤
+                                                                        ▼
+hooks/useMuseumData.ts ─────────────────────────────────────────────> CollectibleRow.tsx
+hooks/useCategoryStats.ts ─────────────────────────────────────────> CategoryProgress.tsx
+hooks/useCategoryFilter.ts ────────────────────────────────────────> CollectibleRow.tsx
+hooks/useSearch.ts ────────────────────────────────────────────────> GlobalSearchBar.tsx
+
+shared/HabitatChip.tsx ────────────────────────────────────────────┐
+shared/DonateToggle.tsx ───────────────────────────────────────────┤
+shared/MonthGrid.tsx ──────────────────────────────────────────────┤
+                                                                    ▼
+                                                           CollectibleRow.tsx
+
+modals/TownModalFrame.tsx ─────────────────────────────────────────┐
+                                                                    ▼
+                                               CreateTownModal.tsx, EditTownModal.tsx
+
+CollectibleRow.tsx ────────────────────────────────────────────────┐
+MuseumHeader.tsx ──────────────────────────────────────────────────┤
+TabBar.tsx ────────────────────────────────────────────────────────┤
+views/AnalyticsView.tsx ───────────────────────────────────────────┤
+views/ActivityFeed.tsx ────────────────────────────────────────────┤
+search/* ──────────────────────────────────────────────────────────┤
+modals/* ──────────────────────────────────────────────────────────┤
+                                                                    ▼
+                                                         ACCanvas.tsx (final refactor)
+```
+
+**Adjustment from audit plan:** `lib/data.ts` (game data loader) is explicitly called out as a dependency of `useMuseumData`. The audit mentioned it in P2-9 but did not include it in the extraction order. It must be written before the custom hooks, since `useMuseumData` will call `loadGameData(gameId)`.
+
+### 4.3 What stays in ACCanvas.tsx after extraction
+
+After all extractions, `ACCanvas.tsx` becomes an orchestration shell (~350 lines) responsible for:
+- Mounting the active tab view (switch on `activeTab`)
+- Passing the town/game context down to mounted views
+- Rendering the modal stack (`CreateTownModal`, `EditTownModal`, `DetailModal`)
+- Wiring the global search bar
+
+No data fetching, no filtering logic, no inline styles for sub-components.
+
+---
+
+## 5. Shared Modal Extraction — TownModalFrame
+
+### 5.1 Design
+
+`TownModalFrame` is a presentational wrapper with no store access. Both `CreateTownModal` and `EditTownModal` pass their content as props/children.
+
+```typescript
+// src/components/modals/TownModalFrame.tsx
+
+interface TownModalFrameProps {
+  title: string;
+  onClose: () => void;
+  onSubmit: () => void;
+  submitLabel: string;
+  submitDisabled?: boolean;
+  children: React.ReactNode;  // form fields
+}
+
+export function TownModalFrame({
+  title, onClose, onSubmit, submitLabel, submitDisabled = false, children
+}: TownModalFrameProps) {
+  return (
+    <div style={{ /* overlay */ }}>
+      <div style={{ background: '#F5E9D4', borderRadius: 12, /* etc */ }}>
+        {/* Gradient header */}
+        <div style={{ background: 'linear-gradient(135deg, #7B5E3B, #5a4a35)', padding: '20px 24px', borderRadius: '12px 12px 0 0' }}>
+          <h2 style={{ color: '#F5E9D4', fontFamily: 'Varela Round, sans-serif' }}>{title}</h2>
+          <button onClick={onClose} style={{ /* close × button */ }}>×</button>
+        </div>
+
+        {/* Form body */}
+        <div style={{ padding: 24 }}>
+          {children}
+        </div>
+
+        {/* Footer */}
+        <div style={{ padding: '0 24px 24px', display: 'flex', gap: 12, justifyContent: 'flex-end' }}>
+          <button onClick={onClose} style={{ /* cancel style */ }}>Cancel</button>
+          <button onClick={onSubmit} disabled={submitDisabled} style={{ /* primary style */ }}>
+            {submitLabel}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
+```
+
+**CreateTownModal** becomes:
+```typescript
+export function CreateTownModal({ onClose }: { onClose: () => void }) {
+  const [name, setName] = useState('');
+  const [player, setPlayer] = useState('');
+  const [gameId, setGameId] = useState<GameId>('ACGCN');
+  const createTown = useAppStore(s => s.createTown);
+
+  return (
+    <TownModalFrame
+      title="New Town"
+      onClose={onClose}
+      onSubmit={() => { createTown(name, player, gameId); onClose(); }}
+      submitLabel="Create Town"
+      submitDisabled={!name.trim()}
+    >
+      {/* name input, player input, game selector */}
+    </TownModalFrame>
+  );
+}
+```
+
+**EditTownModal** becomes the same pattern with pre-populated state and `updateTown`.
+
+### 5.2 Game selector field
+
+Because `Town` now has `gameId`, `CreateTownModal` gains a game selector. `EditTownModal` should **not** allow changing `gameId` after creation — the game is immutable once a town has donation data. Showing a disabled badge ("Animal Crossing GCN") is the right UX.
+
+---
+
+## 6. Migration Ordering
+
+The following ordering respects all dependency edges and minimizes risk. Each step is independently reviewable.
+
+### Step 1 — Foundation (no user-visible change)
+
+**Dependencies:** none  
+**Files:** `src/lib/types.ts`, `src/lib/constants.ts`, `src/lib/colors.ts`
+
+- Expand `GameId` to the full union type
+- Add `Game` interface and `GAMES` registry
+- Extract `MONTH_NAMES` and `CATEGORY_META` to `constants.ts`
+- Create `colors.ts` with design token hex constants
+
+This is pure type/constant work. Zero runtime risk. All existing code continues to compile because `'ACGCN'` is still a valid `GameId`.
+
+---
+
+### Step 2 — Store schema + migration (data integrity critical)
+
+**Dependencies:** Step 1  
+**Files:** `src/lib/store.ts`, `src/lib/storeMigrations.ts`, `src/lib/bootstrapMigration.ts`, `src/main.tsx`
+
+- Write `bootstrapMigration.ts` and call it in `main.tsx` before `createRoot`
+- Write `migrateStore` in `storeMigrations.ts`
+- Add `Town.gameId: GameId`
+- Update `createTown` action signature to accept `gameId`
+- Lift `donated`/`donatedAt` to 3-level schema
+- Update `toggle`, `isDonated`, `getDonatedAt` to read `gameId` from active town
+- Wire `version: 2` + `migrate` into `persist` options
+- Change store `name` from `'ac-web:v1'` to `'ac-web'`
+
+**Verification before merging:** Run a manual localStorage round-trip test. Populate v1 data in devtools, reload, confirm v2 schema appears correctly.
+
+---
+
+### Step 3 — Hydration guard
+
+**Dependencies:** Step 2  
+**Files:** `src/hooks/useHydration.ts`, `src/App.tsx`
+
+- Write `useHydration` hook
+- Add hydration gate in `App.tsx`
+
+Isolated, self-contained, no coupling to the decomposition work.
+
+---
+
+### Step 4 — Custom hooks extraction
+
+**Dependencies:** Steps 1 + 2  
+**Files:** `src/hooks/useMuseumData.ts`, `src/lib/data.ts`, `src/hooks/useSearch.ts`, `src/hooks/useCategoryFilter.ts`, `src/hooks/useCategoryStats.ts`
+
+- Write `data.ts` with `loadGameData(gameId: GameId)` (resolves path `public/data/${gameId.toLowerCase()}/`)
+- Extract `useMuseumData` to call `loadGameData`
+- Extract `useSearch` (search history, click-outside, debounce)
+- Extract `useCategoryFilter` (donated/undonated/all + query filter)
+- Extract `useCategoryStats` (memoized donated counts)
+
+ACCanvas still uses these hooks internally at this point — the function signatures move, but ACCanvas is not yet decomposed.
+
+---
+
+### Step 5 — Atomic shared components
+
+**Dependencies:** Step 1 (colors/constants)  
+**Files:** `src/components/shared/*`
+
+- `HabitatChip`, `DonateToggle`, `CategoryProgress`, `SearchBar`, `EmptyState`, `MonthGrid`
+
+These have zero store access. Pure props-driven UI. Can be extracted one at a time. Each extraction shrinks ACCanvas by ~15–30 lines.
+
+---
+
+### Step 6 — Modals
+
+**Dependencies:** Steps 1 + 2 (for `GameId` in `CreateTownModal`)  
+**Files:** `src/components/modals/*`
+
+- Extract `TownModalFrame`
+- Extract `CreateTownModal` (gains game selector)
+- Extract `EditTownModal` (game field shows as disabled badge)
+- Extract `DetailModal`
+
+---
+
+### Step 7 — Views and search cluster
+
+**Dependencies:** Steps 4 + 5  
+**Files:** `src/components/views/*`, `src/components/search/*`, `src/components/MuseumHeader.tsx`, `src/components/TabBar.tsx`, `src/components/CollectibleRow.tsx`
+
+- Extract `AnalyticsView`, `ActivityFeed`, `SectionCard`
+- Extract `GlobalSearchBar`, `GlobalSearchResults`, `SearchHistoryPopover`
+- Extract `MuseumHeader`, `TabBar`, `CollectibleRow`
+
+---
+
+### Step 8 — Final ACCanvas refactor
+
+**Dependencies:** All of Steps 4–7  
+**Files:** `src/components/ACCanvas.tsx`
+
+- Strip all extracted code, wire up imported components and hooks
+- Target: ~350 lines, orchestration only
+- Full regression test of all four museum tabs, search, town switching, modals
+
+---
+
+### Step 9 — P2 cleanup (can run in parallel with Steps 4–7)
+
+**Dependencies:** Step 1  
+**Files:** `src/lib/utils.ts`, `src/lib/csvExport.ts`, `eslint.config.js`
+
+- Replace `as` casts in `utils.ts` with type guards (P1-3)
+- Dedup `fossilDisplayName` in `csvExport.ts` (P2-4)
+- Fix `filterByQuery` not being used in ACCanvas inline filter (P1-8)
+- Add `eslint-plugin-react` to ESLint config (P2-7)
+
+---
+
+## Summary Table
+
+| Step | What | P0/P1 Addressed | Risk | User-Visible? |
+|------|------|-----------------|------|---------------|
+| 1 | Types + constants | P0-3 (GameId) | None | No |
+| 2 | Store schema + migration | P0-2 (schema), P1-2 (Town.gameId), P2-12 (migration config) | High (data integrity) | No |
+| 3 | Hydration guard | P0-4 | Low | Yes (removes flash) |
+| 4 | Custom hooks | P1-1 (partial) | Medium | No |
+| 5 | Atomic shared components | P1-1 (partial) | Low | No |
+| 6 | Modals + TownModalFrame | P1-5 | Low | Minor (game selector added) |
+| 7 | Views + search + header | P1-1 (partial) | Medium | No |
+| 8 | ACCanvas final refactor | P1-1 (complete) | Medium | No |
+| 9 | P2 cleanup | P1-3, P1-8, P2-4, P2-7 | Low | No |
+
+---
+
+## Open Questions for Dispatch
+
+1. **Game selector in CreateTownModal:** Should the game selector default to `ACGCN` and show all five games, or show only games with data files present? Showing all five is simpler but creates towns for games with no data yet (Wild World, etc.). Showing only available games requires `loadGameData` to be queryable before the modal opens.
+
+2. **Item ID namespacing:** Should `itemId` values be globally unique (`acgcn-sea-bass`) or game-local (`sea-bass` scoped by the 3-level schema)? Game-local is simpler and already handled by the 3-level schema. Global IDs would allow cross-game "shared item" queries but add migration complexity and require renaming all existing IDs.
+
+3. **`bootstrapMigration` timing:** `main.tsx` is the proposed call site (before `createRoot`). Is this acceptable, or should the migration run inside a Zustand store initializer? The `main.tsx` approach is simpler but couples a store concern to the entry point.
+
+4. **`skipHydration` vs `onFinishHydration`:** The proposal uses `onFinishHydration`. If the data fetch in `useMuseumData` needs to be gated on hydration too (to avoid fetching the wrong game's data before `activeTownId` is known), should hydration and data loading be unified into a single loading gate?
+
+---
+
+*End of proposal. Awaiting Dispatch approval before implementation begins.*


### PR DESCRIPTION
## Summary

- Architecture proposal document for v0.7 multi-game foundation
- Addresses all four P0 blockers from the codebase audit: donation schema (2→3 level), `GameId` literal→union, `Town.gameId` missing, hydration guard
- Covers ACCanvas decomposition plan, `TownModalFrame` extraction, and full migration ordering with dependency graph

## What's in this PR

`docs/v0.7-architecture-proposal.md` — a detailed pre-implementation review document containing:

1. **Multi-game data model** — `GameId` union type, `Game` interface + registry, `Town.gameId`, 3-level donation schema with before/after code
2. **Store migration strategy** — `bootstrapMigration` for key rename, Zustand `version`/`migrate` wiring, `migrateStore` function that backfills `ACGCN` for all existing towns/donations
3. **Hydration guard** — `useHydration` hook using `onFinishHydration`, loading gate in `App.tsx`
4. **ACCanvas decomposition** — confirms audit split plan, adds explicit dependency graph, notes `lib/data.ts` must precede `useMuseumData`
5. **TownModalFrame** — full prop interface and usage sketch for both modals; notes that `EditTownModal` must lock `gameId` after creation
6. **9-step migration ordering** — risk-annotated, with explicit dependencies between steps

## Open questions for reviewer

Four design decisions are flagged at the bottom of the doc requiring Dispatch input before implementation starts.

## Test plan

- [ ] Proposal doc renders correctly in GitHub markdown
- [ ] No code changes — no tests needed
- [ ] Implementation begins only after Dispatch approves

🤖 Generated with [Claude Code](https://claude.com/claude-code)