### PR TITLE
feat: game-aware museum data loading

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,8 @@ All notable changes to this project are documented here.
 - `docs/v0.7-audit.md` — comprehensive codebase audit covering component modularity, type safety, state management, latent bugs, and multi-game architectural readiness
 - `docs/v0.7-architecture-proposal.md` — multi-game foundation design: store schema, decomposition plan for ACCanvas
 
+- **Game-aware museum data loading** — `useMuseumData` now accepts a `gameId` and fetches from the correct `/data/<game>/` directory; re-fetches automatically when the active town's game changes. Art tab is hidden for games without art data (ACWW, ACCF). If the user was on the art tab and switches to a non-GCN town, the tab resets to Home.
+
 ### Changed
 - `AppErrorKind` unified across `ErrorBanner` and `ErrorState` — single discriminated union in `types.ts`
 - `HomeTab` — replaced `as any` cast with `AnyItem` union type; fixed stale `React.ElementType` import

--- a/src/components/ACCanvas.tsx
+++ b/src/components/ACCanvas.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { useState, useMemo } from 'react';
+import { useState, useMemo, useEffect } from 'react';
 import { useAppStore } from '../lib/store';
 import { CATEGORY_ORDER } from '../lib/constants';
 import { CATEGORY_META } from '../lib/categoryMeta';
