### PR TITLE
chore: fix .gitignore and add .claude/rules/ session context files

### DIFF
--- a/.claude/rules/architecture.md
+++ b/.claude/rules/architecture.md
@@ -1,0 +1,37 @@
+# Architecture Reference (v0.7)
+
+## Stack
+Vite + React 19 + TypeScript + Tailwind CSS v4 + Zustand (persist middleware)
+
+## Key Files
+- `src/lib/store.ts` — Zustand store, persist v2, 3-level donation schema
+- `src/lib/types.ts` — GameId union, Town, Game interface, GAMES registry
+- `src/lib/constants.ts` — MONTH_NAMES, CATEGORY_LABELS, SEASONS (single source of truth)
+- `src/lib/colors.ts` — design token hex constants
+- `src/lib/storeMigrations.ts` — Zustand migrate callback (v1→v2, backfills gameId)
+- `src/lib/bootstrapMigration.ts` — one-time localStorage key rename, called in main.tsx before createRoot
+- `src/hooks/useHydration.ts` — onFinishHydration guard, prevents flash of empty state
+- `src/components/ErrorBoundary.tsx` — wraps app root, crashes show ErrorState not blank page
+- `src/ACCanvas.tsx` — ~1500 lines, SCHEDULED FOR DECOMPOSITION in v0.7 (see docs/v0.7-architecture-proposal.md)
+- `public/data/<gameId>/` — item data files per game (acgcn/, acww/ exist; accf/, acnl/, acnh/ pending)
+
+## Store Schema (v2)
+```
+donated: Record<townId, Record<gameId, Record<itemId, boolean>>>
+donatedAt: Record<townId, Record<gameId, Record<itemId, string>>>
+towns: Town[]  // each Town has id, name, playerName, gameId, createdAt
+```
+CRITICAL: callers use getActiveTown().gameId to scope donations — store handles the 3rd level.
+
+## Multi-Game Support
+- GameId = 'ACGCN' | 'ACWW' | 'ACCF' | 'ACNL' | 'ACNH'
+- Data files use game-local IDs (sea-bass in ACGCN == sea-bass in ACWW — schema handles scoping)
+- Only show games with data files present in CreateTownModal
+
+## Dev Preview
+https://development-animalcrossingwebapp.vercel.app/ — deploy with `vercel deploy` from development branch
+
+## Reference Docs
+- docs/v0.7-audit.md — full ranked audit (P0/P1/P2)
+- docs/v0.7-architecture-proposal.md — approved design decisions
+- docs/dev-process.md — full dev process (this is the .claude/rules/ version)

--- a/.claude/rules/dev-process.md
+++ b/.claude/rules/dev-process.md
@@ -1,0 +1,22 @@
+# Dev Process Rules (v0.7+)
+
+Every feature, fix, or change must follow this checklist before the PR is complete:
+
+1. Feature branch with clean, descriptive commits
+2. PR with proper description targeting `development` branch
+3. CHANGELOG.md updated with entry under the current version section
+4. CLAUDE.md updated if any of these changed: file structure, new components/hooks/utils, architecture, commands, known issues, version number
+5. Tests pass — run `npm run build` and `npm test` before pushing
+6. Dev preview tested at https://development-animalcrossingwebapp.vercel.app/ for any user-visible changes
+7. Version references kept current (CLAUDE.md, README.md)
+
+## Documentation Standards
+- CLAUDE.md is the primary context file for new sessions. If it's wrong, every future session starts with bad info.
+- CHANGELOG.md follows Keep a Changelog format
+- When in doubt whether to update docs: UPDATE THEM. Stale docs are worse than no docs.
+
+## Git Workflow
+- Branch from `development`, PR back to `development`
+- `main` is production — only merge `development` → `main` for releases
+- Use merge commits (not squash) to preserve history
+- ACCanvas.tsx is a frequent conflict point — coordinate with Dispatch before touching it

--- a/.gitignore
+++ b/.gitignore
@@ -147,6 +147,6 @@ expo-env.d.ts
 # Expo build cache
 .expo/
 
-# Claude Code internals (worktrees, settings)
-.claude/
+# Claude Code local settings only — rules/ and other tracked files are committed
+.claude/settings.local.json
 .vercel


### PR DESCRIPTION
## Summary
- Narrows `.gitignore` entry from `.claude/` (entire directory) to `.claude/settings.local.json`, so `.claude/rules/` files can be committed and auto-loaded by Claude Code at session start
- Adds `.claude/rules/dev-process.md` — PR checklist, documentation standards, git workflow reminders
- Adds `.claude/rules/architecture.md` — stack overview, key file index, store schema, multi-game notes

## Why
`.claude/rules/` files are loaded automatically by Claude Code each session, giving every agent instant context without relying on CLAUDE.md alone. The previous blanket ignore of `.claude/` was blocking this.

`settings.local.json` remains gitignored (contains machine-local overrides).

## Test plan
- [ ] Confirm `.claude/settings.local.json` is still ignored (`git status` should not show it)
- [ ] Confirm `.claude/rules/*.md` are tracked
- [ ] Open a new Claude Code session and verify rules files appear in context

🤖 Generated with [Claude Code](https://claude.com/claude-code)