### PR TITLE
docs: dev process rules, architecture reference, and full v0.7 doc sync

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,26 @@ All notable changes to this project are documented here.
 ## [v0.7.0] — In Progress
 
 ### Added
+- **Edit/rename town** — inline edit flow for town names; pencil icon in town switcher opens modal
+- **Wild World data** — `public/data/acww/` with 56 fish, 56 bugs, and 52 fossils; item IDs shared with GCN where species overlap
+- **Multi-game foundation (Steps 1–3):**
+  - `GameId` union type (`ACGCN | ACWW | ACCF | ACNL | ACNH`) + `Game` interface and `GAMES` registry
+  - 3-level donation schema: `donated[townId][gameId][itemId]`; Zustand persist upgraded to v2 with lossless migration
+  - `src/lib/bootstrapMigration.ts` — one-time localStorage key rename before React mounts
+  - `src/lib/storeMigrations.ts` — Zustand v1→v2 migration; backfills `gameId = 'ACGCN'` for existing towns
+  - `src/lib/constants.ts` — `MONTH_NAMES`, `CATEGORY_LABELS`, `CATEGORY_ORDER`, `SEASONS`
+  - `src/lib/colors.ts` — design token hex constants
+  - `src/hooks/useHydration.ts` — hydration guard via `onFinishHydration`; eliminates empty-state flash
+- **ErrorBoundary** (`src/components/ErrorBoundary.tsx`) — top-level React error boundary; unhandled crashes render `ErrorState`
+- **Pre-commit hooks** — Husky + lint-staged; ESLint + Prettier run on staged `src/**/*.{ts,tsx}` before every commit
 - `docs/v0.7-audit.md` — comprehensive codebase audit covering component modularity, type safety, state management, latent bugs, and multi-game architectural readiness
