### PR TITLE
feat: add build version badge to museum canvas footer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project are documented here.
 ## [v0.7.0] — In Progress
 
 ### Added
+- **Build version badge** — version string (from `package.json` via `VITE_APP_VERSION`) displayed in small muted text at the bottom of the museum canvas; `vite.config.ts` injects version at build time
 - **Edit/rename town** — inline edit flow for town names; pencil icon in town switcher opens modal
 - **Wild World data** — `public/data/acww/` with 56 fish, 56 bugs, and 52 fossils; item IDs shared with GCN where species overlap
 - **Multi-game foundation (Steps 1–3):**

--- a/src/components/ACCanvas.tsx
+++ b/src/components/ACCanvas.tsx
@@ -2142,6 +2142,12 @@ export default function ACCanvas() {
             )}
           </>
         )}
+        {/* Version badge */}
+        <div className="text-center pb-2">
+          <span style={{ color: '#9c8a6e', fontSize: '0.7rem', letterSpacing: '0.05em' }}>
+            {import.meta.env.VITE_APP_VERSION}
+          </span>
+        </div>
       </div>
 
       {/* Create town modal — required on first load, optional after */}

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -1,0 +1,9 @@
+/// <reference types="vite/client" />
+
+interface ImportMetaEnv {
+  readonly VITE_APP_VERSION: string;
+}
+
+interface ImportMeta {
+  readonly env: ImportMetaEnv;
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,6 +1,12 @@
 import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
+import { readFileSync } from 'fs';
+
+const { version } = JSON.parse(readFileSync('./package.json', 'utf-8'));
 
 export default defineConfig({
+  define: {
+    'import.meta.env.VITE_APP_VERSION': JSON.stringify(version),
+  },
   plugins: [react()],
 });


### PR DESCRIPTION
## Summary
- Injects `package.json` version into the build via `VITE_APP_VERSION` in `vite.config.ts`
- Displays the version string as small muted text at the bottom of the museum canvas (below all tab content)
- Adds `src/vite-env.d.ts` for proper TypeScript typing of `import.meta.env`
- Updates CHANGELOG.md

## Test plan
- [ ] Build passes (`npm run build`)
- [ ] Version string visible as small muted text at bottom of the app
- [ ] No visual disruption to main UI

🤖 Generated with [Claude Code](https://claude.com/claude-code)