### PR TITLE
feat: add New Leaf and New Horizons to game selector

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,8 @@ All notable changes to this project are documented here.
 
 ### Added
 - **New Horizons data** — `public/data/acnh/` with 81 fish, 80 bugs, 86 fossil pieces, 43 art pieces, and 40 sea creatures; fish/bugs/sea creatures include both Northern and Southern Hemisphere month availability (`months_nh` / `months_sh`); art pieces include `hasFake` flag for counterfeit detection
-- Game selector in Create Town modal — players can now choose Animal Crossing (GCN), Wild World, or City Folk when creating a new town
+- Game selector in Create Town modal — players can now choose Animal Crossing (GCN), Wild World, City Folk, New Leaf, or New Horizons when creating a new town; `CreateTownModal` now derives game list from the `GAMES` registry rather than a hardcoded array
+- `categoryMeta.ts` — added ACNL and ACNH data directory paths and art support for both games
 - **Item detail view (inline expand)** — clicking a fish, bug, or fossil row now expands it in-place to show full detail: month availability grid, sell value, habitat (fish), and notes. Art still opens the existing bottom-sheet modal. Donate/undonate button is included in the expand panel so the user never needs to leave the list.
   - `src/components/ItemExpandPanel.tsx` — new inline expand panel component
   - `CollectibleRow` updated with optional chevron indicator and rounded-top-only corners when expanded

--- a/src/components/modals/CreateTownModal.tsx
+++ b/src/components/modals/CreateTownModal.tsx
@@ -115,7 +115,7 @@ export function CreateTownModal({
                   color: '#2A2A2A',
                 }}
               >
-                {(['ACGCN', 'ACWW', 'ACCF'] as GameId[]).map(id => (
+                {(Object.keys(GAMES) as GameId[]).map(id => (
                   <option key={id} value={id}>
                     {GAMES[id].name}
                   </option>

--- a/src/lib/categoryMeta.ts
+++ b/src/lib/categoryMeta.ts
@@ -16,9 +16,11 @@ const GAME_DATA_DIR: Partial<Record<GameId, string>> = {
   ACGCN: '/data/acgcn',
   ACWW: '/data/acww',
   ACCF: '/data/accf',
+  ACNL: '/data/acnl',
+  ACNH: '/data/acnh',
 };
 
-const GAMES_WITH_ART = new Set<GameId>(['ACGCN']);
+const GAMES_WITH_ART = new Set<GameId>(['ACGCN', 'ACNL', 'ACNH']);
 
 /** Returns per-category fetch paths for the given game. Art is null for games without art data. */
 export function getDataPaths(


### PR DESCRIPTION
## Summary
- `CreateTownModal` now derives the game list from `Object.keys(GAMES)` instead of the hardcoded `['ACGCN', 'ACWW', 'ACCF']` array — all 5 games (GCN, Wild World, City Folk, New Leaf, New Horizons) appear in the selector
- `categoryMeta.ts`: added ACNL and ACNH to `GAME_DATA_DIR` and `GAMES_WITH_ART` so fish, bugs, fossils, and art load from the correct `public/data/acnl/` and `public/data/acnh/` directories

## Decisions
- **No sea creatures tab yet** — ACNL/ACNH both ship `sea_creatures.json` but `CategoryId` doesn't include `sea_creatures`. Adding that category requires UI work (new tab, new type) and is tracked separately.
- **ACNH hemisphere months** — ACNH data uses `months_nh`/`months_sh` instead of `months`. The data loads and items render; the month availability grid will show empty until hemisphere-aware rendering is wired. This is a known limitation, not a regression.
- **`Object.keys(GAMES)` approach** — means any future game added to `GAMES` in `types.ts` + `GAME_DATA_DIR` in `categoryMeta.ts` automatically appears in the modal. No more forgetting to update the hardcoded list.

## Test plan
- [x] `npm run build` passes (tsc + vite, no errors)
- [x] `npm test` passes (50/50 tests)
- [ ] Create an ACNL town — museum tabs load fish, bugs, fossils, art
- [ ] Create an ACNH town — museum tabs load fish, bugs, fossils, art
- [ ] Existing ACGCN/ACWW/ACCF towns unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)