@@ -66,7 +66,7 @@ export default function ACCanvas() {
   const noTowns = towns.length === 0;
   const activeTown = towns.find(t => t.id === activeTownId);
 
-  const { data, loading, loadError, reload } = useMuseumData();
+  const { data, loading, loadError, reload } = useMuseumData(activeTown?.gameId ?? 'ACGCN');
   const {
     globalQuery,
     setGlobalQuery,
@@ -79,6 +79,13 @@ export default function ACCanvas() {
   } = useSearch();
 
   const catCounts = useCategoryStats(data, activeTownDonated);
+
+  // If the user was on the art tab and switches to a game without art, go home.
+  useEffect(() => {
+    if (activeTab === 'art' && data.art.length === 0 && !loading) {
+      setActiveTab('home');
+    }
+  }, [data.art.length, loading, activeTab]);
 
   const totalItems = CATEGORY_ORDER.reduce(
     (sum, cat) => sum + data[cat].length,

--- a/src/components/TabBar.tsx
+++ b/src/components/TabBar.tsx
@@ -36,7 +36,7 @@ export function TabBar({
           ·
         </span>
       </button>
-      {CATEGORY_ORDER.map(cat => {
+      {CATEGORY_ORDER.filter(cat => cat !== 'art' || data.art.length > 0).map(cat => {
         const { label, Icon } = CATEGORY_META[cat];
         const isActive = cat === active;
         const total = data[cat].length;

--- a/src/hooks/useMuseumData.ts
+++ b/src/hooks/useMuseumData.ts
@@ -1,12 +1,12 @@
-import { useState, useEffect } from 'react';
-import { CATEGORY_META } from '../lib/categoryMeta';
+import { useState, useEffect, useCallback } from 'react';
+import { getDataPaths } from '../lib/categoryMeta';
 import { CATEGORY_ORDER } from '../lib/constants';
-import type { AppErrorKind } from '../lib/types';
+import type { GameId, AppErrorKind } from '../lib/types';
 import type { AllData } from '../lib/viewTypes';
 
 export type { AllData };
 
-export function useMuseumData() {
+export function useMuseumData(gameId: GameId = 'ACGCN') {
   const [data, setData] = useState<AllData>({
     fish: [],
     bugs: [],
@@ -16,16 +16,19 @@ export function useMuseumData() {
   const [loading, setLoading] = useState(true);
   const [loadError, setLoadError] = useState<AppErrorKind | null>(null);
 
-  function load() {
+  const load = useCallback(() => {
+    const paths = getDataPaths(gameId);
     setLoading(true);
     setLoadError(null);
     Promise.all(
-      CATEGORY_ORDER.map(cat =>
-        fetch(CATEGORY_META[cat].file).then(r => {
+      CATEGORY_ORDER.map(cat => {
+        const path = paths[cat];
+        if (!path) return Promise.resolve([]);
+        return fetch(path).then(r => {
           if (!r.ok) throw new Error(`HTTP ${r.status}`);
           return r.json();
-        })
-      )
+        });
+      })
     )
       .then(([fish, bugs, fossils, art]) => {
         setData({ fish, bugs, fossils, art });
@@ -48,11 +51,11 @@ export function useMuseumData() {
         );
         setLoading(false);
       });
-  }
+  }, [gameId]);
 
   useEffect(() => {
     load();
-  }, []);
+  }, [load]);
 
   return { data, loading, loadError, reload: load };
 }

--- a/src/lib/categoryMeta.ts
+++ b/src/lib/categoryMeta.ts
@@ -1,6 +1,6 @@
 import type React from 'react';
 import { Fish as FishIcon, Bug, Bone, Palette } from 'lucide-react';
-import type { CategoryId } from './types';
+import type { CategoryId, GameId } from './types';
 
 export const CATEGORY_META: Record<
   CategoryId,
@@ -11,3 +11,22 @@ export const CATEGORY_META: Record<
   fossils: { label: 'Fossils', Icon: Bone, file: '/data/acgcn/fossils.json' },
   art: { label: 'Art', Icon: Palette, file: '/data/acgcn/art.json' },
 };
+
+const GAME_DATA_DIR: Partial<Record<GameId, string>> = {
+  ACGCN: '/data/acgcn',
+  ACWW: '/data/acww',
+  ACCF: '/data/accf',
+};
+
+const GAMES_WITH_ART = new Set<GameId>(['ACGCN']);
+
+/** Returns per-category fetch paths for the given game. Art is null for games without art data. */
+export function getDataPaths(gameId: GameId): Record<CategoryId, string | null> {
+  const dir = GAME_DATA_DIR[gameId] ?? '/data/acgcn';
+  return {
+    fish: `${dir}/fish.json`,
+    bugs: `${dir}/bugs.json`,
+    fossils: `${dir}/fossils.json`,
+    art: GAMES_WITH_ART.has(gameId) ? `${dir}/art.json` : null,
+  };
+}


### PR DESCRIPTION
## Summary
- `useMuseumData` now accepts a `gameId` parameter and loads from the correct `/data/<game>/` directory (acgcn, acww, accf)
- Re-fetches automatically when the active town's game changes (gameId is a `useCallback`/`useEffect` dependency)
- `ACCanvas` passes `activeTown?.gameId ?? 'ACGCN'` to the hook, so no-town state falls back gracefully
- Art tab is hidden in `TabBar` when `data.art.length === 0` (ACWW and ACCF have no art data)
- If the user is on the art tab and switches to a non-GCN town, `ACCanvas` resets the active tab to `home`

## Decisions

**`getDataPaths` in `categoryMeta.ts` vs a new file:** Added it directly to `categoryMeta.ts` since it's tightly coupled to the same data-path concerns already there. No new file needed.

**Art tab hidden vs disabled/greyed:** Hiding is cleaner than showing a disabled `0/0` tab. The tab simply disappears for ACWW and ACCF. If a future game adds art data, it appears automatically — no conditional needed elsewhere.

**Art tab reset on game switch:** Without the `useEffect`, a user on the art tab switching to Wild World would land on an invisible tab rendering the category view for an empty array. The effect detects `data.art.length === 0` after loading completes and redirects to Home. Only fires when needed (art tab active + no art + not loading).

**Fallback to ACGCN when no active town:** Keeps the hook's behavior consistent with previous hardcoded behavior. The no-towns empty state is shown before data is rendered anyway.

## Test plan
- `npm run build` ✅
- `npm run test` ✅ (50 tests, 2 files)
- Verified: ACGCN towns show fish/bugs/fossils/art tabs; ACWW and ACCF towns hide art tab
- Verified: switching between towns of different games re-fetches correct data