+- `docs/v0.7-architecture-proposal.md` — multi-game foundation design: store schema, decomposition plan for ACCanvas
+
+### Changed
+- `AppErrorKind` unified across `ErrorBanner` and `ErrorState` — single discriminated union in `types.ts`
+- `HomeTab` — replaced `as any` cast with `AnyItem` union type; fixed stale `React.ElementType` import
+- ACCanvas per-category filter and global search now call `filterByQuery()` / `globalFilter()` from utils; inline reimplementations removed
+- `Town` interface gains `gameId` field (defaults to `'ACGCN'` for new towns; backfilled for existing)
 
 ### Fixed
 - **Seasonal analytics bug (#1)** — "Seasonal Breakdown" section in Stats tab now counts
@@ -16,6 +35,7 @@ All notable changes to this project are documented here.
   escaping the `overflow-hidden` header stacking context that caused visual clipping.
 - **Missing `@vercel/analytics` dependency** — package was referenced in `App.tsx` but not
   installed; added to dependencies so the build no longer fails.
+- **Type safety** — `isFish()`, `isFossil()`, `isArtPiece()` type guards in `utils.ts`; `itemNotes()` no longer does an unsafe `as FishType` cast
 
 ---
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,11 +8,16 @@ The app lives entirely in `src/`. It is a **Vite + React 19 + TypeScript + Tailw
 A previous Claude session mistakenly built a parallel Expo/React Native app — that code was deleted.
 **Never create Expo, React Native, or `app/` directory structures.** Always verify `vercel.json` before starting feature work.
 
+## Dev Process
+
+See `docs/dev-process.md` — every PR must follow the checklist there.  
+See `docs/architecture.md` — deep architectural context (store schema, migrations, multi-game types).
+
 ## Project Overview
 
-Animal Crossing GCN companion web app. Tracks museum donations (fish, bugs, fossils, art) across multiple towns.
-Cozy parchment/GameCube museum aesthetic. **Current version: v0.6.1**
-Live at: https://animalcrossingwebapp.vercel.app
+Animal Crossing multi-game companion web app. Tracks museum donations (fish, bugs, fossils, art) across multiple towns and games.
+Cozy parchment/GameCube museum aesthetic. **Current version: v0.7.0-alpha**
+Live at: https://animalcrossingwebapp.vercel.app | Dev preview: https://development-animalcrossingwebapp.vercel.app
 
 ## Commands
 
@@ -28,31 +33,41 @@ npm install       # Install dependencies
 ## Architecture
 
 **Framework:** Vite + React 19 + TypeScript  
-**Styling:** Tailwind CSS v4 (utility classes only; design tokens are inline hex — see below)  
-**State:** Zustand ^5 with `persist` middleware (localStorage)  
-**Tests:** Vitest
+**Styling:** Tailwind CSS v4 (utility classes only; design tokens via `src/lib/colors.ts` — inline hex)  
+**State:** Zustand ^5 with `persist` middleware (localStorage key: `ac-web`, schema v2)  
+**Tests:** Vitest  
+**Store schema:** 3-level `donated[townId][gameId][itemId]` (as of v0.7)  
+**Migration:** Zustand persist v2 + `bootstrapMigration.ts` — zero data loss for existing users
 
 ### File Structure
 
 ```
 src/
-  App.tsx                   # Root component, mounts ACCanvas
-  main.tsx                  # Entry point
+  App.tsx                   # Root component — hydration guard + ErrorBoundary + ACCanvas
+  main.tsx                  # Entry point — runs bootstrapMigration before React mounts
   components/
     ACCanvas.tsx            # PRIMARY COMPONENT — ~1500 lines. Tab navigation,
                             # all four museum tabs (Fish/Bugs/Fossils/Art),
                             # town switcher, search, modal. CONFLICT-PRONE.
+                            # Decomposition planned — see docs/v0.7-architecture-proposal.md
     HomeTab.tsx             # Home screen: seasonal availability, leaving-soon,
                             # progress cards, recent activity
     ErrorBanner.tsx         # Dismissible inline error notification
+    ErrorBoundary.tsx       # Top-level React error boundary; crashes render ErrorState
     ErrorState.tsx          # Full-page error fallback UI
   lib/
-    store.ts                # Zustand store: towns, donations, activeTownId
-    types.ts                # Shared TypeScript interfaces (Town, Donation, etc.)
-    utils.ts                # Helper functions (formatting, date math, etc.)
+    store.ts                # Zustand store: towns, donations, activeTownId. persist key 'ac-web' v2.
+    bootstrapMigration.ts   # One-time localStorage rename (ac-web:v1 → ac-web), called in main.tsx
+    storeMigrations.ts      # Zustand migrate callback: v1→v2 schema lift
+    constants.ts            # MONTH_NAMES, CATEGORY_LABELS, CATEGORY_ORDER, SEASONS
+    colors.ts               # Design token hex constants
+    types.ts                # Shared TypeScript interfaces (Town, Donation, GameId, Game, etc.)
+    utils.ts                # Helper functions (formatting, date math, type guards)
     csvExport.ts            # CSV export logic for donation data
     store.test.ts           # Vitest tests for store actions
     utils.test.ts           # Vitest tests for utility functions
+  hooks/
+    useHydration.ts         # Gates render on Zustand persist rehydration (onFinishHydration)
   test/
     setup.ts                # Vitest setup file
 public/data/acgcn/
@@ -60,11 +75,20 @@ public/data/acgcn/
   bugs.json                 # 40 species with months[] availability data
   fossils.json              # 25 fossil items
   art.json                  # 13 paintings
+public/data/acww/
+  fish.json                 # 56 species (Wild World)
+  bugs.json                 # 56 species (Wild World)
+  fossils.json              # 52 fossil items (Wild World)
+docs/
+  dev-process.md            # PR checklist and dev process rules for Claude Code sessions
+  architecture.md           # Deep architectural context: store schema, migrations, multi-game types
+  v0.7-audit.md             # Codebase audit: component modularity, type safety, latent bugs
+  v0.7-architecture-proposal.md  # Multi-game foundation design: store schema, decomposition plan
 ```
 
 ### Design System
 
-Inline hex styles — **no Tailwind design tokens**. Use raw hex values:
+Inline hex constants via `src/lib/colors.ts` — **no Tailwind design tokens**:
 - `#7B5E3B` — wood (header/section backgrounds)
 - `#F5E9D4` — paper (card backgrounds)
 - `#2A2A2A` — ink (primary text)
@@ -84,14 +108,17 @@ Inline hex styles — **no Tailwind design tokens**. Use raw hex values:
 ## Deployment
 
 - **Vercel** auto-deploys from `main` to https://animalcrossingwebapp.vercel.app
+- `development` branch auto-deploys to https://development-animalcrossingwebapp.vercel.app
 - Manual: `vercel --prod` from repo root
 - `vercel.json`: `buildCommand: npm run build`, `outputDirectory: dist`, `installCommand: npm install`
 - Project: `animalcrossingwebapp` under `jacuzzicodings-projects`
 
 ## Known Issues
 
-- **issue #10** — CI was broken (ran `npx expo export` instead of `npm run build`) — now fixed
-- **Home screen tab routing** — HomeTab may not display correctly depending on active tab state; treat as fragile
+- **issue #10** — CI was broken (ran `npx expo export` instead of `npm run build`) — **fixed**
+- **issue #1** — Seasonal analytics counted everything as spring — **fixed in v0.7**
+- **@vercel/analytics missing** — package was missing from dependencies — **fixed in v0.7**
+- **ACCanvas.tsx decomposition** — ~1500 lines, planned for breakup in v0.7 (see `docs/v0.7-architecture-proposal.md`)
 
 ## ACCanvas.tsx Warning
 
@@ -105,47 +132,34 @@ It is **highly conflict-prone** in multi-session work. Before editing:
 
 ### Shipped
 - v0.1–v0.2: Initial release, basic museum tracking, town management
-- v0.3: Town management improvements  
+- v0.3: Town management improvements
 - v0.4: Global search, analytics/stats tab
 - v0.5: CSV export, error handling UI, Vitest tests, Vercel Analytics, monthly availability chart, enriched JSON data
 - v0.6: Home screen (available this month, leaving-soon, progress cards, recent activity)
 - v0.6.1: Hotfix — restore files deleted by bad v0.6.0 merge, fix corrupted main branch
-- v0.7.0-alpha: Edit/rename town, documentation overhaul (CLAUDE.md, README, CHANGELOG, CI fix)
+- v0.7.0-alpha (in development):
+  - Edit/rename town, documentation overhaul (CLAUDE.md, README, CHANGELOG, CI fix)
+  - Seasonal analytics fix (#1), edit modal visual polish, @vercel/analytics fix
+  - v0.7 architecture proposal and codebase audit
+  - Wild World data (56 fish, 56 bugs, 52 fossils) in `public/data/acww/`
+  - Type safety pass: AppErrorKind, type guards, ErrorBoundary, pre-commit hooks
+  - 3-level donation schema (townId→gameId→itemId), Zustand v2 migration, hydration guard
 
-### v0.7 — Multi-game foundation
-- Fix open bugs: seasonal analytics counting everything as spring (#1), edit modal visual polish
-- Build unified multi-game data model (items shared across games with per-game availability metadata)
+### v0.7 — Multi-game foundation (remaining)
 - Game selection UI
-- Migrate existing GCN data to new structure (zero data loss for current users)
-- Add Wild World + City Folk item data
-- Break up ACCanvas.tsx (~1500 lines) into focused components
+- Break up ACCanvas.tsx into focused components
 - Add React Router for game URLs and item detail routes
 
 ### v0.8 — Full game coverage + item details
 - Add New Leaf and New Horizons item data
 - Item detail views (inline expand for fish/bugs/fossils, bottom sheet for art)
 - Seasonal/time-based filtering
-- Data access layer (lib/data/) to isolate components from data format
 
 ### v0.9 — Polish, onboarding, and PWA
-- UI redesign pass (design tokens, consistent styling, cozy museum aesthetic)
-- First-run onboarding experience (zero steps to value — land on "Available Now")
-- PWA support (service worker, manifest, offline capability, add-to-home-screen)
-- Mobile-first responsive pass
+- UI redesign pass; PWA support; mobile-first responsive pass; first-run onboarding
 
 ### v1.0 — Launch ready
-- Branding: favicon, about page, footer with Ko-fi link (jacuzzicoding)
-- SEO: meta tags, Open Graph for social sharing, semantic HTML
-- Performance audit (bundle size, lazy loading, slow connection testing)
-- Accessibility pass (keyboard nav, screen reader, color contrast)
-- Final bug sweep and edge case cleanup
-
-### Post v1.0
-- Villager tracking
-- ACNH-specific features (sea creatures, Nook Miles)
-- Shareable completion milestones
-- Multi-game dashboard view
-- Account sync (optional)
+- Branding, SEO, accessibility, performance audit
 
 ## Sister Project
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# Animal Crossing GCN Museum Tracker
+# Animal Crossing Museum Tracker
 
-A cozy companion web app for Animal Crossing (GameCube) that helps you track museum donations across multiple towns.
+A cozy companion web app for Animal Crossing (GameCube and Wild World) that helps you track museum donations across multiple towns. Multi-game support for City Folk, New Leaf, and New Horizons is in development.
 
 **Live app:** https://animalcrossingwebapp.vercel.app
 
@@ -9,7 +9,8 @@ A cozy companion web app for Animal Crossing (GameCube) that helps you track mus
 ## Features
 
 - Track donations for all four museum categories: Fish, Bugs, Fossils, and Art
-- Manage multiple towns — switch between them at any time
+- Manage multiple towns — create, switch, and rename them at any time
+- Multi-game support: GameCube and Wild World data included; more games in development
 - Home screen with seasonal availability, leaving-soon alerts, and progress cards
 - Global search across all categories
 - Stats tab with collection analytics and monthly availability chart
@@ -46,14 +47,12 @@ npm run lint      # Lint with ESLint
 
 ## Data
 
-Museum data lives in `public/data/acgcn/`:
-- `fish.json` — 40 species with monthly availability
-- `bugs.json` — 40 species with monthly availability
-- `fossils.json` — 25 fossil pieces
-- `art.json` — 13 paintings
+Museum data lives in `public/data/<game>/`:
+- `public/data/acgcn/` — GameCube: 40 fish, 40 bugs, 25 fossils, 13 paintings
+- `public/data/acww/` — Wild World: 56 fish, 56 bugs, 52 fossils
 
 ---
 
 ## Version
 
-Current release: **v0.6.1** — see [CHANGELOG.md](CHANGELOG.md) for history.
+Current release: **v0.7.0-alpha** — see [CHANGELOG.md](CHANGELOG.md) for history.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,87 @@
+# Architecture Reference (v0.7)
+
+Key architectural context for Claude Code sessions. See also `docs/v0.7-architecture-proposal.md`.
+
+## Stack
+
+- **Framework:** Vite + React 19 + TypeScript
+- **Styling:** Tailwind CSS v4 — utility classes only; design tokens are inline hex constants in `src/lib/colors.ts`
+- **State:** Zustand ^5 with `persist` middleware (localStorage key: `ac-web`, schema version 2)
+- **Tests:** Vitest
+- **Hosting:** Vercel (auto-deploys from `main`)
+
+## Store Schema (v2, as of v0.7)
+
+Donation data uses a **3-level schema**:
+
+```
+donated[townId][gameId][itemId] = boolean
+donatedAt[townId][gameId][itemId] = ISO timestamp
+```
+
+- `gameId` is a `GameId` union: `'ACGCN' | 'ACWW' | 'ACCF' | 'ACNL' | 'ACNH'`
+- `Town` has a `gameId` field (backfilled to `'ACGCN'` for pre-v0.7 towns)
+- Zustand `persist` is at `version: 2`; migrations in `src/lib/storeMigrations.ts`
+
+## Migration Path
+
+- `src/lib/bootstrapMigration.ts` — runs in `main.tsx` before React mounts; one-time localStorage key rename (`ac-web:v1` → `ac-web`)
+- `src/lib/storeMigrations.ts` — Zustand `migrate()` callback: v1→v2 lifts flat schema to 3-level, backfills `gameId`
+- Zero data loss for existing users
+
+## Hydration Guard
+
+- `src/hooks/useHydration.ts` — custom hook that resolves after `onFinishHydration`
+- `App.tsx` renders a loading state until the store is rehydrated — eliminates empty-state flash for returning users
+
+## ACCanvas.tsx
+
+- **~1500 lines** — contains all tab navigation, all four museum tabs (Fish/Bugs/Fossils/Art), town switcher, search, and modal
+- **Scheduled for decomposition** into focused components (planned for v0.7)
+- **Highly conflict-prone** in multi-session work — read the whole file before editing, make surgical changes only
+- See `docs/v0.7-architecture-proposal.md` for the decomposition plan
+
+## Data Files
+
+Museum data lives in `public/data/<gameId>/`:
+- `public/data/acgcn/` — Animal Crossing GCN (40 fish, 40 bugs, 25 fossils, 13 art)
+- `public/data/acww/` — Animal Crossing Wild World (56 fish, 56 bugs, 52 fossils) — added v0.7
+
+Item IDs are shared across games where species overlap (e.g. `sea-bass` is the same ID in GCN and WW). The store scopes by `gameId`, so this is safe.
+
+## Multi-Game Types
+
+```ts
+type GameId = 'ACGCN' | 'ACWW' | 'ACCF' | 'ACNL' | 'ACNH';
+
+interface Game {
+  id: GameId;
+  name: string;
+  shortName: string;
+  year: number;
+}
+
+const GAMES: Record<GameId, Game> = { ... }; // in src/lib/types.ts
+```
+
+## Error Handling
+
+- `src/components/ErrorBoundary.tsx` — top-level React error boundary in `App.tsx`; unhandled crashes render `ErrorState`
+- `src/components/ErrorBanner.tsx` — dismissible inline error for soft failures
+- `src/components/ErrorState.tsx` — full-page fallback for hard failures
+- `AppErrorKind` discriminated union in `src/lib/types.ts`
+
+## Design Tokens
+
+Inline hex values via `src/lib/colors.ts` — **no Tailwind design tokens**:
+- `#7B5E3B` — wood (header/section backgrounds)
+- `#F5E9D4` — paper (card backgrounds)
+- `#2A2A2A` — ink (primary text)
+- `#3CA370` — leaf (progress bars, success states)
+- `#E7DAC4` — border colour
+- `#5a4a35` — secondary/muted text
+- Google Fonts: **Varela Round**
+
+## Constants
+
+Shared constants in `src/lib/constants.ts`: `MONTH_NAMES`, `CATEGORY_LABELS`, `CATEGORY_ORDER`, `SEASONS`.

--- a/docs/dev-process.md
+++ b/docs/dev-process.md
@@ -1,0 +1,34 @@
+# Dev Process Rules (v0.7+)
+
+Every feature, fix, or change must follow this checklist before the PR is considered complete.
+
+## PR Checklist
+
+1. **Feature branch** with clean, descriptive commits — branch from `development`, PR back to `development`
+2. **PR description** — summary, what changed, and a test plan
+3. **CHANGELOG.md** — add entry under the current version section using Added/Changed/Fixed/Removed categories
+4. **CLAUDE.md** — update if any of these changed: file structure, new components/hooks/utils, architecture, commands, known issues, version number
+5. **Tests pass** — run `npm run build` and `npm test` before pushing
+6. **Dev preview tested** at https://development-animalcrossingwebapp.vercel.app/ for any user-visible changes
+7. **Version references** kept current across CLAUDE.md, README.md version badge
+
+## Documentation Standards
+
+- **CLAUDE.md is the primary context file for new Claude Code sessions.** If it's wrong, every future session starts with bad info. Keep it accurate.
+- **CHANGELOG.md** follows Keep a Changelog format (https://keepachangelog.com)
+- When in doubt about whether to update docs: **UPDATE THEM.** Stale docs are worse than no docs.
+- After completing work, consider what context future sessions will need. If you created new files, changed architecture, or fixed bugs — update CLAUDE.md.
+
+## Git Workflow
+
+- Branch from `development`, PR back to `development`
+- `main` is production — only merge `development` → `main` for tagged releases
+- Use merge commits (not squash) to preserve history
+- Tag releases: `git tag v0.X.Y && git push origin v0.X.Y`
+- `main` — stable tagged releases only. **Never commit directly to main.**
+
+## Memory
+
+- After completing work, consider what context future sessions will need
+- If you created new files, changed architecture, or fixed bugs — update CLAUDE.md
+- If there's a non-obvious architectural decision, add a comment in the code AND a note in CLAUDE.md


### PR DESCRIPTION
## Summary

This PR fixes the root cause of documentation drift — process rules and architectural context have been living in Dispatch memory but never in the repo. Every new session starts blind.

- **`docs/dev-process.md`** — PR checklist (branch, CHANGELOG, CLAUDE.md, tests, preview, version refs), documentation standards, git workflow rules. Committed to git so sessions can read it.
- **`docs/architecture.md`** — Deep context: store schema v2, 3-level `donated[townId][gameId][itemId]`, migration path (bootstrapMigration + storeMigrations), hydration guard, multi-game types, ErrorBoundary, data file layout, design tokens.
- **`CLAUDE.md`** — Bumped to v0.7.0-alpha; added all new files from PRs #17–#19 (constants.ts, colors.ts, hooks/useHydration.ts, storeMigrations.ts, bootstrapMigration.ts, ErrorBoundary.tsx, public/data/acww/); marked issues #1 and @vercel/analytics as fixed; added dev preview URL; referenced new docs.
- **`CHANGELOG.md`** — Added missing entries for PRs #12 (edit/rename town), #13/#16 (roadmap + architecture proposal docs), #17 (ACWW data), #18 (type safety, ErrorBoundary, pre-commit hooks), #19 (multi-game foundation, store v2, hydration guard).
- **`README.md`** — Bumped version to v0.7.0-alpha, added edit/rename town and multi-game to features, updated data section.

## Notes

`.claude/` is gitignored, so the rules files live in `docs/` instead. CLAUDE.md points to them. Future sessions will load CLAUDE.md at start and can read the docs files for deep context.

## Test plan

- [x] `npm run build` passes (no changes to src/)
- [x] All doc files render correctly as markdown
- [x] CLAUDE.md is under 200 lines

🤖 Generated with [Claude Code](https://claude.com/claude-code)