### PR TITLE
fix: wire game selector in CreateTownModal (WW/CF towns now creatable)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to this project are documented here.
 
+## [v0.8.0-alpha] — In Progress
+
+### Added
+- Game selector in Create Town modal — players can now choose Animal Crossing (GCN), Wild World, or City Folk when creating a new town
+
 ## [v0.7.0-alpha] — 2026-04-17
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ npm run lint      # Lint with ESLint
 Museum data lives in `public/data/<game>/`:
 - `public/data/acgcn/` — GameCube: 40 fish, 40 bugs, 25 fossils, 13 paintings
 - `public/data/acww/` — Wild World: 56 fish, 56 bugs, 52 fossils
+- `public/data/accf/` — City Folk: 40 fish, 40 bugs, 52 fossils
 
 ---
 

--- a/src/components/modals/CreateTownModal.tsx
+++ b/src/components/modals/CreateTownModal.tsx
@@ -1,6 +1,7 @@
 import React, { useState } from 'react';
 import { X } from 'lucide-react';
 import { useAppStore } from '../../lib/store';
+import { type GameId, GAMES } from '../../lib/types';
 
 export function CreateTownModal({
   onClose,
@@ -12,11 +13,12 @@ export function CreateTownModal({
   const createTown = useAppStore(s => s.createTown);
   const [name, setName] = useState('');
   const [playerName, setPlayerName] = useState('');
+  const [gameId, setGameId] = useState<GameId>('ACGCN');
 
   function handleSubmit(e: React.FormEvent) {
     e.preventDefault();
     if (!name.trim() || !playerName.trim()) return;
-    createTown(name.trim(), playerName.trim());
+    createTown(name.trim(), playerName.trim(), gameId);
     onClose();
   }
 
@@ -91,6 +93,21 @@ export function CreateTownModal({
                 color: '#2A2A2A',
               }}
             />
+          </div>
+          <div>
+            <label className="block text-xs font-medium mb-1.5" style={{ color: '#5a4a35' }}>
+              Game
+            </label>
+            <select
+              value={gameId}
+              onChange={e => setGameId(e.target.value as GameId)}
+              className="w-full rounded-[10px] border px-3 py-2 text-sm outline-none"
+              style={{ borderColor: '#E7DAC4', backgroundColor: '#FFFDF6', color: '#2A2A2A' }}
+            >
+              {(['ACGCN', 'ACWW', 'ACCF'] as GameId[]).map(id => (
+                <option key={id} value={id}>{GAMES[id].name}</option>
+              ))}
+            </select>
           </div>
           <button
             type="submit"


### PR DESCRIPTION
## Summary

- `CreateTownModal` had name/playerName fields but never passed `gameId` to `createTown()` — every new town silently defaulted to ACGCN regardless of what the user picked in the game UI
- Added `gameId` state (default `'ACGCN'`), a `<select>` dropdown listing the three supported games (ACGCN, ACWW, ACCF), and wires it through to `createTown()` on submit
- Visual style matches existing text inputs (same border/background/color tokens)

## Decisions

- **Only ACGCN, ACWW, ACCF listed** — ACNL and ACNH have no data files yet. Showing them would let users create towns with no collectibles to track. They'll be added to the selector when their data ships.
- **`select` instead of card picker** — a dropdown is simpler and consistent with the existing form aesthetic; card pickers would require layout changes that are out of scope for a bug fix.
- **Store already supported `gameId`** — `createTown(name, playerName, gameId?)` existed with a default of `'ACGCN'`; this PR is purely a UI fix to pass the value through.

## Test plan

- [x] `npm run build` — clean
- [x] `npm test` — passes
- [x] Creating a Wild World town stores the correct gameId
- [x] Creating a City Folk town stores the correct gameId
- [x] ACGCN still defaults correctly when no game is changed

🤖 Generated with [Claude Code](https://claude.com/claude-code)