### PR TITLE
feat: Step 9 — type safety, error boundary, pre-commit hooks

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,1 @@
+npx lint-staged

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ All notable changes to this project are documented here.
 
 ### Added
 - `docs/v0.7-audit.md` — comprehensive codebase audit covering component modularity, type safety, state management, latent bugs, and multi-game architectural readiness
+- **ErrorBoundary** — top-level React error boundary wraps `<ACCanvas />`; crashes now render `ErrorState` instead of a blank page
+- **Pre-commit hooks** — Husky + lint-staged run ESLint and Prettier on staged `src/**/*.{ts,tsx}` files before every commit
+- **Type guards in utils** — `isFish()`, `isFossil()`, `isArtPiece()` predicates replace unsafe `as` casts; `itemNotes()` now returns `undefined` for non-fish items correctly
+- **Unified `AppErrorKind`** — moved to `src/lib/types.ts`; `ErrorState` now accepts the full discriminated union instead of a separate `LoadErrorKind` string
+
+### Fixed
+- **`as any` cast in HomeTab** — `displayName(item as any, cat)` replaced with `displayName(item as AnyItem, cat)`
+- **`filterByQuery` duplication** — ACCanvas per-category filter and global search filter now use the `filterByQuery()` / `globalFilter()` utilities from `src/lib/utils.ts` instead of reimplementing the same logic inline
 
 ### Fixed
 - **Seasonal analytics bug (#1)** — "Seasonal Breakdown" section in Stats tab now counts

--- a/package-lock.json
+++ b/package-lock.json
@@ -39,7 +39,9 @@
         "eslint-plugin-react-hooks": "^5.2.0",
         "eslint-plugin-react-refresh": "^0.4.20",
         "globals": "^16.3.0",
+        "husky": "^9.1.7",
         "jsdom": "^25.0.0",
+        "lint-staged": "^16.4.0",
         "prettier": "^3.6.2",
         "vitest": "^2.0.0"
       }
@@ -2500,6 +2502,22 @@
         "url": "https://github.com/sponsors/epoberezkin"
       }
     },
+    "node_modules/ansi-escapes": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-7.3.0.tgz",
+      "integrity": "sha512-BvU8nYgGQBxcmMuEeUEmNTvrMVjJNSH7RgW24vXexN4Ven6qCvy4TntnvlnwnMLTVlcRQQdbRY8NKnaIoeWDNg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "environment": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/ansi-regex": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
@@ -2979,6 +2997,56 @@
         "url": "https://polar.sh/cva"
       }
     },
+    "node_modules/cli-cursor": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-5.0.0.tgz",
+      "integrity": "sha512-aCj4O5wKyszjMmDT4tZj93kxyydN/K5zPWSCe6/0AV/AA1pqe5ZBIw0a2ZfPQV7lL5/yb5HsUreJ6UFAF1tEQw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "restore-cursor": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/cli-truncate": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/cli-truncate/-/cli-truncate-5.2.0.tgz",
+      "integrity": "sha512-xRwvIOMGrfOAnM1JYtqQImuaNtDEv9v6oIYAs4LIHwTiKee8uwvIi363igssOC0O5U04i4AlENs79LQLu9tEMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "slice-ansi": "^8.0.0",
+        "string-width": "^8.2.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/cli-truncate/node_modules/string-width": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-8.2.0.tgz",
+      "integrity": "sha512-6hJPQ8N0V0P3SNmP6h2J99RLuzrWz2gvT7VnK5tKvrNqJoyS9W4/Fb8mo31UiPvy00z7DQXkP2hnKBVav76thw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "get-east-asian-width": "^1.5.0",
+        "strip-ansi": "^7.1.2"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/clsx": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
@@ -3008,6 +3076,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/colorette": {
+      "version": "2.0.20",
+      "resolved": "https://registry.npmjs.org/colorette/-/colorette-2.0.20.tgz",
+      "integrity": "sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/combined-stream": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
@@ -3019,6 +3094,16 @@
       },
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/commander": {
+      "version": "14.0.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-14.0.3.tgz",
+      "integrity": "sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/concat-map": {
@@ -3339,6 +3424,19 @@
       },
       "funding": {
         "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/environment": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/environment/-/environment-1.1.0.tgz",
+      "integrity": "sha512-xUtoPkMggbz0MPyPiIWr1Kp4aeWJjDZ6SMvURhimjdZgsRuDplF5/s9hcgGhyXMhs+6vpnuoiZ2kFiu3FMnS8Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/es-abstract": {
@@ -3940,6 +4038,13 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/eventemitter3": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.4.tgz",
+      "integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/expect-type": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
@@ -4224,6 +4329,19 @@
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/get-east-asian-width": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.5.0.tgz",
+      "integrity": "sha512-CQ+bEO+Tva/qlmw24dCejulK5pMzVnUOFOijVogd3KQs07HnRIgp8TGipvCCRT06xeYEbpbgwaCxglFyiuIcmA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/get-intrinsic": {
@@ -4515,6 +4633,22 @@
       },
       "engines": {
         "node": ">= 14"
+      }
+    },
+    "node_modules/husky": {
+      "version": "9.1.7",
+      "resolved": "https://registry.npmjs.org/husky/-/husky-9.1.7.tgz",
+      "integrity": "sha512-5gs5ytaNjBrh5Ow3zrvdUUY+0VxIuWVL4i9irt6friV+BqdCfmV11CQTWMiBYWHbXhco+J1kHfTOUkePhCDvMA==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "husky": "bin.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/typicode"
       }
     },
     "node_modules/iconv-lite": {
@@ -5496,6 +5630,114 @@
         "url": "https://opencollective.com/parcel"
       }
     },
+    "node_modules/lint-staged": {
+      "version": "16.4.0",
+      "resolved": "https://registry.npmjs.org/lint-staged/-/lint-staged-16.4.0.tgz",
+      "integrity": "sha512-lBWt8hujh/Cjysw5GYVmZpFHXDCgZzhrOm8vbcUdobADZNOK/bRshr2kM3DfgrrtR1DQhfupW9gnIXOfiFi+bw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "commander": "^14.0.3",
+        "listr2": "^9.0.5",
+        "picomatch": "^4.0.3",
+        "string-argv": "^0.3.2",
+        "tinyexec": "^1.0.4",
+        "yaml": "^2.8.2"
+      },
+      "bin": {
+        "lint-staged": "bin/lint-staged.js"
+      },
+      "engines": {
+        "node": ">=20.17"
+      },
+      "funding": {
+        "url": "https://opencollective.com/lint-staged"
+      }
+    },
+    "node_modules/lint-staged/node_modules/tinyexec": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.1.1.tgz",
+      "integrity": "sha512-VKS/ZaQhhkKFMANmAOhhXVoIfBXblQxGX1myCQ2faQrfmobMftXeJPcZGp0gS07ocvGJWDLZGyOZDadDBqYIJg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/listr2": {
+      "version": "9.0.5",
+      "resolved": "https://registry.npmjs.org/listr2/-/listr2-9.0.5.tgz",
+      "integrity": "sha512-ME4Fb83LgEgwNw96RKNvKV4VTLuXfoKudAmm2lP8Kk87KaMK0/Xrx/aAkMWmT8mDb+3MlFDspfbCs7adjRxA2g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cli-truncate": "^5.0.0",
+        "colorette": "^2.0.20",
+        "eventemitter3": "^5.0.1",
+        "log-update": "^6.1.0",
+        "rfdc": "^1.4.1",
+        "wrap-ansi": "^9.0.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/listr2/node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/listr2/node_modules/emoji-regex": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.6.0.tgz",
+      "integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/listr2/node_modules/string-width": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
+      "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^10.3.0",
+        "get-east-asian-width": "^1.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/listr2/node_modules/wrap-ansi": {
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-9.0.2.tgz",
+      "integrity": "sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.2.1",
+        "string-width": "^7.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
     "node_modules/locate-path": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
@@ -5518,6 +5760,115 @@
       "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/log-update": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/log-update/-/log-update-6.1.0.tgz",
+      "integrity": "sha512-9ie8ItPR6tjY5uYJh8K/Zrv/RMZ5VOlOWvtZdEHYSTFKZfIBPQa9tOAEeAWhd+AnIneLJ22w5fjOYtoutpWq5w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-escapes": "^7.0.0",
+        "cli-cursor": "^5.0.0",
+        "slice-ansi": "^7.1.0",
+        "strip-ansi": "^7.1.0",
+        "wrap-ansi": "^9.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/log-update/node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/log-update/node_modules/emoji-regex": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.6.0.tgz",
+      "integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/log-update/node_modules/is-fullwidth-code-point": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-5.1.0.tgz",
+      "integrity": "sha512-5XHYaSyiqADb4RnZ1Bdad6cPp8Toise4TzEjcOYDHZkTCbKgiUl7WTUCpNWHuxmDt91wnsZBc9xinNzopv3JMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "get-east-asian-width": "^1.3.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/log-update/node_modules/slice-ansi": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-7.1.2.tgz",
+      "integrity": "sha512-iOBWFgUX7caIZiuutICxVgX1SdxwAVFFKwt1EvMYYec/NWO5meOJ6K5uQxhrYBdQJne4KxiqZc+KptFOWFSI9w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.2.1",
+        "is-fullwidth-code-point": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/slice-ansi?sponsor=1"
+      }
+    },
+    "node_modules/log-update/node_modules/string-width": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
+      "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^10.3.0",
+        "get-east-asian-width": "^1.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/log-update/node_modules/wrap-ansi": {
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-9.0.2.tgz",
+      "integrity": "sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.2.1",
+        "string-width": "^7.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
     },
     "node_modules/loose-envify": {
       "version": "1.4.0",
@@ -5687,6 +6038,19 @@
       },
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/mimic-function": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/mimic-function/-/mimic-function-5.0.1.tgz",
+      "integrity": "sha512-VP79XUPxV2CigYP3jWwAUFSku2aKqBH7uTAapFWCBqutsbmDo96KY5o8uh6U+/YSIn5OxJnXp73beVkpqMIGhA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/min-indent": {
@@ -5913,6 +6277,22 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/onetime": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-7.0.0.tgz",
+      "integrity": "sha512-VXJjc87FScF88uafS3JllDgvAm+c/Slfz06lorj2uAY34rlUu0Nt+v8wreiImcrgAjjIHp1rXpTDlLOGw29WwQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mimic-function": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/optionator": {
@@ -6389,6 +6769,23 @@
         "node": ">=4"
       }
     },
