### PR TITLE
feat: v0.7 Steps 1-3 — multi-game foundation (types, store v2, hydration guard)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ All notable changes to this project are documented here.
 
 ### Added
 - `docs/v0.7-audit.md` — comprehensive codebase audit covering component modularity, type safety, state management, latent bugs, and multi-game architectural readiness
+- **Multi-game foundation — Steps 1–3** (v0.7 architecture, PR targeting development):
+  - `src/lib/types.ts` — `GameId` expanded to union of all 5 games (`ACGCN | ACWW | ACCF | ACNL | ACNH`); `Game` interface and `GAMES` registry added
+  - `src/lib/constants.ts` — `MONTH_NAMES`, `CATEGORY_LABELS`, `CATEGORY_ORDER`, `SEASONS` extracted from ACCanvas
+  - `src/lib/colors.ts` — design token hex constants (`wood`, `paper`, `ink`, `leaf`, `border`, `muted`)
+  - `src/lib/bootstrapMigration.ts` — one-time localStorage key rename (`ac-web:v1` → `ac-web`) called synchronously in `main.tsx` before `createRoot`
+  - `src/lib/storeMigrations.ts` — Zustand `migrateStore` function (v1→v2): backfills `Town.gameId = 'ACGCN'`, lifts `donated`/`donatedAt` to 3-level schema (`townId → gameId → itemId`)
+  - `src/hooks/useHydration.ts` — `useHydration()` hook via `onFinishHydration`; gates `App.tsx` render to prevent empty-state flash for returning users
+- `Town` now carries `gameId: GameId` (defaults to `'ACGCN'` for existing and new towns)
+- Zustand persist store upgraded to `version: 2` with lossless migration — zero data loss for existing users
 
 ### Fixed
 - **Seasonal analytics bug (#1)** — "Seasonal Breakdown" section in Stats tab now counts

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,7 +11,7 @@ A previous Claude session mistakenly built a parallel Expo/React Native app — 
 ## Project Overview
 
 Animal Crossing GCN companion web app. Tracks museum donations (fish, bugs, fossils, art) across multiple towns.
-Cozy parchment/GameCube museum aesthetic. **Current version: v0.6.1**
+Cozy parchment/GameCube museum aesthetic. **Current version: v0.7.0-dev**
 Live at: https://animalcrossingwebapp.vercel.app
 
 ## Commands
@@ -47,12 +47,18 @@ src/
     ErrorBanner.tsx         # Dismissible inline error notification
     ErrorState.tsx          # Full-page error fallback UI
   lib/
-    store.ts                # Zustand store: towns, donations, activeTownId
+    store.ts                # Zustand store: towns, donations, activeTownId. persist key 'ac-web' v2.
+    bootstrapMigration.ts   # One-time localStorage rename (ac-web:v1 → ac-web), called in main.tsx
+    storeMigrations.ts      # Zustand migrate callback: v1→v2 schema lift
+    constants.ts            # MONTH_NAMES, CATEGORY_LABELS, CATEGORY_ORDER, SEASONS
+    colors.ts               # Design token hex constants
     types.ts                # Shared TypeScript interfaces (Town, Donation, etc.)
     utils.ts                # Helper functions (formatting, date math, etc.)
     csvExport.ts            # CSV export logic for donation data
     store.test.ts           # Vitest tests for store actions
     utils.test.ts           # Vitest tests for utility functions
+  hooks/
+    useHydration.ts         # Gates render on Zustand persist rehydration (onFinishHydration)
   test/
     setup.ts                # Vitest setup file
 public/data/acgcn/
@@ -111,6 +117,7 @@ It is **highly conflict-prone** in multi-session work. Before editing:
 - v0.6: Home screen (available this month, leaving-soon, progress cards, recent activity)
 - v0.6.1: Hotfix — restore files deleted by bad v0.6.0 merge, fix corrupted main branch
 - v0.7.0-alpha: Edit/rename town, documentation overhaul (CLAUDE.md, README, CHANGELOG, CI fix)
+- v0.7.0-dev Steps 1–3: GameId union + GAMES registry, 3-level donation schema (townId→gameId→itemId), Zustand v2 migration, hydration guard
 
 ### v0.7 — Multi-game foundation
 - Fix open bugs: seasonal analytics counting everything as spring (#1), edit modal visual polish

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,7 +1,20 @@
 import { Analytics } from '@vercel/analytics/react';
 import ACCanvas from './components/ACCanvas';
+import { useHydration } from './hooks/useHydration';
 
 function App() {
+  const hydrated = useHydration();
+
+  if (!hydrated) {
+    return (
+      <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'center', height: '100vh', background: '#F5E9D4' }}>
+        <span style={{ color: '#7B5E3B', fontFamily: 'Varela Round, sans-serif', fontSize: 18 }}>
+          Loading museum…
+        </span>
+      </div>
+    );
+  }
+
   return (
     <>
       <ACCanvas />

--- a/src/components/ACCanvas.tsx
+++ b/src/components/ACCanvas.tsx
@@ -1469,8 +1469,18 @@ export default function ACCanvas() {
 
   const towns = useAppStore(s => s.towns);
   const activeTownId = useAppStore(s => s.activeTownId);
-  const activeTownDonated = useAppStore(s => s.activeTownId ? (s.donated[s.activeTownId] ?? EMPTY_DONATED) : EMPTY_DONATED);
-  const activeTownDonatedAt = useAppStore(s => s.activeTownId ? (s.donatedAt[s.activeTownId] ?? EMPTY_DONATED_AT) : EMPTY_DONATED_AT);
+  const activeTownDonated = useAppStore(s => {
+    if (!s.activeTownId) return EMPTY_DONATED;
+    const town = s.towns.find(t => t.id === s.activeTownId);
+    if (!town) return EMPTY_DONATED;
+    return s.donated[s.activeTownId]?.[town.gameId] ?? EMPTY_DONATED;
+  });
+  const activeTownDonatedAt = useAppStore(s => {
+    if (!s.activeTownId) return EMPTY_DONATED_AT;
+    const town = s.towns.find(t => t.id === s.activeTownId);
+    if (!town) return EMPTY_DONATED_AT;
+    return s.donatedAt[s.activeTownId]?.[town.gameId] ?? EMPTY_DONATED_AT;
+  });
   const toggle = useAppStore(s => s.toggle);
 
   // Show create town modal on first load if no towns exist

--- a/src/hooks/useHydration.ts
+++ b/src/hooks/useHydration.ts
@@ -1,0 +1,20 @@
+import { useEffect, useState } from 'react';
+import { useAppStore } from '../lib/store';
+
+/**
+ * Returns true once Zustand persist has finished rehydrating from localStorage.
+ * Gate rendering on this to prevent flash of empty state for returning users.
+ */
+export function useHydration(): boolean {
+  const [hydrated, setHydrated] = useState(false);
+
+  useEffect(() => {
+    // Subscribe for the case where hydration completes after this effect runs
+    const unsub = useAppStore.persist.onFinishHydration(() => setHydrated(true));
+    // Handle the case where hydration already completed before this effect ran
+    setHydrated(useAppStore.persist.hasHydrated());
+    return unsub;
+  }, []);
+
+  return hydrated;
+}

--- a/src/lib/bootstrapMigration.ts
+++ b/src/lib/bootstrapMigration.ts
@@ -1,0 +1,18 @@
+/**
+ * Called from main.tsx before createRoot.
+ * Copies old 'ac-web:v1' localStorage key to 'ac-web' so Zustand's
+ * built-in migrate() function can perform a lossless schema upgrade.
+ * Safe to call on every startup — no-ops if already migrated.
+ */
+export function bootstrapLocalStorageMigration(): void {
+  const OLD_KEY = 'ac-web:v1';
+  const NEW_KEY = 'ac-web';
+  const old = localStorage.getItem(OLD_KEY);
+  if (old && !localStorage.getItem(NEW_KEY)) {
+    localStorage.setItem(NEW_KEY, old);
+  }
+  // Remove old key once new key is confirmed present
+  if (localStorage.getItem(NEW_KEY)) {
+    localStorage.removeItem(OLD_KEY);
+  }
+}

--- a/src/lib/colors.ts
+++ b/src/lib/colors.ts
@@ -1,0 +1,9 @@
+/** Design token hex values — single source of truth for all inline styles */
+export const colors = {
+  wood:    '#7B5E3B',  // header/section backgrounds
+  paper:   '#F5E9D4',  // card backgrounds
+  ink:     '#2A2A2A',  // primary text
+  leaf:    '#3CA370',  // progress bars, success states
+  border:  '#E7DAC4',  // borders
+  muted:   '#5a4a35',  // secondary/muted text
+} as const;

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -1,0 +1,22 @@
+import type { CategoryId } from './types';
+
+export const MONTH_NAMES = [
+  'Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun',
+  'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec',
+] as const;
+
+export const CATEGORY_LABELS: Record<CategoryId, string> = {
+  fish:    'Fish',
+  bugs:    'Bugs',
+  fossils: 'Fossils',
+  art:     'Art',
+};
+
+export const CATEGORY_ORDER: CategoryId[] = ['fish', 'bugs', 'fossils', 'art'];
+
+export const SEASONS = [
+  { label: 'Spring', months: [3, 4, 5],   color: '#3CA370' },
+  { label: 'Summer', months: [6, 7, 8],   color: '#E8A838' },
+  { label: 'Fall',   months: [9, 10, 11], color: '#C8663A' },
+  { label: 'Winter', months: [12, 1, 2],  color: '#6A9EC8' },
+] as const;

--- a/src/lib/store.ts
+++ b/src/lib/store.ts
@@ -1,22 +1,25 @@
 import { create } from 'zustand';
 import { persist } from 'zustand/middleware';
+import type { GameId } from './types';
+import { migrateStore } from './storeMigrations';
 
 export interface Town {
   id: string;
   name: string;
   playerName: string;
+  gameId: GameId;
   createdAt: string;
 }
 
 interface AppState {
   towns: Town[];
   activeTownId: string | null;
-  // donated[townId][itemId] = true
-  donated: Record<string, Record<string, boolean>>;
-  // donatedAt[townId][itemId] = ISO string
-  donatedAt: Record<string, Record<string, string>>;
+  // donated[townId][gameId][itemId] = true
+  donated: Record<string, Record<string, Record<string, boolean>>>;
+  // donatedAt[townId][gameId][itemId] = ISO string
+  donatedAt: Record<string, Record<string, Record<string, string>>>;
 
-  createTown: (name: string, playerName: string) => Town;
+  createTown: (name: string, playerName: string, gameId?: GameId) => Town;
   updateTown: (id: string, name: string, playerName: string) => void;
   setActiveTown: (id: string) => void;
   deleteTown: (id: string) => void;
@@ -38,11 +41,12 @@ export const useAppStore = create<AppState>()(
       donated: {},
       donatedAt: {},
 
-      createTown: (name, playerName) => {
+      createTown: (name, playerName, gameId = 'ACGCN') => {
         const town: Town = {
           id: generateId(),
           name,
           playerName,
+          gameId,
           createdAt: new Date().toISOString(),
         };
         set(state => ({ towns: [...state.towns, town], activeTownId: town.id }));
@@ -74,32 +78,44 @@ export const useAppStore = create<AppState>()(
         set(state => {
           const { activeTownId } = state;
           if (!activeTownId) return state;
-          const townDonated = { ...(state.donated[activeTownId] ?? {}) };
+          const activeTown = state.towns.find(t => t.id === activeTownId);
+          if (!activeTown) return state;
+          const { gameId } = activeTown;
+
+          const townDonated   = { ...(state.donated[activeTownId]   ?? {}) };
           const townDonatedAt = { ...(state.donatedAt[activeTownId] ?? {}) };
-          const nowDonated = !townDonated[itemId];
+          const gameDonated   = { ...(townDonated[gameId]   ?? {}) };
+          const gameDonatedAt = { ...(townDonatedAt[gameId] ?? {}) };
+
+          const nowDonated = !gameDonated[itemId];
           if (nowDonated) {
-            townDonated[itemId] = true;
-            townDonatedAt[itemId] = new Date().toISOString();
+            gameDonated[itemId]   = true;
+            gameDonatedAt[itemId] = new Date().toISOString();
           } else {
-            delete townDonated[itemId];
-            delete townDonatedAt[itemId];
+            delete gameDonated[itemId];
+            delete gameDonatedAt[itemId];
           }
+
           return {
-            donated: { ...state.donated, [activeTownId]: townDonated },
-            donatedAt: { ...state.donatedAt, [activeTownId]: townDonatedAt },
+            donated:   { ...state.donated,   [activeTownId]: { ...townDonated,   [gameId]: gameDonated   } },
+            donatedAt: { ...state.donatedAt, [activeTownId]: { ...townDonatedAt, [gameId]: gameDonatedAt } },
           };
         }),
 
       isDonated: (itemId) => {
-        const { activeTownId, donated } = get();
+        const { activeTownId, donated, towns } = get();
         if (!activeTownId) return false;
-        return !!(donated[activeTownId]?.[itemId]);
+        const activeTown = towns.find(t => t.id === activeTownId);
+        if (!activeTown) return false;
+        return !!(donated[activeTownId]?.[activeTown.gameId]?.[itemId]);
       },
 
       getDonatedAt: (itemId) => {
-        const { activeTownId, donatedAt } = get();
+        const { activeTownId, donatedAt, towns } = get();
         if (!activeTownId) return undefined;
-        return donatedAt[activeTownId]?.[itemId];
+        const activeTown = towns.find(t => t.id === activeTownId);
+        if (!activeTown) return undefined;
+        return donatedAt[activeTownId]?.[activeTown.gameId]?.[itemId];
       },
 
       getActiveTown: () => {
@@ -107,6 +123,10 @@ export const useAppStore = create<AppState>()(
         return towns.find(t => t.id === activeTownId);
       },
     }),
-    { name: 'ac-web:v1' }
+    {
+      name: 'ac-web',
+      version: 2,
+      migrate: migrateStore,
+    }
   )
 );

--- a/src/lib/storeMigrations.ts
+++ b/src/lib/storeMigrations.ts
@@ -1,0 +1,42 @@
+import type { Town } from './store';
+
+/**
+ * Zustand persist migrate callback.
+ * Called when the stored version is older than the current version.
+ */
+export function migrateStore(persisted: unknown, fromVersion: number): unknown {
+  let state = persisted as Record<string, unknown>;
+
+  if (fromVersion < 2) {
+    // v1 → v2:
+    // 1. Backfill Town.gameId = 'ACGCN' for all existing towns
+    // 2. Lift donated/donatedAt from [townId][itemId] to [townId][gameId][itemId]
+
+    const towns = (state.towns as Town[] | undefined) ?? [];
+    const migratedTowns = towns.map(t => ({ ...t, gameId: t.gameId ?? 'ACGCN' }));
+
+    const oldDonated   = (state.donated   as Record<string, Record<string, boolean>> | undefined) ?? {};
+    const oldDonatedAt = (state.donatedAt as Record<string, Record<string, string>>  | undefined) ?? {};
+
+    const newDonated:   Record<string, Record<string, Record<string, boolean>>> = {};
+    const newDonatedAt: Record<string, Record<string, Record<string, string>>>  = {};
+
+    for (const townId of Object.keys(oldDonated)) {
+      newDonated[townId]   = { ACGCN: oldDonated[townId] };
+    }
+    for (const townId of Object.keys(oldDonatedAt)) {
+      newDonatedAt[townId] = { ACGCN: oldDonatedAt[townId] };
+    }
+
+    state = {
+      ...state,
+      towns:     migratedTowns,
+      donated:   newDonated,
+      donatedAt: newDonatedAt,
+    };
+  }
+
+  // Future: if (fromVersion < 3) { ... }
+
+  return state;
+}

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -1,4 +1,22 @@
-export type GameId = 'ACGCN';
+export type GameId = 'ACGCN' | 'ACWW' | 'ACCF' | 'ACNL' | 'ACNH';
+
+export interface Game {
+  id: GameId;
+  name: string;
+  shortName: string;
+  year: number;
+  platform: string;
+  /** Whether this game has hemisphere-specific availability (NL, NH only) */
+  hasHemispheres: boolean;
+}
+
+export const GAMES: Record<GameId, Game> = {
+  ACGCN: { id: 'ACGCN', name: 'Animal Crossing (GameCube)', shortName: 'Animal Crossing', year: 2001, platform: 'Nintendo GameCube', hasHemispheres: false },
+  ACWW:  { id: 'ACWW',  name: 'Animal Crossing: Wild World',  shortName: 'Wild World',    year: 2005, platform: 'Nintendo DS',        hasHemispheres: false },
+  ACCF:  { id: 'ACCF',  name: 'Animal Crossing: City Folk',   shortName: 'City Folk',     year: 2008, platform: 'Nintendo Wii',       hasHemispheres: false },
+  ACNL:  { id: 'ACNL',  name: 'Animal Crossing: New Leaf',    shortName: 'New Leaf',      year: 2012, platform: 'Nintendo 3DS',       hasHemispheres: true  },
+  ACNH:  { id: 'ACNH',  name: 'Animal Crossing: New Horizons',shortName: 'New Horizons',  year: 2020, platform: 'Nintendo Switch',    hasHemispheres: true  },
+};
 
 export type Habitat = 'river' | 'ocean' | 'pond' | 'lake' | 'other';
 

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,7 +1,10 @@
 import { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';
 import App from './App';
+import { bootstrapLocalStorageMigration } from './lib/bootstrapMigration';
 import './index.css';
+
+bootstrapLocalStorageMigration();
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>


### PR DESCRIPTION
## Summary

- **Step 1 — Types + constants:** `GameId` expanded to 5-game union; `Game` interface + `GAMES` registry; `constants.ts` and `colors.ts` extracted
- **Step 2 — Store schema v2 + migration:** `Town.gameId` added; donation schema lifted to 3-level `townId → gameId → itemId`; lossless Zustand migration (v1→v2); `bootstrapMigration.ts` renames old localStorage key before React mounts
- **Step 3 — Hydration guard:** `useHydration` hook via `onFinishHydration`; `App.tsx` gated — eliminates empty-state flash for returning users

Zero data loss: existing towns backfill `gameId = 'ACGCN'`, existing donations lifted into `[townId][ACGCN][itemId]` shape. All 50 tests pass. Build clean.

## Test plan

- [ ] Fresh user: app loads, can create town, donate items — all work normally
- [ ] Returning user with v1 data: reload confirms donations persist (localStorage key renamed transparently)
- [ ] DevTools: verify `localStorage['ac-web']` has 3-level `donated` shape and `towns[*].gameId === 'ACGCN'`
- [ ] `npm run build` passes with no TypeScript errors
- [ ] `npm test` — 50/50 tests green

🤖 Generated with [Claude Code](https://claude.com/claude-code)