+    "node_modules/restore-cursor": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-5.1.0.tgz",
+      "integrity": "sha512-oMA2dcrw6u0YfxJQXm342bFKX/E4sG9rbTzO9ptUcR/e8A33cHuvStiYOwH7fszkZlZ1z/ta9AAoPk2F4qIOHA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "onetime": "^7.0.0",
+        "signal-exit": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/reusify": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.1.0.tgz",
@@ -6399,6 +6796,13 @@
         "iojs": ">=1.0.0",
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/rfdc": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/rfdc/-/rfdc-1.4.1.tgz",
+      "integrity": "sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/rollup": {
       "version": "4.46.2",
@@ -6728,6 +7132,52 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/slice-ansi": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-8.0.0.tgz",
+      "integrity": "sha512-stxByr12oeeOyY2BlviTNQlYV5xOj47GirPr4yA1hE9JCtxfQN0+tVbkxwCtYDQWhEKWFHsEK48ORg5jrouCAg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.2.3",
+        "is-fullwidth-code-point": "^5.1.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/slice-ansi?sponsor=1"
+      }
+    },
+    "node_modules/slice-ansi/node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/slice-ansi/node_modules/is-fullwidth-code-point": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-5.1.0.tgz",
+      "integrity": "sha512-5XHYaSyiqADb4RnZ1Bdad6cPp8Toise4TzEjcOYDHZkTCbKgiUl7WTUCpNWHuxmDt91wnsZBc9xinNzopv3JMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "get-east-asian-width": "^1.3.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -6763,6 +7213,16 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/string-argv": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/string-argv/-/string-argv-0.3.2.tgz",
+      "integrity": "sha512-aqD2Q0144Z+/RqG52NeHEkZauTAUWJO8c6yTftGJKO3Tja5tUgIfmIl6kExvhtxSDP7fXB6DvzkfMpCd/F3G+Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6.19"
       }
     },
     "node_modules/string-width": {
@@ -8920,6 +9380,22 @@
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
       "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
       "license": "ISC"
+    },
+    "node_modules/yaml": {
+      "version": "2.8.3",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.3.tgz",
+      "integrity": "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==",
+      "devOptional": true,
+      "license": "ISC",
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
+      }
     },
     "node_modules/yocto-queue": {
       "version": "0.1.0",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
     "format:check": "prettier --check \"src/**/*.{ts,tsx,js,jsx}\"",
     "test": "vitest run",
     "test:watch": "vitest",
-    "test:coverage": "vitest run --coverage"
+    "test:coverage": "vitest run --coverage",
+    "prepare": "husky"
   },
   "repository": {
     "type": "git",
@@ -44,6 +45,12 @@
     "vite": "^7.1.2",
     "zustand": "^5.0.7"
   },
+  "lint-staged": {
+    "src/**/*.{ts,tsx}": [
+      "eslint --max-warnings 0",
+      "prettier --check"
+    ]
+  },
   "devDependencies": {
     "@eslint/js": "^9.33.0",
     "@tailwindcss/postcss": "^4.1.12",
@@ -59,7 +66,9 @@
     "eslint-plugin-react-hooks": "^5.2.0",
     "eslint-plugin-react-refresh": "^0.4.20",
     "globals": "^16.3.0",
+    "husky": "^9.1.7",
     "jsdom": "^25.0.0",
+    "lint-staged": "^16.4.0",
     "prettier": "^3.6.2",
     "vitest": "^2.0.0"
   }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,12 +1,13 @@
 import { Analytics } from '@vercel/analytics/react';
 import ACCanvas from './components/ACCanvas';
+import ErrorBoundary from './components/ErrorBoundary';
 
 function App() {
   return (
-    <>
+    <ErrorBoundary>
       <ACCanvas />
       <Analytics />
-    </>
+    </ErrorBoundary>
   );
 }
 

--- a/src/components/ACCanvas.tsx
+++ b/src/components/ACCanvas.tsx
@@ -39,40 +39,53 @@ import {
   formatRelativeDate,
   formatTime,
   filterByQuery,
+  globalFilter,
   type AnyItem,
 } from '../lib/utils';
 
 // ─── Constants ────────────────────────────────────────────────────────────────
 
 const MONTH_NAMES = [
-  'Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun',
-  'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec',
+  'Jan',
+  'Feb',
+  'Mar',
+  'Apr',
+  'May',
+  'Jun',
+  'Jul',
+  'Aug',
+  'Sep',
+  'Oct',
+  'Nov',
+  'Dec',
 ];
 
-const CATEGORY_META: Record<CategoryId, {
-  label: string;
-  Icon: React.ElementType;
-  file: string;
-}> = {
-  fish:    { label: 'Fish',    Icon: FishIcon, file: '/data/acgcn/fish.json'    },
-  bugs:    { label: 'Bugs',    Icon: Bug,      file: '/data/acgcn/bugs.json'    },
-  fossils: { label: 'Fossils', Icon: Bone,     file: '/data/acgcn/fossils.json' },
-  art:     { label: 'Art',     Icon: Palette,  file: '/data/acgcn/art.json'     },
+const CATEGORY_META: Record<
+  CategoryId,
+  {
+    label: string;
+    Icon: React.ElementType;
+    file: string;
+  }
+> = {
+  fish: { label: 'Fish', Icon: FishIcon, file: '/data/acgcn/fish.json' },
+  bugs: { label: 'Bugs', Icon: Bug, file: '/data/acgcn/bugs.json' },
+  fossils: { label: 'Fossils', Icon: Bone, file: '/data/acgcn/fossils.json' },
+  art: { label: 'Art', Icon: Palette, file: '/data/acgcn/art.json' },
 };
 
 const CATEGORY_ORDER: CategoryId[] = ['fish', 'bugs', 'fossils', 'art'];
 
 const SEASONS: { label: string; months: number[]; color: string }[] = [
-  { label: 'Spring', months: [3, 4, 5],   color: '#3CA370' },
-  { label: 'Summer', months: [6, 7, 8],   color: '#E8A838' },
-  { label: 'Fall',   months: [9, 10, 11], color: '#C8663A' },
-  { label: 'Winter', months: [12, 1, 2],  color: '#6A9EC8' },
+  { label: 'Spring', months: [3, 4, 5], color: '#3CA370' },
+  { label: 'Summer', months: [6, 7, 8], color: '#E8A838' },
+  { label: 'Fall', months: [9, 10, 11], color: '#C8663A' },
+  { label: 'Winter', months: [12, 1, 2], color: '#6A9EC8' },
 ];
 
 // Stable empty fallbacks so Zustand selectors don't return new {} references
 const EMPTY_DONATED: Record<string, boolean> = {};
 const EMPTY_DONATED_AT: Record<string, string> = {};
-
 
 // ─── Types ────────────────────────────────────────────────────────────────────
 
@@ -119,13 +132,18 @@ function CreateTownModal({
         {/* Header */}
         <div
           className="px-6 py-4 flex items-center justify-between"
-          style={{ background: 'linear-gradient(180deg, #7B5E3B 0%, #6e5234 100%)' }}
+          style={{
+            background: 'linear-gradient(180deg, #7B5E3B 0%, #6e5234 100%)',
+          }}
         >
           <h2 className="text-base font-semibold" style={{ color: '#F5E9D4' }}>
             New Town
           </h2>
           {!required && (
-            <button onClick={onClose} style={{ color: '#F5E9D4', opacity: 0.7 }}>
+            <button
+              onClick={onClose}
+              style={{ color: '#F5E9D4', opacity: 0.7 }}
+            >
               <X className="w-4 h-4" />
             </button>
           )}
@@ -133,7 +151,10 @@ function CreateTownModal({
 
         <form onSubmit={handleSubmit} className="px-6 py-5 space-y-4">
           <div>
-            <label className="block text-xs font-medium mb-1.5" style={{ color: '#5a4a35' }}>
+            <label
+              className="block text-xs font-medium mb-1.5"
+              style={{ color: '#5a4a35' }}
+            >
               Town Name
             </label>
             <input
@@ -143,11 +164,18 @@ function CreateTownModal({
               onChange={e => setName(e.target.value)}
               placeholder="e.g. Plumeria"
               className="w-full rounded-[10px] border px-3 py-2 text-sm outline-none"
-              style={{ borderColor: '#E7DAC4', backgroundColor: '#FFFDF6', color: '#2A2A2A' }}
+              style={{
+                borderColor: '#E7DAC4',
+                backgroundColor: '#FFFDF6',
+                color: '#2A2A2A',
+              }}
             />
           </div>
           <div>
-            <label className="block text-xs font-medium mb-1.5" style={{ color: '#5a4a35' }}>
+            <label
+              className="block text-xs font-medium mb-1.5"
+              style={{ color: '#5a4a35' }}
+            >
               Your Name
             </label>
             <input
@@ -156,7 +184,11 @@ function CreateTownModal({
               onChange={e => setPlayerName(e.target.value)}
               placeholder="e.g. Brock"
               className="w-full rounded-[10px] border px-3 py-2 text-sm outline-none"
-              style={{ borderColor: '#E7DAC4', backgroundColor: '#FFFDF6', color: '#2A2A2A' }}
+              style={{
+                borderColor: '#E7DAC4',
+                backgroundColor: '#FFFDF6',
+                color: '#2A2A2A',
+              }}
             />
           </div>
           <button
@@ -164,7 +196,8 @@ function CreateTownModal({
             disabled={!name.trim() || !playerName.trim()}
             className="w-full py-3 rounded-[12px] text-sm font-semibold transition"
             style={{
-              backgroundColor: name.trim() && playerName.trim() ? '#3CA370' : '#D9CCBA',
+              backgroundColor:
+                name.trim() && playerName.trim() ? '#3CA370' : '#D9CCBA',
               color: '#fff',
             }}
           >
@@ -210,7 +243,9 @@ function EditTownModal({
         {/* Header */}
         <div
           className="px-6 py-4 flex items-center justify-between"
-          style={{ background: 'linear-gradient(180deg, #7B5E3B 0%, #6e5234 100%)' }}
+          style={{
+            background: 'linear-gradient(180deg, #7B5E3B 0%, #6e5234 100%)',
+          }}
         >
           <h2 className="text-base font-semibold" style={{ color: '#F5E9D4' }}>
             Edit Town
@@ -222,7 +257,10 @@ function EditTownModal({
 
         <form onSubmit={handleSubmit} className="px-6 py-5 space-y-4">
           <div>
-            <label className="block text-xs font-medium mb-1.5" style={{ color: '#5a4a35' }}>
+            <label
+              className="block text-xs font-medium mb-1.5"
+              style={{ color: '#5a4a35' }}
+            >
               Town Name
             </label>
             <input
@@ -231,11 +269,18 @@ function EditTownModal({
               value={name}
               onChange={e => setName(e.target.value)}
               className="w-full rounded-[10px] border px-3 py-2 text-sm outline-none"
-              style={{ borderColor: '#E7DAC4', backgroundColor: '#FFFDF6', color: '#2A2A2A' }}
+              style={{
+                borderColor: '#E7DAC4',
+                backgroundColor: '#FFFDF6',
+                color: '#2A2A2A',
+              }}
             />
           </div>
           <div>
-            <label className="block text-xs font-medium mb-1.5" style={{ color: '#5a4a35' }}>
+            <label
+              className="block text-xs font-medium mb-1.5"
+              style={{ color: '#5a4a35' }}
+            >
               Your Name
             </label>
             <input
@@ -243,7 +288,11 @@ function EditTownModal({
               value={playerName}
               onChange={e => setPlayerName(e.target.value)}
               className="w-full rounded-[10px] border px-3 py-2 text-sm outline-none"
-              style={{ borderColor: '#E7DAC4', backgroundColor: '#FFFDF6', color: '#2A2A2A' }}
+              style={{
+                borderColor: '#E7DAC4',
+                backgroundColor: '#FFFDF6',
+                color: '#2A2A2A',
+              }}
             />
           </div>
           <button
@@ -251,7 +300,8 @@ function EditTownModal({
             disabled={!name.trim() || !playerName.trim()}
             className="w-full py-3 rounded-[12px] text-sm font-semibold transition"
             style={{
-              backgroundColor: name.trim() && playerName.trim() ? '#3CA370' : '#D9CCBA',
+              backgroundColor:
+                name.trim() && playerName.trim() ? '#3CA370' : '#D9CCBA',
               color: '#fff',
             }}
           >
@@ -260,7 +310,7 @@ function EditTownModal({
         </form>
       </div>
     </div>,
-    document.body,
+    document.body
   );
 }
 
@@ -278,76 +328,96 @@ function TownSwitcher({ onCreateNew }: { onCreateNew: () => void }) {
 
   return (
     <>
-    <div className="relative">
-      <div className="flex items-center gap-2">
-        {/* Town name button — only tappable if multiple towns */}
-        {towns.length > 1 ? (
+      <div className="relative">
+        <div className="flex items-center gap-2">
+          {/* Town name button — only tappable if multiple towns */}
+          {towns.length > 1 ? (
+            <button
+              onClick={() => setOpen(o => !o)}
+              className="flex items-center gap-1.5 rounded-[10px] px-3 py-1.5 text-sm font-medium transition"
+              style={{
+                backgroundColor: '#EDE3D0',
+                color: '#2A2A2A',
+                border: '1px solid #E7DAC4',
+              }}
+            >
+              {activeTown.name}
+              <ChevronDown className="w-3.5 h-3.5 opacity-60" />
+            </button>
+          ) : (
+            <span
+              className="text-sm font-medium px-1"
+              style={{ color: '#2A2A2A' }}
+            >
+              {activeTown.name}
+            </span>
+          )}
+
+          {/* Edit town button */}
           <button
-            onClick={() => setOpen(o => !o)}
-            className="flex items-center gap-1.5 rounded-[10px] px-3 py-1.5 text-sm font-medium transition"
-            style={{ backgroundColor: '#EDE3D0', color: '#2A2A2A', border: '1px solid #E7DAC4' }}
+            onClick={() => setEditing(true)}
+            className="flex items-center justify-center rounded-[10px] p-1.5 transition"
+            style={{ backgroundColor: '#EDE3D0', border: '1px solid #E7DAC4' }}
+            aria-label="Edit town"
           >
-            {activeTown.name}
-            <ChevronDown className="w-3.5 h-3.5 opacity-60" />
+            <Pencil className="w-3.5 h-3.5" style={{ color: '#5a4a35' }} />
           </button>
-        ) : (
-          <span className="text-sm font-medium px-1" style={{ color: '#2A2A2A' }}>
-            {activeTown.name}
-          </span>
-        )}
 
-        {/* Edit town button */}
-        <button
-          onClick={() => setEditing(true)}
-          className="flex items-center justify-center rounded-[10px] p-1.5 transition"
-          style={{ backgroundColor: '#EDE3D0', border: '1px solid #E7DAC4' }}
-          aria-label="Edit town"
-        >
-          <Pencil className="w-3.5 h-3.5" style={{ color: '#5a4a35' }} />
-        </button>
-
-        {/* New town button */}
-        <button
-          onClick={onCreateNew}
-          className="flex items-center justify-center rounded-[10px] p-1.5 transition"
-          style={{ backgroundColor: '#EDE3D0', border: '1px solid #E7DAC4' }}
-          aria-label="Add town"
-        >
-          <Plus className="w-3.5 h-3.5" style={{ color: '#5a4a35' }} />
-        </button>
-      </div>
-
-      {/* Dropdown */}
-      {open && towns.length > 1 && (
-        <>
-          <div className="fixed inset-0 z-10" onClick={() => setOpen(false)} />
-          <div
-            className="absolute left-0 top-full mt-1.5 z-20 rounded-[12px] overflow-hidden shadow-lg"
-            style={{ backgroundColor: '#FDF9F1', border: '1px solid #E7DAC4', minWidth: '160px' }}
+          {/* New town button */}
+          <button
+            onClick={onCreateNew}
+            className="flex items-center justify-center rounded-[10px] p-1.5 transition"
+            style={{ backgroundColor: '#EDE3D0', border: '1px solid #E7DAC4' }}
+            aria-label="Add town"
           >
-            {towns.map((town, i) => (
-              <button
-                key={town.id}
-                onClick={() => { setActiveTown(town.id); setOpen(false); }}
-                className="w-full text-left px-4 py-2.5 text-sm transition"
-                style={{
-                  backgroundColor: town.id === activeTownId ? '#F5E9D4' : 'transparent',
-                  color: '#2A2A2A',
-                  borderTop: i > 0 ? '1px solid #E7DAC4' : 'none',
-                  fontWeight: town.id === activeTownId ? '600' : '400',
-                }}
-              >
-                <div>{town.name}</div>
-                <div className="text-[11px] opacity-60">{town.playerName}</div>
-              </button>
-            ))}
-          </div>
-        </>
+            <Plus className="w-3.5 h-3.5" style={{ color: '#5a4a35' }} />
+          </button>
+        </div>
+
+        {/* Dropdown */}
+        {open && towns.length > 1 && (
+          <>
+            <div
+              className="fixed inset-0 z-10"
+              onClick={() => setOpen(false)}
+            />
+            <div
+              className="absolute left-0 top-full mt-1.5 z-20 rounded-[12px] overflow-hidden shadow-lg"
+              style={{
+                backgroundColor: '#FDF9F1',
+                border: '1px solid #E7DAC4',
+                minWidth: '160px',
+              }}
+            >
+              {towns.map((town, i) => (
+                <button
+                  key={town.id}
+                  onClick={() => {
+                    setActiveTown(town.id);
+                    setOpen(false);
+                  }}
+                  className="w-full text-left px-4 py-2.5 text-sm transition"
+                  style={{
+                    backgroundColor:
+                      town.id === activeTownId ? '#F5E9D4' : 'transparent',
+                    color: '#2A2A2A',
+                    borderTop: i > 0 ? '1px solid #E7DAC4' : 'none',
+                    fontWeight: town.id === activeTownId ? '600' : '400',
+                  }}
+                >
+                  <div>{town.name}</div>
+                  <div className="text-[11px] opacity-60">
+                    {town.playerName}
+                  </div>
+                </button>
+              ))}
+            </div>
+          </>
+        )}
+      </div>
+      {editing && (
+        <EditTownModal town={activeTown} onClose={() => setEditing(false)} />
       )}
-    </div>
-    {editing && (
-      <EditTownModal town={activeTown} onClose={() => setEditing(false)} />
-    )}
     </>
   );
 }
@@ -378,9 +448,14 @@ function MuseumHeader({
           color: '#F5E9D4',
         }}
       >
-        <div className="text-[13px] tracking-wide opacity-90">AC GCN Museum</div>
+        <div className="text-[13px] tracking-wide opacity-90">
+          AC GCN Museum
+        </div>
         <div className="flex items-end justify-between">
-          <h1 className="text-2xl font-semibold" style={{ letterSpacing: '0.2px' }}>
+          <h1
+            className="text-2xl font-semibold"
+            style={{ letterSpacing: '0.2px' }}
+          >
             Museum Tracker
           </h1>
           <div className="flex items-center gap-2">
@@ -393,8 +468,14 @@ function MuseumHeader({
                 color: '#F5E9D4',
                 border: '1px solid rgba(245,233,212,0.3)',
               }}
-              onMouseEnter={e => (e.currentTarget.style.backgroundColor = 'rgba(245,233,212,0.25)')}
-              onMouseLeave={e => (e.currentTarget.style.backgroundColor = 'rgba(245,233,212,0.15)')}
+              onMouseEnter={e =>
+                (e.currentTarget.style.backgroundColor =
+                  'rgba(245,233,212,0.25)')
+              }
+              onMouseLeave={e =>
+                (e.currentTarget.style.backgroundColor =
+                  'rgba(245,233,212,0.15)')
+              }
             >
               <Download className="w-3.5 h-3.5" />
               <span>Export CSV</span>
@@ -409,7 +490,9 @@ function MuseumHeader({
           style={{ color: '#2A2A2A' }}
         >
           <span>Overall progress</span>
-          <span>{donatedCount} / {totalCount} · {pct}% complete</span>
+          <span>
+            {donatedCount} / {totalCount} · {pct}% complete
+          </span>
         </div>
         <div
           className="h-2 w-full rounded-full overflow-hidden"
@@ -455,9 +538,11 @@ function TabBar({
       >
         <Home className="w-4 h-4" />
         <span>Home</span>
-        <span className="opacity-0" style={{ fontSize: '10px' }}>·</span>
+        <span className="opacity-0" style={{ fontSize: '10px' }}>
+          ·
+        </span>
       </button>
-      {CATEGORY_ORDER.map((cat) => {
+      {CATEGORY_ORDER.map(cat => {
         const { label, Icon } = CATEGORY_META[cat];
         const isActive = cat === active;
         const total = data[cat].length;
@@ -493,7 +578,9 @@ function TabBar({
       >
         <Clock className="w-4 h-4" />
         <span>Log</span>
-        <span className="opacity-0" style={{ fontSize: '10px' }}>·</span>
+        <span className="opacity-0" style={{ fontSize: '10px' }}>
+          ·
+        </span>
       </button>
       {/* Search tab */}
       <button
@@ -507,7 +594,9 @@ function TabBar({
       >
         <Search className="w-4 h-4" />
         <span>Search</span>
-        <span className="opacity-0" style={{ fontSize: '10px' }}>·</span>
+        <span className="opacity-0" style={{ fontSize: '10px' }}>
+          ·
+        </span>
       </button>
       {/* Analytics tab */}
       <button
@@ -521,7 +610,9 @@ function TabBar({
       >
         <BarChart2 className="w-4 h-4" />
         <span>Stats</span>
-        <span className="opacity-0" style={{ fontSize: '10px' }}>·</span>
+        <span className="opacity-0" style={{ fontSize: '10px' }}>
+          ·
+        </span>
       </button>
     </div>
   );
@@ -529,18 +620,34 @@ function TabBar({
 
 // ─── CategoryProgress ─────────────────────────────────────────────────────────
 
-function CategoryProgress({ donated, total, label }: { donated: number; total: number; label: string }) {
+function CategoryProgress({
+  donated,
+  total,
+  label,
+}: {
+  donated: number;
+  total: number;
+  label: string;
+}) {
   const pct = total ? Math.round((donated / total) * 100) : 0;
   return (
     <div
       className="rounded-[12px] border px-4 py-3"
       style={{ borderColor: '#E7DAC4', backgroundColor: '#FFFDF6' }}
     >
-      <div className="flex items-center justify-between text-sm mb-1.5" style={{ color: '#2A2A2A' }}>
+      <div
+        className="flex items-center justify-between text-sm mb-1.5"
+        style={{ color: '#2A2A2A' }}
+      >
         <span className="font-medium">{label} Collection</span>
-        <span>{donated} / {total} donated · {pct}%</span>
+        <span>
+          {donated} / {total} donated · {pct}%
+        </span>
       </div>
-      <div className="h-1.5 w-full rounded-full overflow-hidden" style={{ backgroundColor: '#e9dcc3' }}>
+      <div
+        className="h-1.5 w-full rounded-full overflow-hidden"
+        style={{ backgroundColor: '#e9dcc3' }}
+      >
         <div
           className="h-full transition-all duration-500"
           style={{ width: `${pct}%`, backgroundColor: '#3CA370' }}
@@ -552,7 +659,15 @@ function CategoryProgress({ donated, total, label }: { donated: number; total: n
 
 // ─── SearchBar ────────────────────────────────────────────────────────────────
 
-function SearchBar({ query, setQuery, placeholder }: { query: string; setQuery: (v: string) => void; placeholder: string }) {
+function SearchBar({
+  query,
+  setQuery,
+  placeholder,
+}: {
+  query: string;
+  setQuery: (v: string) => void;
+  placeholder: string;
+}) {
   return (
     <div
       className="flex items-center gap-2 rounded-[14px] border px-3 py-2"
@@ -567,7 +682,10 @@ function SearchBar({ query, setQuery, placeholder }: { query: string; setQuery: 
         className="w-full bg-transparent outline-none text-sm"
       />
       {query && (
-        <button onClick={() => setQuery('')} className="opacity-40 hover:opacity-70 shrink-0">
+        <button
+          onClick={() => setQuery('')}
+          className="opacity-40 hover:opacity-70 shrink-0"
+        >
           <X className="w-3.5 h-3.5" />
         </button>
       )}
@@ -581,7 +699,11 @@ function HabitatChip({ label }: { label: string }) {
   return (
     <span
       className="inline-block px-2 py-0.5 text-[11px] rounded-[10px] shrink-0"
-      style={{ backgroundColor: '#F5E9D4', border: '1px solid #E7DAC4', color: '#5a4a35' }}
+      style={{
+        backgroundColor: '#F5E9D4',
+        border: '1px solid #E7DAC4',
+        color: '#5a4a35',
+      }}
     >
       {label.charAt(0).toUpperCase() + label.slice(1)}
     </span>
@@ -590,10 +712,19 @@ function HabitatChip({ label }: { label: string }) {
 
 // ─── DonateToggle ─────────────────────────────────────────────────────────────
 
-function DonateToggle({ checked, onToggle }: { checked: boolean; onToggle: () => void }) {
+function DonateToggle({
+  checked,
+  onToggle,
+}: {
+  checked: boolean;
+  onToggle: () => void;
+}) {
   return (
     <button
-      onClick={e => { e.stopPropagation(); onToggle(); }}
+      onClick={e => {
+        e.stopPropagation();
+        onToggle();
+      }}
       aria-pressed={checked}
       aria-label={checked ? 'Mark as not donated' : 'Mark as donated'}
       className="shrink-0 inline-flex items-center gap-1.5 rounded-[10px] px-2.5 py-1.5 text-xs transition select-none"
@@ -612,9 +743,17 @@ function DonateToggle({ checked, onToggle }: { checked: boolean; onToggle: () =>
 // ─── CollectibleRow ───────────────────────────────────────────────────────────
 
 function CollectibleRow({
-  item, category, checked, onToggle, onClick,
+  item,
+  category,
+  checked,
+  onToggle,
+  onClick,
 }: {
-  item: AnyItem; category: CategoryId; checked: boolean; onToggle: () => void; onClick: () => void;
+  item: AnyItem;
+  category: CategoryId;
+  checked: boolean;
+  onToggle: () => void;
+  onClick: () => void;
 }) {
   const { Icon } = CATEGORY_META[category];
   const name = displayName(item, category);
@@ -642,18 +781,34 @@ function CollectibleRow({
       </div>
       <div className="min-w-0 flex-1">
         <div className="flex items-center gap-2 flex-wrap">
-          <span className="truncate font-medium text-sm" style={{ color: '#2A2A2A' }}>{name}</span>
+          <span
+            className="truncate font-medium text-sm"
+            style={{ color: '#2A2A2A' }}
+          >
+            {name}
+          </span>
           {category === 'fish' && subtitle && <HabitatChip label={subtitle} />}
         </div>
-        <div className="text-[12px] mt-0.5 truncate" style={{ color: '#5a4a35' }}>
-          {bells != null ? `${bells.toLocaleString()} Bells` : category === 'art' ? 'Painting' : '—'}
+        <div
+          className="text-[12px] mt-0.5 truncate"
+          style={{ color: '#5a4a35' }}
+        >
+          {bells != null
+            ? `${bells.toLocaleString()} Bells`
+            : category === 'art'
+              ? 'Painting'
+              : '—'}
           {category !== 'fossils' && category !== 'art' && (
             <span className="ml-2 opacity-60">
-              {months && months.length > 0 ? `${months.length} months` : 'Year-round'}
+              {months && months.length > 0
+                ? `${months.length} months`
+                : 'Year-round'}
             </span>
           )}
           {category === 'art' && subtitle && (
-            <span className="ml-1 opacity-70">· {subtitle.length > 38 ? subtitle.slice(0, 38) + '…' : subtitle}</span>
+            <span className="ml-1 opacity-70">
+              · {subtitle.length > 38 ? subtitle.slice(0, 38) + '…' : subtitle}
+            </span>
           )}
           {notes && <span className="ml-2 italic opacity-70">{notes}</span>}
         </div>
@@ -674,9 +829,15 @@ function MonthGrid({ months }: { months?: number[] }) {
           <div
             key={m}
             className="flex items-center justify-center rounded-[6px] py-1.5"
-            style={{ backgroundColor: active ? '#3CA370' : '#EDE3D0', opacity: active ? 1 : 0.45 }}
+            style={{
+              backgroundColor: active ? '#3CA370' : '#EDE3D0',
+              opacity: active ? 1 : 0.45,
+            }}
           >
-            <span className="text-[10px] font-semibold" style={{ color: active ? '#fff' : '#5a4a35' }}>
+            <span
+              className="text-[10px] font-semibold"
+              style={{ color: active ? '#fff' : '#5a4a35' }}
+            >
               {m}
             </span>
           </div>
@@ -689,9 +850,19 @@ function MonthGrid({ months }: { months?: number[] }) {
 // ─── DetailModal ──────────────────────────────────────────────────────────────
 
 function DetailModal({
-  item, category, checked, donatedAt, onToggle, onClose,
+  item,
+  category,
+  checked,
+  donatedAt,
+  onToggle,
+  onClose,
 }: {
-  item: AnyItem; category: CategoryId; checked: boolean; donatedAt?: string; onToggle: () => void; onClose: () => void;
+  item: AnyItem;
+  category: CategoryId;
+  checked: boolean;
+  donatedAt?: string;
+  onToggle: () => void;
+  onClose: () => void;
 }) {
   const { Icon, label } = CATEGORY_META[category];
   const name = displayName(item, category);
@@ -708,11 +879,18 @@ function DetailModal({
     >
       <div
         className="w-full max-w-3xl rounded-t-[20px] overflow-hidden"
-        style={{ backgroundColor: '#FDF9F1', maxHeight: '88vh', overflowY: 'auto' }}
+        style={{
+          backgroundColor: '#FDF9F1',
+          maxHeight: '88vh',
+          overflowY: 'auto',
+        }}
         onClick={e => e.stopPropagation()}
       >
         <div className="flex justify-center pt-3 pb-1">
-          <div className="w-10 h-1 rounded-full" style={{ backgroundColor: '#D9CCBA' }} />
+          <div
+            className="w-10 h-1 rounded-full"
+            style={{ backgroundColor: '#D9CCBA' }}
+          />
         </div>
         <div className="flex justify-end px-4 pt-1 pb-2">
           <button
@@ -728,34 +906,73 @@ function DetailModal({
           <div className="flex items-start gap-4">
             <div
               className="rounded-2xl p-3.5 shrink-0"
-              style={{ backgroundColor: '#EDE3D0', border: '1px solid #E7DAC4' }}
+              style={{
+                backgroundColor: '#EDE3D0',
+                border: '1px solid #E7DAC4',
+              }}
             >
               <Icon className="w-7 h-7" />
             </div>
             <div className="pt-1">
-              <div className="text-[11px] uppercase tracking-wider opacity-60 mb-0.5" style={{ color: '#5a4a35' }}>
+              <div
+                className="text-[11px] uppercase tracking-wider opacity-60 mb-0.5"
+                style={{ color: '#5a4a35' }}
+              >
                 {label}
               </div>
-              <h2 className="text-xl font-semibold leading-snug" style={{ color: '#2A2A2A' }}>{name}</h2>
-              {subtitle && <p className="text-sm mt-1" style={{ color: '#5a4a35' }}>{subtitle}</p>}
+              <h2
+                className="text-xl font-semibold leading-snug"
+                style={{ color: '#2A2A2A' }}
+              >
+                {name}
+              </h2>
+              {subtitle && (
+                <p className="text-sm mt-1" style={{ color: '#5a4a35' }}>
+                  {subtitle}
+                </p>
+              )}
             </div>
           </div>
 
           {bells != null && (
-            <div className="rounded-[12px] px-4 py-3" style={{ backgroundColor: '#F5E9D4', border: '1px solid #E7DAC4' }}>
-              <div className="text-[11px] uppercase tracking-wider opacity-60 mb-0.5" style={{ color: '#5a4a35' }}>Value</div>
-              <div className="font-semibold text-base" style={{ color: '#2A2A2A' }}>{bells.toLocaleString()} Bells</div>
+            <div
+              className="rounded-[12px] px-4 py-3"
+              style={{
+                backgroundColor: '#F5E9D4',
+                border: '1px solid #E7DAC4',
+              }}
+            >
+              <div
+                className="text-[11px] uppercase tracking-wider opacity-60 mb-0.5"
+                style={{ color: '#5a4a35' }}
+              >
+                Value
+              </div>
+              <div
+                className="font-semibold text-base"
+                style={{ color: '#2A2A2A' }}
+              >
+                {bells.toLocaleString()} Bells
+              </div>
             </div>
           )}
 
           {category !== 'fossils' && category !== 'art' && (
             <div>
-              <div className="text-[11px] uppercase tracking-wider opacity-60 mb-2" style={{ color: '#5a4a35' }}>
+              <div
+                className="text-[11px] uppercase tracking-wider opacity-60 mb-2"
+                style={{ color: '#5a4a35' }}
+              >
                 Availability
               </div>
               <MonthGrid months={months} />
               {(!months || months.length === 0) && (
-                <p className="text-xs mt-1.5 opacity-60" style={{ color: '#5a4a35' }}>Active all year</p>
+                <p
+                  className="text-xs mt-1.5 opacity-60"
+                  style={{ color: '#5a4a35' }}
+                >
+                  Active all year
+                </p>
               )}
             </div>
           )}
@@ -763,16 +980,33 @@ function DetailModal({
           {notes && (
             <div
               className="rounded-[12px] px-4 py-3 italic text-sm"
-              style={{ backgroundColor: '#fff8ee', border: '1px solid #E7DAC4', color: '#5a4a35' }}
+              style={{
+                backgroundColor: '#fff8ee',
+                border: '1px solid #E7DAC4',
+                color: '#5a4a35',
+              }}
             >
               {notes}
             </div>
           )}
 
           {checked && donatedAt && (
-            <div className="rounded-[12px] px-4 py-3" style={{ backgroundColor: '#f2faf6', border: '1px solid #b8dfc8' }}>
-              <div className="text-[11px] uppercase tracking-wider opacity-60 mb-0.5" style={{ color: '#2A7A52' }}>Donated</div>
-              <div className="text-sm font-medium" style={{ color: '#2A7A52' }}>{formatTimestamp(donatedAt)}</div>
+            <div
+              className="rounded-[12px] px-4 py-3"
+              style={{
+                backgroundColor: '#f2faf6',
+                border: '1px solid #b8dfc8',
+              }}
+            >
+              <div
+                className="text-[11px] uppercase tracking-wider opacity-60 mb-0.5"
+                style={{ color: '#2A7A52' }}
+              >
+                Donated
+              </div>
+              <div className="text-sm font-medium" style={{ color: '#2A7A52' }}>
+                {formatTimestamp(donatedAt)}
+              </div>
             </div>
           )}
 
@@ -870,16 +1104,25 @@ function ActivityFeed({
                 >
                   <div
                     className="shrink-0 rounded-xl p-2"
-                    style={{ backgroundColor: '#EDE3D0', border: '1px solid #E7DAC4' }}
+                    style={{
+                      backgroundColor: '#EDE3D0',
+                      border: '1px solid #E7DAC4',
+                    }}
                     aria-hidden
                   >
                     <Icon className="w-4 h-4" />
                   </div>
                   <div className="min-w-0 flex-1">
-                    <div className="font-medium text-sm truncate" style={{ color: '#2A2A2A' }}>
+                    <div
+                      className="font-medium text-sm truncate"
+                      style={{ color: '#2A2A2A' }}
+                    >
                       {entry.name}
                     </div>
-                    <div className="text-[12px] mt-0.5" style={{ color: '#2A7A52' }}>
+                    <div
+                      className="text-[12px] mt-0.5"
+                      style={{ color: '#2A7A52' }}
+                    >
                       Donated to museum
                     </div>
                   </div>
@@ -913,12 +1156,29 @@ function SectionCard({
   return (
     <div
       className="rounded-[14px] border"
-      style={{ borderColor: '#E7DAC4', backgroundColor: '#FFFDF6', padding: 16 }}
+      style={{
+        borderColor: '#E7DAC4',
+        backgroundColor: '#FFFDF6',
+        padding: 16,
+      }}
     >
-      <div style={{ display: 'flex', alignItems: 'baseline', gap: 8, marginBottom: 14 }}>
-        <h2 style={{ fontSize: 14, fontWeight: 700, color: '#2A2A2A', margin: 0 }}>{title}</h2>
+      <div
+        style={{
+          display: 'flex',
+          alignItems: 'baseline',
+          gap: 8,
+          marginBottom: 14,
+        }}
+      >
+        <h2
+          style={{ fontSize: 14, fontWeight: 700, color: '#2A2A2A', margin: 0 }}
+        >
+          {title}
+        </h2>
         {subtitle && (
-          <span style={{ fontSize: 11, color: '#5a4a35', opacity: 0.7 }}>{subtitle}</span>
+          <span style={{ fontSize: 11, color: '#5a4a35', opacity: 0.7 }}>
+            {subtitle}
+          </span>
         )}
       </div>
       {children}
@@ -954,8 +1214,12 @@ function AnalyticsView({
     for (const cat of ['fish', 'bugs'] as const) {
       for (const item of data[cat]) {
         if (!donatedIds.has(item.id)) continue;
-        const months: number[] | undefined = (item as FishType | BugItem).months;
-        const active = months && months.length > 0 ? months : [1,2,3,4,5,6,7,8,9,10,11,12];
+        const months: number[] | undefined = (item as FishType | BugItem)
+          .months;
+        const active =
+          months && months.length > 0
+            ? months
+            : [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12];
         for (const m of active) counts[m - 1]++;
       }
     }
@@ -966,12 +1230,21 @@ function AnalyticsView({
   // Seasonal breakdown: for each season, count donated fish/bugs available in that season
   const seasonalData = useMemo(() => {
     const donatedIds = new Set(Object.keys(donatedAt));
-    const counts: Record<string, number> = { Spring: 0, Summer: 0, Fall: 0, Winter: 0 };
+    const counts: Record<string, number> = {
+      Spring: 0,
+      Summer: 0,
+      Fall: 0,
+      Winter: 0,
+    };
     for (const cat of ['fish', 'bugs'] as const) {
       for (const item of data[cat]) {
         if (!donatedIds.has(item.id)) continue;
-        const months: number[] | undefined = (item as FishType | BugItem).months;
-        const active = months && months.length > 0 ? months : [1,2,3,4,5,6,7,8,9,10,11,12];
+        const months: number[] | undefined = (item as FishType | BugItem)
+          .months;
+        const active =
+          months && months.length > 0
+            ? months
+            : [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12];
         for (const season of SEASONS) {
           if (active.some(m => season.months.includes(m))) {
             counts[season.label]++;
@@ -979,8 +1252,8 @@ function AnalyticsView({
         }
       }
     }
-    const totalDonatedFishBugs = [...donatedIds].filter(id =>
-      data.fish.some(f => f.id === id) || data.bugs.some(b => b.id === id)
+    const totalDonatedFishBugs = [...donatedIds].filter(
+      id => data.fish.some(f => f.id === id) || data.bugs.some(b => b.id === id)
     ).length;
     return { counts, total: totalDonatedFishBugs };
   }, [donatedAt, data]);
@@ -997,8 +1270,18 @@ function AnalyticsView({
           const pct = total ? Math.round((donated / total) * 100) : 0;
           const complete = donated === total && total > 0;
           return (
-            <div key={cat} style={{ marginBottom: i < CATEGORY_ORDER.length - 1 ? 14 : 0 }}>
-              <div style={{ display: 'flex', alignItems: 'center', gap: 10, marginBottom: 6 }}>
+            <div
+              key={cat}
+              style={{ marginBottom: i < CATEGORY_ORDER.length - 1 ? 14 : 0 }}
+            >
+              <div
+                style={{
+                  display: 'flex',
+                  alignItems: 'center',
+                  gap: 10,
+                  marginBottom: 6,
+                }}
+              >
                 <div
                   style={{
                     backgroundColor: '#EDE3D0',
@@ -1012,10 +1295,19 @@ function AnalyticsView({
                 >
                   <Icon style={{ width: 14, height: 14, color: '#5a4a35' }} />
                 </div>
-                <span style={{ flex: 1, fontSize: 13, fontWeight: 600, color: '#2A2A2A' }}>
+                <span
+                  style={{
+                    flex: 1,
+                    fontSize: 13,
+                    fontWeight: 600,
+                    color: '#2A2A2A',
+                  }}
+                >
                   {label}
                 </span>
-                <span style={{ fontSize: 12, color: '#5a4a35' }}>{donated}/{total}</span>
+                <span style={{ fontSize: 12, color: '#5a4a35' }}>
+                  {donated}/{total}
+                </span>
                 <span
                   style={{
                     fontSize: 12,
@@ -1054,14 +1346,23 @@ function AnalyticsView({
       {/* Section 2: Monthly Donation Timeline */}
       <SectionCard
         title="Donation Timeline"
-        subtitle={totalDonated > 0 ? `${totalDonated} donation${totalDonated !== 1 ? 's' : ''}` : undefined}
+        subtitle={
+          totalDonated > 0
+            ? `${totalDonated} donation${totalDonated !== 1 ? 's' : ''}`
+            : undefined
+        }
       >
         {monthlyBuckets.buckets.length === 0 ? (
           <div
             className="rounded-[10px] border px-4 py-6 text-center text-sm"
-            style={{ borderColor: '#E7DAC4', backgroundColor: '#F5E9D4', color: '#5a4a35' }}
+            style={{
+              borderColor: '#E7DAC4',
+              backgroundColor: '#F5E9D4',
+              color: '#5a4a35',
+            }}
           >
-            No donations yet — timestamps will appear here once you start donating.
+            No donations yet — timestamps will appear here once you start
+            donating.
           </div>
         ) : (
           <div
@@ -1090,7 +1391,12 @@ function AnalyticsView({
                   }}
                 >
                   <span
-                    style={{ fontSize: 9, color: '#5a4a35', opacity: 0.75, lineHeight: 1 }}
+                    style={{
+                      fontSize: 9,
+                      color: '#5a4a35',
+                      opacity: 0.75,
+                      lineHeight: 1,
+                    }}
                   >
                     {count}
                   </span>
@@ -1134,7 +1440,11 @@ function AnalyticsView({
         {totalDonated === 0 ? (
           <div
             className="rounded-[10px] border px-4 py-6 text-center text-sm"
-            style={{ borderColor: '#E7DAC4', backgroundColor: '#F5E9D4', color: '#5a4a35' }}
+            style={{
+              borderColor: '#E7DAC4',
+              backgroundColor: '#F5E9D4',
+              color: '#5a4a35',
+            }}
           >
             Donate fish or bugs to see monthly availability.
           </div>
@@ -1144,8 +1454,18 @@ function AnalyticsView({
               const count = monthAvailability.counts[i];
               const barWidth = (count / monthAvailability.max) * 100;
               return (
-                <div key={name} style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
-                  <div style={{ width: 28, fontSize: 11, color: '#5a4a35', flexShrink: 0 }}>
+                <div
+                  key={name}
+                  style={{ display: 'flex', alignItems: 'center', gap: 8 }}
+                >
+                  <div
+                    style={{
+                      width: 28,
+                      fontSize: 11,
+                      color: '#5a4a35',
+                      flexShrink: 0,
+                    }}
+                  >
                     {name.slice(0, 3)}
                   </div>
                   <div
@@ -1167,7 +1487,16 @@ function AnalyticsView({
                       }}
                     />
                   </div>
-                  <div style={{ width: 18, fontSize: 12, fontWeight: 600, color: '#2A2A2A', textAlign: 'right', flexShrink: 0 }}>
+                  <div
+                    style={{
+                      width: 18,
+                      fontSize: 12,
+                      fontWeight: 600,
+                      color: '#2A2A2A',
+                      textAlign: 'right',
+                      flexShrink: 0,
+                    }}
+                  >
                     {count}
                   </div>
                 </div>
@@ -1185,18 +1514,28 @@ function AnalyticsView({
         {seasonalData.total === 0 ? (
           <div
             className="rounded-[10px] border px-4 py-6 text-center text-sm"
-            style={{ borderColor: '#E7DAC4', backgroundColor: '#F5E9D4', color: '#5a4a35' }}
+            style={{
+              borderColor: '#E7DAC4',
+              backgroundColor: '#F5E9D4',
+              color: '#5a4a35',
+            }}
           >
             Donate fish or bugs to see seasonal availability.
           </div>
         ) : (
-          <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 10 }}>
+          <div
+            style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 10 }}
+          >
             {SEASONS.map(season => {
               const count = seasonalData.counts[season.label];
-              const pct = seasonalData.total > 0
-                ? Math.round((count / seasonalData.total) * 100)
-                : 0;
-              const maxCount = Math.max(...SEASONS.map(s => seasonalData.counts[s.label]), 1);
+              const pct =
+                seasonalData.total > 0
+                  ? Math.round((count / seasonalData.total) * 100)
+                  : 0;
+              const maxCount = Math.max(
+                ...SEASONS.map(s => seasonalData.counts[s.label]),
+                1
+              );
               const barWidth = (count / maxCount) * 100;
               return (
                 <div
@@ -1208,7 +1547,9 @@ function AnalyticsView({
                     padding: '12px 14px',
                   }}
                 >
-                  <div style={{ fontSize: 11, color: '#5a4a35', marginBottom: 3 }}>
+                  <div
+                    style={{ fontSize: 11, color: '#5a4a35', marginBottom: 3 }}
+                  >
                     {season.label}
                   </div>
                   <div
@@ -1222,7 +1563,9 @@ function AnalyticsView({
                   >
                     {count}
                   </div>
-                  <div style={{ fontSize: 11, color: '#5a4a35', marginBottom: 8 }}>
+                  <div
+                    style={{ fontSize: 11, color: '#5a4a35', marginBottom: 8 }}
+                  >
                     {pct}% of donated
                   </div>
                   <div
@@ -1259,7 +1602,11 @@ function EmptyState({ message }: { message: string }) {
   return (
     <div
       className="rounded-[14px] border px-4 py-8 text-center text-sm"
-      style={{ borderColor: '#E7DAC4', backgroundColor: '#FFFDF6', color: '#5a4a35' }}
+      style={{
+        borderColor: '#E7DAC4',
+        backgroundColor: '#FFFDF6',
+        color: '#5a4a35',
+      }}
     >
       {message}
     </div>
@@ -1286,7 +1633,10 @@ function SearchHistoryPopover({
         className="flex items-center justify-between px-4 py-2.5"
         style={{ borderBottom: '1px solid #E7DAC4' }}
       >
-        <span className="text-xs font-semibold uppercase tracking-wider" style={{ color: '#5a4a35' }}>
+        <span
+          className="text-xs font-semibold uppercase tracking-wider"
+          style={{ color: '#5a4a35' }}
+        >
           Recent Searches
         </span>
         <button
@@ -1298,7 +1648,10 @@ function SearchHistoryPopover({
         </button>
       </div>
       {searches.length === 0 ? (
-        <div className="px-4 py-3 text-sm" style={{ color: '#5a4a35', opacity: 0.6 }}>
+        <div
+          className="px-4 py-3 text-sm"
+          style={{ color: '#5a4a35', opacity: 0.6 }}
+        >
           No recent searches.
         </div>
       ) : (
@@ -1352,13 +1705,18 @@ function GlobalSearchBar({
           type="text"
           value={query}
           onChange={e => setQuery(e.target.value)}
-          onKeyDown={e => { if (e.key === 'Enter' && query.trim()) onSubmit(query.trim()); }}
+          onKeyDown={e => {
+            if (e.key === 'Enter' && query.trim()) onSubmit(query.trim());
+          }}
           placeholder="Search all categories…"
           className="w-full bg-transparent outline-none text-sm"
           style={{ color: '#2A2A2A' }}
         />
         {query && (
-          <button onClick={() => setQuery('')} className="opacity-40 hover:opacity-70 shrink-0">
+          <button
+            onClick={() => setQuery('')}
+            className="opacity-40 hover:opacity-70 shrink-0"
+          >
             <X className="w-3.5 h-3.5" />
           </button>
         )}
@@ -1374,7 +1732,10 @@ function GlobalSearchBar({
       {historyOpen && (
         <SearchHistoryPopover
           searches={recentSearches}
-          onSelect={s => { onSelectHistory(s); setHistoryOpen(false); }}
+          onSelect={s => {
+            onSelectHistory(s);
+            setHistoryOpen(false);
+          }}
           onClear={onClearHistory}
         />
       )}
@@ -1460,17 +1821,33 @@ export default function ACCanvas() {
   const [recentSearches, setRecentSearches] = useState<string[]>([]);
   const [historyOpen, setHistoryOpen] = useState(false);
   const historyRef = useRef<HTMLDivElement>(null);
-  const [data, setData] = useState<AllData>({ fish: [], bugs: [], fossils: [], art: [] });
+  const [data, setData] = useState<AllData>({
+    fish: [],
+    bugs: [],
+    fossils: [],
+    art: [],
+  });
   const [loading, setLoading] = useState(true);
-  const [loadError, setLoadError] = useState<'dataLoadFailed' | 'networkError' | null>(null);
+  const [loadError, setLoadError] = useState<AppErrorKind | null>(null);
   const [banner, setBanner] = useState<AppErrorKind | null>(null);
-  const [selected, setSelected] = useState<{ item: AnyItem; category: CategoryId } | null>(null);
+  const [selected, setSelected] = useState<{
+    item: AnyItem;
+    category: CategoryId;
+  } | null>(null);
   const [showCreateTown, setShowCreateTown] = useState(false);
 
   const towns = useAppStore(s => s.towns);
   const activeTownId = useAppStore(s => s.activeTownId);
-  const activeTownDonated = useAppStore(s => s.activeTownId ? (s.donated[s.activeTownId] ?? EMPTY_DONATED) : EMPTY_DONATED);
-  const activeTownDonatedAt = useAppStore(s => s.activeTownId ? (s.donatedAt[s.activeTownId] ?? EMPTY_DONATED_AT) : EMPTY_DONATED_AT);
+  const activeTownDonated = useAppStore(s =>
+    s.activeTownId
+      ? (s.donated[s.activeTownId] ?? EMPTY_DONATED)
+      : EMPTY_DONATED
+  );
+  const activeTownDonatedAt = useAppStore(s =>
+    s.activeTownId
+      ? (s.donatedAt[s.activeTownId] ?? EMPTY_DONATED_AT)
+      : EMPTY_DONATED_AT
+  );
   const toggle = useAppStore(s => s.toggle);
 
   // Show create town modal on first load if no towns exist
@@ -1480,7 +1857,13 @@ export default function ACCanvas() {
 
   function handleExport() {
     if (!activeTown) return;
-    downloadCSV(data, activeTownDonated, activeTownDonatedAt, activeTown.name, activeTown.playerName);
+    downloadCSV(
+      data,
+      activeTownDonated,
+      activeTownDonatedAt,
+      activeTown.name,
+      activeTown.playerName
+    );
   }
 
   function loadMuseumData() {
@@ -1488,7 +1871,10 @@ export default function ACCanvas() {
     setLoadError(null);
     Promise.all(
       CATEGORY_ORDER.map(cat =>
-        fetch(CATEGORY_META[cat].file).then(r => { if (!r.ok) throw new Error(`HTTP ${r.status}`); return r.json(); })
+        fetch(CATEGORY_META[cat].file).then(r => {
+          if (!r.ok) throw new Error(`HTTP ${r.status}`);
+          return r.json();
+        })
       )
     )
       .then(([fish, bugs, fossils, art]) => {
@@ -1498,7 +1884,18 @@ export default function ACCanvas() {
       .catch(err => {
         console.error('Failed to load museum data:', err);
         const isNetwork = !navigator.onLine || err instanceof TypeError;
-        setLoadError(isNetwork ? 'networkError' : 'dataLoadFailed');
+        setLoadError(
+          isNetwork
+            ? {
+                type: 'networkError',
+                message: 'Check your internet connection and try again.',
+              }
+            : {
+                type: 'dataLoadFailed',
+                message:
+                  'Something went wrong while fetching the museum collection.',
+              }
+        );
         setLoading(false);
       });
   }
@@ -1507,28 +1904,26 @@ export default function ACCanvas() {
     loadMuseumData();
   }, []);
 
-  const activeCat: CategoryId | null = (activeTab !== 'home' && activeTab !== 'activity' && activeTab !== 'search' && activeTab !== 'analytics') ? activeTab : null;
-  const activeItems = activeCat ? data[activeCat] as AnyItem[] : [];
+  const activeCat: CategoryId | null =
+    activeTab !== 'home' &&
+    activeTab !== 'activity' &&
+    activeTab !== 'search' &&
+    activeTab !== 'analytics'
+      ? activeTab
+      : null;
+  const activeItems = useMemo(
+    () => (activeCat ? (data[activeCat] as AnyItem[]) : []),
+    [activeCat, data]
+  );
 
   const filtered = useMemo(() => {
     if (!activeCat) return [];
-    const q = query.trim().toLowerCase();
-    if (!q) return activeItems;
-    return activeItems.filter(item =>
-      displayName(item, activeCat).toLowerCase().includes(q)
-    );
+    return filterByQuery(activeItems, activeCat, query);
   }, [activeItems, activeCat, query]);
 
   const globalResults = useMemo(() => {
-    const q = globalQuery.trim().toLowerCase();
-    if (!q) return null;
-    const results = {} as Record<CategoryId, AnyItem[]>;
-    for (const cat of CATEGORY_ORDER) {
-      results[cat] = (data[cat] as AnyItem[]).filter(item =>
-        displayName(item, cat).toLowerCase().includes(q)
-      );
-    }
-    return results;
+    if (!globalQuery.trim()) return null;
+    return globalFilter(data as Record<CategoryId, AnyItem[]>, globalQuery);
   }, [globalQuery, data]);
 
   function pushRecentSearch(term: string) {
@@ -1543,7 +1938,10 @@ export default function ACCanvas() {
   useEffect(() => {
     if (!historyOpen) return;
     function handleOutside(e: MouseEvent) {
-      if (historyRef.current && !historyRef.current.contains(e.target as Node)) {
+      if (
+        historyRef.current &&
+        !historyRef.current.contains(e.target as Node)
+      ) {
         setHistoryOpen(false);
       }
     }
@@ -1552,15 +1950,26 @@ export default function ACCanvas() {
   }, [historyOpen]);
 
   const catCounts = useMemo(() => {
-    const counts = { fish: 0, bugs: 0, fossils: 0, art: 0 } as Record<CategoryId, number>;
+    const counts = { fish: 0, bugs: 0, fossils: 0, art: 0 } as Record<
+      CategoryId,
+      number
+    >;
     for (const cat of CATEGORY_ORDER) {
-      counts[cat] = (data[cat] as AnyItem[]).filter(item => !!activeTownDonated[item.id]).length;
+      counts[cat] = (data[cat] as AnyItem[]).filter(
+        item => !!activeTownDonated[item.id]
+      ).length;
     }
     return counts;
   }, [data, activeTownDonated]);
 
-  const totalItems = CATEGORY_ORDER.reduce((sum, cat) => sum + data[cat].length, 0);
-  const totalDonated = CATEGORY_ORDER.reduce((sum, cat) => sum + catCounts[cat], 0);
+  const totalItems = CATEGORY_ORDER.reduce(
+    (sum, cat) => sum + data[cat].length,
+    0
+  );
+  const totalDonated = CATEGORY_ORDER.reduce(
+    (sum, cat) => sum + catCounts[cat],
+    0
+  );
 
   const handleTabChange = (cat: ViewId) => {
     setActiveTab(cat);
@@ -1568,20 +1977,22 @@ export default function ACCanvas() {
   };
 
   if (loadError) {
-    return (
-      <ErrorState
-        kind={loadError}
-        onRetry={loadMuseumData}
-      />
-    );
+    return <ErrorState error={loadError} onRetry={loadMuseumData} />;
   }
 
   if (loading) {
     return (
       <div className="min-h-screen w-full flex items-center justify-center">
         <div className="text-center">
-          <div className="text-lg font-medium" style={{ color: '#2A2A2A' }}>Loading museum data…</div>
-          <div className="text-sm mt-1" style={{ color: '#5a4a35', opacity: 0.7 }}>Preparing your collection</div>
+          <div className="text-lg font-medium" style={{ color: '#2A2A2A' }}>
+            Loading museum data…
+          </div>
+          <div
+            className="text-sm mt-1"
+            style={{ color: '#5a4a35', opacity: 0.7 }}
+          >
+            Preparing your collection
+          </div>
         </div>
       </div>
     );
@@ -1592,7 +2003,12 @@ export default function ACCanvas() {
   return (
     <div className="min-h-screen w-full relative overflow-hidden">
       {/* Parchment background */}
-      <div className="absolute inset-0" style={{ background: 'linear-gradient(180deg, #f7f3ea 0%, #efe6d6 100%)' }} />
+      <div
+        className="absolute inset-0"
+        style={{
+          background: 'linear-gradient(180deg, #f7f3ea 0%, #efe6d6 100%)',
+        }}
+      />
       <div
         className="absolute inset-0 opacity-[0.06] pointer-events-none"
         style={{
@@ -1614,7 +2030,14 @@ export default function ACCanvas() {
           <ErrorBanner
             error={banner}
             onDismiss={() => setBanner(null)}
-            onRetry={banner.type === 'networkError' ? () => { setBanner(null); loadMuseumData(); } : undefined}
+            onRetry={
+              banner.type === 'networkError'
+                ? () => {
+                    setBanner(null);
+                    loadMuseumData();
+                  }
+                : undefined
+            }
           />
         )}
 
@@ -1635,7 +2058,7 @@ export default function ACCanvas() {
                 donated={activeTownDonated}
                 donatedAt={activeTownDonatedAt}
                 catCounts={catCounts}
-                onNavigate={(v) => handleTabChange(v)}
+                onNavigate={v => handleTabChange(v)}
               />
             ) : activeTab === 'analytics' ? (
               <AnalyticsView
@@ -1644,10 +2067,7 @@ export default function ACCanvas() {
                 donatedAt={activeTownDonatedAt}
               />
             ) : activeTab === 'activity' ? (
-              <ActivityFeed
-                donatedAt={activeTownDonatedAt}
-                data={data}
-              />
+              <ActivityFeed donatedAt={activeTownDonatedAt} data={data} />
             ) : activeTab === 'search' ? (
               <>
                 <GlobalSearchBar
@@ -1657,8 +2077,14 @@ export default function ACCanvas() {
                   historyOpen={historyOpen}
                   setHistoryOpen={setHistoryOpen}
                   recentSearches={recentSearches}
-                  onSelectHistory={s => { setGlobalQuery(s); pushRecentSearch(s); }}
-                  onClearHistory={() => { setRecentSearches([]); setHistoryOpen(false); }}
+                  onSelectHistory={s => {
+                    setGlobalQuery(s);
+                    pushRecentSearch(s);
+                  }}
+                  onClearHistory={() => {
+                    setRecentSearches([]);
+                    setHistoryOpen(false);
+                  }}
                   wrapperRef={historyRef}
                 />
                 <GlobalSearchResults
@@ -1667,7 +2093,8 @@ export default function ACCanvas() {
                   donated={activeTownDonated}
                   onToggle={id => toggle(id)}
                   onSelect={(item, category) => {
-                    if (globalQuery.trim()) pushRecentSearch(globalQuery.trim());
+                    if (globalQuery.trim())
+                      pushRecentSearch(globalQuery.trim());
                     setSelected({ item, category });
                   }}
                 />
@@ -1694,12 +2121,18 @@ export default function ACCanvas() {
                       category={activeCat!}
                       checked={!!activeTownDonated[item.id]}
                       onToggle={() => toggle(item.id)}
-                      onClick={() => setSelected({ item, category: activeCat! })}
+                      onClick={() =>
+                        setSelected({ item, category: activeCat! })
+                      }
                     />
                   ))}
                   {filtered.length === 0 && (
                     <EmptyState
-                      message={query ? `No ${catLabel.toLowerCase()} match "${query}".` : `No ${catLabel.toLowerCase()} found.`}
+                      message={
+                        query
+                          ? `No ${catLabel.toLowerCase()} match "${query}".`
+                          : `No ${catLabel.toLowerCase()} found.`
+                      }
                     />
                   )}
                 </div>

--- a/src/components/ErrorBanner.tsx
+++ b/src/components/ErrorBanner.tsx
@@ -1,46 +1,51 @@
 import React from 'react';
 import { AlertTriangle, WifiOff, AlertCircle, X } from 'lucide-react';
+import type { AppErrorKind } from '../lib/types';
 
-// ─── Types ────────────────────────────────────────────────────────────────────
-
-export type AppErrorKind =
-  | { type: 'dataLoadFailed'; message: string }
-  | { type: 'operationFailed'; message: string; recoverySuggestion?: string }
-  | { type: 'networkError'; message: string }
-  | { type: 'validationFailed'; message: string };
+export type { AppErrorKind };
 
 // ─── Helpers ──────────────────────────────────────────────────────────────────
 
 function iconFor(kind: AppErrorKind['type']) {
   switch (kind) {
-    case 'dataLoadFailed':    return AlertTriangle;
-    case 'networkError':      return WifiOff;
-    case 'operationFailed':   return AlertCircle;
-    case 'validationFailed':  return AlertCircle;
+    case 'dataLoadFailed':
+      return AlertTriangle;
+    case 'networkError':
+      return WifiOff;
+    case 'operationFailed':
+      return AlertCircle;
+    case 'validationFailed':
+      return AlertCircle;
   }
 }
 
 function colorFor(kind: AppErrorKind['type']): string {
   switch (kind) {
     case 'dataLoadFailed':
-    case 'networkError':    return '#C8663A';   // warm orange-brown (matches Fall season colour)
+    case 'networkError':
+      return '#C8663A'; // warm orange-brown (matches Fall season colour)
     case 'operationFailed':
-    case 'validationFailed': return '#B94040';  // muted red
+    case 'validationFailed':
+      return '#B94040'; // muted red
   }
 }
 
 function bgFor(kind: AppErrorKind['type']): string {
   switch (kind) {
     case 'dataLoadFailed':
-    case 'networkError':    return 'rgba(200,102,58,0.10)';
+    case 'networkError':
+      return 'rgba(200,102,58,0.10)';
     case 'operationFailed':
-    case 'validationFailed': return 'rgba(185,64,64,0.10)';
+    case 'validationFailed':
+      return 'rgba(185,64,64,0.10)';
   }
 }
 
 function recoverySuggestionFor(error: AppErrorKind): string | undefined {
-  if (error.type === 'networkError') return 'Check your connection and try again.';
-  if (error.type === 'validationFailed') return 'Please correct the error and try again.';
+  if (error.type === 'networkError')
+    return 'Check your connection and try again.';
+  if (error.type === 'validationFailed')
+    return 'Please correct the error and try again.';
   if (error.type === 'operationFailed') return error.recoverySuggestion;
   return undefined;
 }
@@ -53,7 +58,11 @@ interface ErrorBannerProps {
   onRetry?: () => void;
 }
 
-export default function ErrorBanner({ error, onDismiss, onRetry }: ErrorBannerProps) {
+export default function ErrorBanner({
+  error,
+  onDismiss,
+  onRetry,
+}: ErrorBannerProps) {
   const Icon = iconFor(error.type);
   const color = colorFor(error.type);
   const bg = bgFor(error.type);
@@ -105,7 +114,14 @@ export default function ErrorBanner({ error, onDismiss, onRetry }: ErrorBannerPr
         )}
       </div>
 
-      <div style={{ display: 'flex', alignItems: 'center', gap: '6px', flexShrink: 0 }}>
+      <div
+        style={{
+          display: 'flex',
+          alignItems: 'center',
+          gap: '6px',
+          flexShrink: 0,
+        }}
+      >
         {onRetry && (
           <button
             onClick={onRetry}

--- a/src/components/ErrorBoundary.tsx
+++ b/src/components/ErrorBoundary.tsx
@@ -1,0 +1,40 @@
+import { Component, type ErrorInfo, type ReactNode } from 'react';
+import ErrorState from './ErrorState';
+
+interface Props {
+  children: ReactNode;
+}
+
+interface State {
+  caught: boolean;
+}
+
+export default class ErrorBoundary extends Component<Props, State> {
+  state: State = { caught: false };
+
+  static getDerivedStateFromError(): State {
+    return { caught: true };
+  }
+
+  componentDidCatch(error: Error, info: ErrorInfo) {
+    console.error(
+      '[ErrorBoundary] Uncaught error:',
+      error,
+      info.componentStack
+    );
+  }
+
+  render() {
+    if (this.state.caught) {
+      return (
+        <ErrorState
+          error={{
+            type: 'dataLoadFailed',
+            message: 'Something went wrong. Please refresh the page.',
+          }}
+        />
+      );
+    }
+    return this.props.children;
+  }
+}

--- a/src/components/ErrorState.tsx
+++ b/src/components/ErrorState.tsx
@@ -1,28 +1,22 @@
 import React from 'react';
 import { AlertTriangle, WifiOff, RefreshCw } from 'lucide-react';
+import type { AppErrorKind } from '../lib/types';
 
 // ─── Types ────────────────────────────────────────────────────────────────────
 
-export type LoadErrorKind = 'dataLoadFailed' | 'networkError';
-
 interface ErrorStateProps {
-  kind?: LoadErrorKind;
-  message?: string;
+  error?: AppErrorKind;
   onRetry?: () => void;
 }
 
 // ─── Component ────────────────────────────────────────────────────────────────
 
-export default function ErrorState({
-  kind = 'dataLoadFailed',
-  message,
-  onRetry,
-}: ErrorStateProps) {
-  const isNetwork = kind === 'networkError';
+export default function ErrorState({ error, onRetry }: ErrorStateProps) {
+  const isNetwork = error?.type === 'networkError';
   const Icon = isNetwork ? WifiOff : AlertTriangle;
-  const heading = isNetwork ? 'No Connection' : 'Couldn\'t Load Museum Data';
+  const heading = isNetwork ? 'No Connection' : "Couldn't Load Museum Data";
   const body =
-    message ??
+    error?.message ??
     (isNetwork
       ? 'Check your internet connection and try again.'
       : 'Something went wrong while fetching the museum collection.');
@@ -30,7 +24,9 @@ export default function ErrorState({
   return (
     <div
       className="min-h-screen w-full flex items-center justify-center"
-      style={{ background: 'linear-gradient(180deg, #f7f3ea 0%, #efe6d6 100%)' }}
+      style={{
+        background: 'linear-gradient(180deg, #f7f3ea 0%, #efe6d6 100%)',
+      }}
     >
       {/* Parchment card */}
       <div

--- a/src/components/HomeTab.tsx
+++ b/src/components/HomeTab.tsx
@@ -1,4 +1,4 @@
-import { useMemo } from 'react';
+import { useMemo, type ElementType } from 'react';
 import {
   Fish as FishIcon,
   Bug,
@@ -9,15 +9,31 @@ import {
   AlertTriangle,
   Sparkles,
 } from 'lucide-react';
-import type { Fish as FishType, BugItem, FossilItem, ArtPiece, CategoryId } from '../lib/types';
-import { displayName, formatRelativeDate } from '../lib/utils';
+import type {
+  Fish as FishType,
+  BugItem,
+  FossilItem,
+  ArtPiece,
+  CategoryId,
+} from '../lib/types';
+import { displayName, formatRelativeDate, type AnyItem } from '../lib/utils';
 
 const MONTH_FULL = [
-  'January', 'February', 'March', 'April', 'May', 'June',
-  'July', 'August', 'September', 'October', 'November', 'December',
+  'January',
+  'February',
+  'March',
+  'April',
+  'May',
+  'June',
+  'July',
+  'August',
+  'September',
+  'October',
+  'November',
+  'December',
 ];
 
-const CAT_ICON: Record<CategoryId, React.ElementType> = {
+const CAT_ICON: Record<CategoryId, ElementType> = {
   fish: FishIcon,
   bugs: Bug,
   fossils: Bone,
@@ -51,7 +67,13 @@ interface AvailItem {
   leavingSoon: boolean;
 }
 
-export default function HomeTab({ data, donated, donatedAt, catCounts, onNavigate }: HomeTabProps) {
+export default function HomeTab({
+  data,
+  donated,
+  donatedAt,
+  catCounts,
+  onNavigate,
+}: HomeTabProps) {
   const now = new Date();
   const currentMonth = now.getMonth() + 1;
   const nextMonth = currentMonth === 12 ? 1 : currentMonth + 1;
@@ -73,7 +95,11 @@ export default function HomeTab({ data, donated, donatedAt, catCounts, onNavigat
     };
     push(data.fish, 'fish');
     push(data.bugs, 'bugs');
-    return out.sort((a, b) => Number(b.leavingSoon) - Number(a.leavingSoon) || a.name.localeCompare(b.name));
+    return out.sort(
+      (a, b) =>
+        Number(b.leavingSoon) - Number(a.leavingSoon) ||
+        a.name.localeCompare(b.name)
+    );
   }, [data.fish, data.bugs, donated, currentMonth, nextMonth]);
 
   const fishCount = available.filter(a => a.category === 'fish').length;
@@ -84,7 +110,10 @@ export default function HomeTab({ data, donated, donatedAt, catCounts, onNavigat
     const nameMap: Record<string, { name: string; category: CategoryId }> = {};
     (['fish', 'bugs', 'fossils', 'art'] as CategoryId[]).forEach(cat => {
       for (const item of data[cat]) {
-        nameMap[item.id] = { name: displayName(item as any, cat), category: cat };
+        nameMap[item.id] = {
+          name: displayName(item as AnyItem, cat),
+          category: cat,
+        };
       }
     });
     return Object.entries(donatedAt)
@@ -110,7 +139,10 @@ export default function HomeTab({ data, donated, donatedAt, catCounts, onNavigat
       >
         <div
           className="px-4 py-3 flex items-center gap-2"
-          style={{ background: 'linear-gradient(180deg, #7B5E3B 0%, #6e5234 100%)', color: '#F5E9D4' }}
+          style={{
+            background: 'linear-gradient(180deg, #7B5E3B 0%, #6e5234 100%)',
+            color: '#F5E9D4',
+          }}
         >
           <Sparkles className="w-4 h-4" />
           <div className="text-sm font-semibold">Available in {monthName}</div>
@@ -122,15 +154,20 @@ export default function HomeTab({ data, donated, donatedAt, catCounts, onNavigat
               <div className="text-sm font-medium" style={{ color: '#2A7A52' }}>
                 You're all caught up for {monthName}!
               </div>
-              <div className="text-xs mt-1" style={{ color: '#5a4a35', opacity: 0.75 }}>
-                Every fish and bug available this month is already in your museum.
+              <div
+                className="text-xs mt-1"
+                style={{ color: '#5a4a35', opacity: 0.75 }}
+              >
+                Every fish and bug available this month is already in your
+                museum.
               </div>
             </div>
           ) : (
             <>
               <div className="text-sm mb-3" style={{ color: '#2A2A2A' }}>
                 <span className="font-semibold">{fishCount}</span> fish and{' '}
-                <span className="font-semibold">{bugsCount}</span> bugs still to donate this month
+                <span className="font-semibold">{bugsCount}</span> bugs still to
+                donate this month
                 {leavingCount > 0 && (
                   <>
                     {' · '}
@@ -153,8 +190,14 @@ export default function HomeTab({ data, donated, donatedAt, catCounts, onNavigat
                         backgroundColor: a.leavingSoon ? '#fdf3e8' : '#FDF9F1',
                       }}
                     >
-                      <Icon className="w-4 h-4 shrink-0" style={{ color: '#7B5E3B' }} />
-                      <div className="flex-1 min-w-0 text-sm truncate" style={{ color: '#2A2A2A' }}>
+                      <Icon
+                        className="w-4 h-4 shrink-0"
+                        style={{ color: '#7B5E3B' }}
+                      />
+                      <div
+                        className="flex-1 min-w-0 text-sm truncate"
+                        style={{ color: '#2A2A2A' }}
+                      >
                         {a.name}
                       </div>
                       {a.leavingSoon && (
@@ -191,15 +234,24 @@ export default function HomeTab({ data, donated, donatedAt, catCounts, onNavigat
             >
               <div className="flex items-center gap-2 mb-1.5">
                 <Icon className="w-4 h-4" style={{ color: '#7B5E3B' }} />
-                <div className="text-sm font-semibold" style={{ color: '#2A2A2A' }}>
+                <div
+                  className="text-sm font-semibold"
+                  style={{ color: '#2A2A2A' }}
+                >
                   {CAT_LABEL[cat]}
                 </div>
               </div>
               <div className="text-xs mb-1.5" style={{ color: '#5a4a35' }}>
                 {done} / {total} donated
               </div>
-              <div className="h-1.5 w-full rounded-full overflow-hidden" style={{ backgroundColor: '#e9dcc3' }}>
-                <div className="h-full transition-all duration-500" style={{ width: `${pct}%`, backgroundColor: '#3CA370' }} />
+              <div
+                className="h-1.5 w-full rounded-full overflow-hidden"
+                style={{ backgroundColor: '#e9dcc3' }}
+              >
+                <div
+                  className="h-full transition-all duration-500"
+                  style={{ width: `${pct}%`, backgroundColor: '#3CA370' }}
+                />
               </div>
             </button>
           );
@@ -211,10 +263,15 @@ export default function HomeTab({ data, donated, donatedAt, catCounts, onNavigat
         className="rounded-[14px] border overflow-hidden"
         style={{ borderColor: '#E7DAC4', backgroundColor: '#FFFDF6' }}
       >
-        <div className="px-4 py-2.5 flex items-center justify-between border-b" style={{ borderColor: '#E7DAC4' }}>
+        <div
+          className="px-4 py-2.5 flex items-center justify-between border-b"
+          style={{ borderColor: '#E7DAC4' }}
+        >
           <div className="flex items-center gap-2">
             <Clock className="w-4 h-4" style={{ color: '#7B5E3B' }} />
-            <div className="text-sm font-semibold" style={{ color: '#2A2A2A' }}>Recent donations</div>
+            <div className="text-sm font-semibold" style={{ color: '#2A2A2A' }}>
+              Recent donations
+            </div>
           </div>
           <button
             onClick={() => onNavigate('activity')}
@@ -225,7 +282,10 @@ export default function HomeTab({ data, donated, donatedAt, catCounts, onNavigat
           </button>
         </div>
         {recent.length === 0 ? (
-          <div className="px-4 py-5 text-center text-sm" style={{ color: '#5a4a35', opacity: 0.75 }}>
+          <div
+            className="px-4 py-5 text-center text-sm"
+            style={{ color: '#5a4a35', opacity: 0.75 }}
+          >
             No donations yet.
           </div>
         ) : (
@@ -234,11 +294,20 @@ export default function HomeTab({ data, donated, donatedAt, catCounts, onNavigat
               const Icon = CAT_ICON[r.category];
               return (
                 <div key={r.id} className="px-4 py-2.5 flex items-center gap-3">
-                  <Icon className="w-4 h-4 shrink-0" style={{ color: '#7B5E3B' }} />
-                  <div className="flex-1 min-w-0 text-sm truncate" style={{ color: '#2A2A2A' }}>
+                  <Icon
+                    className="w-4 h-4 shrink-0"
+                    style={{ color: '#7B5E3B' }}
+                  />
+                  <div
+                    className="flex-1 min-w-0 text-sm truncate"
+                    style={{ color: '#2A2A2A' }}
+                  >
                     {r.name}
                   </div>
-                  <div className="text-xs shrink-0" style={{ color: '#5a4a35', opacity: 0.75 }}>
+                  <div
+                    className="text-xs shrink-0"
+                    style={{ color: '#5a4a35', opacity: 0.75 }}
+                  >
                     {formatRelativeDate(r.ts)}
                   </div>
                 </div>
@@ -261,12 +330,16 @@ export default function HomeTab({ data, donated, donatedAt, catCounts, onNavigat
           <BarChart2 className="w-4 h-4" style={{ color: '#2A7A52' }} />
         </div>
         <div className="flex-1 text-left">
-          <div className="text-sm font-semibold" style={{ color: '#2A2A2A' }}>View full stats</div>
+          <div className="text-sm font-semibold" style={{ color: '#2A2A2A' }}>
+            View full stats
+          </div>
           <div className="text-xs" style={{ color: '#5a4a35', opacity: 0.75 }}>
             Progress charts and monthly availability
           </div>
         </div>
-        <div className="text-sm" style={{ color: '#7B5E3B' }}>→</div>
+        <div className="text-sm" style={{ color: '#7B5E3B' }}>
+          →
+        </div>
       </button>
     </div>
   );

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -35,6 +35,14 @@ export interface ArtPiece {
   basedOn: string;
 }
 
+// ─── Error types ─────────────────────────────────────────────────────────────
+
+export type AppErrorKind =
+  | { type: 'dataLoadFailed'; message: string }
+  | { type: 'operationFailed'; message: string; recoverySuggestion?: string }
+  | { type: 'networkError'; message: string }
+  | { type: 'validationFailed'; message: string };
+
 /** Normalised view of any collectible, used for the detail sheet. */
 export interface CollectibleDetail {
   id: string;

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -1,6 +1,28 @@
-import type { Fish as FishType, BugItem, FossilItem, ArtPiece, CategoryId } from './types';
+import type {
+  Fish as FishType,
+  BugItem,
+  FossilItem,
+  ArtPiece,
+  CategoryId,
+} from './types';
 
 export type AnyItem = FishType | BugItem | FossilItem | ArtPiece;
+
+// ─── Type guards ──────────────────────────────────────────────────────────────
+
+export function isFish(item: AnyItem): item is FishType {
+  return 'habitat' in item;
+}
+
+export function isFossil(item: AnyItem): item is FossilItem {
+  return 'part' in item && !('habitat' in item) && !('months' in item);
+}
+
+export function isArtPiece(item: AnyItem): item is ArtPiece {
+  return 'basedOn' in item;
+}
+
+// ─── Item accessors ───────────────────────────────────────────────────────────
 
 export function displayName(item: AnyItem, category: CategoryId): string {
   if (category === 'fossils') {
@@ -10,10 +32,13 @@ export function displayName(item: AnyItem, category: CategoryId): string {
   return item.name;
 }
 
-export function rowSubtitle(item: AnyItem, category: CategoryId): string | null {
-  if (category === 'fish')    return (item as FishType).habitat;
+export function rowSubtitle(
+  item: AnyItem,
+  category: CategoryId
+): string | null {
+  if (category === 'fish') return (item as FishType).habitat;
   if (category === 'fossils') return null;
-  if (category === 'art')     return (item as ArtPiece).basedOn;
+  if (category === 'art') return (item as ArtPiece).basedOn;
   return null;
 }
 
@@ -22,13 +47,16 @@ export function itemBells(item: AnyItem, category: CategoryId): number | null {
   return (item as FishType | BugItem | FossilItem).value ?? null;
 }
 
-export function itemMonths(item: AnyItem, category: CategoryId): number[] | undefined {
+export function itemMonths(
+  item: AnyItem,
+  category: CategoryId
+): number[] | undefined {
   if (category === 'fossils' || category === 'art') return undefined;
   return (item as FishType | BugItem).months;
 }
 
 export function itemNotes(item: AnyItem): string | undefined {
-  return (item as FishType).notes;
+  return isFish(item) ? item.notes : undefined;
 }
 
 export function formatTimestamp(iso: string): string {
@@ -52,31 +80,44 @@ export function formatRelativeDate(iso: string): string {
 
   if (sameDay(date, today)) return 'Today';
   if (sameDay(date, yesterday)) return 'Yesterday';
-  return date.toLocaleDateString('en-US', { month: 'long', day: 'numeric', year: 'numeric' });
+  return date.toLocaleDateString('en-US', {
+    month: 'long',
+    day: 'numeric',
+    year: 'numeric',
+  });
 }
 
 export function formatTime(iso: string): string {
-  return new Date(iso).toLocaleTimeString('en-US', { hour: 'numeric', minute: '2-digit' });
+  return new Date(iso).toLocaleTimeString('en-US', {
+    hour: 'numeric',
+    minute: '2-digit',
+  });
 }
 
 /** Returns items whose display name matches a case-insensitive query string. */
-export function filterByQuery(items: AnyItem[], category: CategoryId, query: string): AnyItem[] {
+export function filterByQuery(
+  items: AnyItem[],
+  category: CategoryId,
+  query: string
+): AnyItem[] {
   const q = query.trim().toLowerCase();
   if (!q) return items;
-  return items.filter(item => displayName(item, category).toLowerCase().includes(q));
+  return items.filter(item =>
+    displayName(item, category).toLowerCase().includes(q)
+  );
 }
 
 /** Cross-category search: filters all items in each category by a single query. */
 export function globalFilter(
   data: Record<CategoryId, AnyItem[]>,
-  query: string,
+  query: string
 ): Record<CategoryId, AnyItem[]> {
   const categories: CategoryId[] = ['fish', 'bugs', 'fossils', 'art'];
   const q = query.trim().toLowerCase();
   const results = {} as Record<CategoryId, AnyItem[]>;
   for (const cat of categories) {
     results[cat] = (data[cat] ?? []).filter(item =>
-      displayName(item, cat).toLowerCase().includes(q),
+      displayName(item, cat).toLowerCase().includes(q)
     );
   }
   return results;


### PR DESCRIPTION
## Summary

- **Unified error types** — `AppErrorKind` moved to `src/lib/types.ts`; `ErrorBanner` re-exports it, `ErrorState` now accepts the full discriminated union instead of a separate `LoadErrorKind` string
- **Type guards** — `isFish()`, `isFossil()`, `isArtPiece()` added to `utils.ts`; `itemNotes()` no longer does an unsafe `as FishType` cast — it returns `undefined` for non-fish items correctly
- **HomeTab `as any` fix** — replaced with `AnyItem` union; fixed stale `React.ElementType` import
- **ErrorBoundary** — new `src/components/ErrorBoundary.tsx` wraps `<ACCanvas />`; unhandled crashes now render `<ErrorState>` instead of a blank page
- **filterByQuery deduplication** — ACCanvas per-category filter and global search now call `filterByQuery()` / `globalFilter()` from utils; inline reimplementations removed
- **Pre-commit hooks** — Husky + lint-staged configured; ESLint + Prettier run on staged `src/**/*.{ts,tsx}` before every commit

## Test plan
- [x] `npm run build` passes (tsc + vite)
- [x] `npm test` — all 50 tests pass
- [x] Pre-commit hook fires and passes on staged files
- [x] No new lint errors introduced in changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)