### PR TITLE
feat: per-town hemisphere toggle for ACNH/ACNL (v0.8.0-alpha)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project are documented here.
 ## [v0.8.0-alpha] — In Progress
 
 ### Added
+- **ACNH hemisphere toggle** — per-town Northern / Southern Hemisphere setting stored in Zustand (persist v3). NH/SH pill toggle appears in the museum header only when the active town's game has hemisphere-specific availability (New Horizons, New Leaf). `itemMonths` now resolves `months_nh` / `months_sh` from critter data based on the active hemisphere; non-hemisphere games continue using `months` with no behaviour change. Store migrated to v3 with `hemisphere: 'NH'` backfilled for all existing towns.
 - **React Router v6** (PR #38) — URL-based navigation replaces single-page state; each town and museum tab now has a shareable URL
   - Route structure: `/` → redirects to active town; `/town/:townId` → home tab; `/town/:townId/:tab` → specific tab
   - `BrowserRouter` wraps the app in `main.tsx`; `vercel.json` adds a catch-all SPA rewrite for preview/branch deploys

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,11 +34,11 @@ npm install       # Install dependencies
 
 **Framework:** Vite + React 19 + TypeScript  
 **Styling:** Tailwind CSS v4 (utility classes only; design tokens via `src/lib/colors.ts` — inline hex)  
-**State:** Zustand ^5 with `persist` middleware (localStorage key: `ac-web`, schema v2)  
+**State:** Zustand ^5 with `persist` middleware (localStorage key: `ac-web`, schema v3)  
 **Routing:** React Router v6 (`BrowserRouter`); URL structure: `/` → redirect, `/town/:townId` → home tab, `/town/:townId/:tab` → specific tab; `vercel.json` has catch-all SPA rewrite for preview/branch deploys  
 **Tests:** Vitest  
-**Store schema:** 3-level `donated[townId][gameId][itemId]` (as of v0.7)  
-**Migration:** Zustand persist v2 + `bootstrapMigration.ts` — zero data loss for existing users  
+**Store schema:** 3-level `donated[townId][gameId][itemId]` (as of v0.7); `Town` includes `hemisphere: 'NH' | 'SH'` (as of v0.8)  
+**Migration:** Zustand persist v3 + `bootstrapMigration.ts` — zero data loss for existing users  
 **Modal pattern:** `CreateTownModal` and `EditTownModal` use always-mounted `isOpen` prop pattern; overlay is a single `flex items-center justify-center` wrapper — no `overflow-y-auto`  
 **TownSwitcher dropdown:** `position: fixed` with `getBoundingClientRect()` anchor to escape `overflow-hidden` header; z-index: dismiss overlay `z-40`, dropdown panel `z-50`, action buttons row `relative z-20`; active town filtered out of list
 

--- a/src/components/ACCanvas.tsx
+++ b/src/components/ACCanvas.tsx
@@ -76,6 +76,7 @@ export default function ACCanvas() {
     return s.donatedAt[s.activeTownId]?.[town.gameId] ?? EMPTY_DONATED_AT;
   });
   const toggle = useAppStore(s => s.toggle);
+  const setTownHemisphere = useAppStore(s => s.setTownHemisphere);
 
   // Sync URL townId → Zustand activeTownId
   useEffect(() => {
@@ -224,6 +225,11 @@ export default function ACCanvas() {
           totalCount={totalItems}
           onCreateTown={() => setShowCreateTown(true)}
           onExport={handleExport}
+          gameId={activeTown?.gameId}
+          hemisphere={activeTown?.hemisphere ?? 'NH'}
+          onHemisphereChange={h => {
+            if (activeTown) setTownHemisphere(activeTown.id, h);
+          }}
         />
 
         {banner && (
@@ -322,6 +328,7 @@ export default function ACCanvas() {
                       onClick={() =>
                         setSelected({ item, category: activeCat! })
                       }
+                      hemisphere={activeTown?.hemisphere ?? 'NH'}
                     />
                   ))}
                   {filtered.length === 0 && (
@@ -366,6 +373,7 @@ export default function ACCanvas() {
           donatedAt={activeTownDonatedAt[selected.item.id]}
           onToggle={() => toggle(selected.item.id)}
           onClose={() => setSelected(null)}
+          hemisphere={activeTown?.hemisphere ?? 'NH'}
         />
       )}
     </div>

--- a/src/components/CollectibleRow.tsx
+++ b/src/components/CollectibleRow.tsx
@@ -20,6 +20,7 @@ export function CollectibleRow({
   onToggle,
   onClick,
   expanded,
+  hemisphere,
 }: {
   item: AnyItem;
   category: CategoryId;
@@ -27,12 +28,13 @@ export function CollectibleRow({
   onToggle: () => void;
   onClick: () => void;
   expanded?: boolean;
+  hemisphere?: 'NH' | 'SH';
 }) {
   const { Icon } = CATEGORY_META[category];
   const name = displayName(item, category);
   const subtitle = rowSubtitle(item, category);
   const bells = itemBells(item, category);
-  const months = itemMonths(item, category);
+  const months = itemMonths(item, category, hemisphere);
   const notes = itemNotes(item);
 
   return (

--- a/src/components/MuseumHeader.tsx
+++ b/src/components/MuseumHeader.tsx
@@ -1,17 +1,26 @@
 import React from 'react';
 import { Download } from 'lucide-react';
 import { TownSwitcher } from './TownSwitcher';
+import type { GameId } from '../lib/types';
+import { GAMES } from '../lib/types';
+import type { Hemisphere } from '../lib/store';
 
 export function MuseumHeader({
   donatedCount,
   totalCount,
   onCreateTown,
   onExport,
+  gameId,
+  hemisphere,
+  onHemisphereChange,
 }: {
   donatedCount: number;
   totalCount: number;
   onCreateTown: () => void;
   onExport: () => void;
+  gameId?: GameId;
+  hemisphere?: Hemisphere;
+  onHemisphereChange?: (h: Hemisphere) => void;
 }) {
   const pct = totalCount ? Math.round((donatedCount / totalCount) * 100) : 0;
   return (
@@ -37,6 +46,25 @@ export function MuseumHeader({
             Museum Tracker
           </h1>
           <div className="flex items-center gap-2">
+            {gameId && GAMES[gameId].hasHemispheres && onHemisphereChange && (
+              <div className="flex rounded-[8px] overflow-hidden" style={{ border: '1px solid rgba(245,233,212,0.3)' }}>
+                {(['NH', 'SH'] as const).map(h => (
+                  <button
+                    key={h}
+                    onClick={() => onHemisphereChange(h)}
+                    aria-pressed={hemisphere === h}
+                    title={h === 'NH' ? 'Northern Hemisphere' : 'Southern Hemisphere'}
+                    className="px-2.5 py-1.5 text-[12px] font-medium transition-colors"
+                    style={{
+                      backgroundColor: hemisphere === h ? 'rgba(245,233,212,0.3)' : 'transparent',
+                      color: '#F5E9D4',
+                    }}
+                  >
+                    {h}
+                  </button>
+                ))}
+              </div>
+            )}
             <button
               onClick={onExport}
               title="Export CSV"

--- a/src/components/modals/DetailModal.tsx
+++ b/src/components/modals/DetailModal.tsx
@@ -20,6 +20,7 @@ export function DetailModal({
   donatedAt,
   onToggle,
   onClose,
+  hemisphere,
 }: {
   item: AnyItem;
   category: CategoryId;
@@ -27,12 +28,13 @@ export function DetailModal({
   donatedAt?: string;
   onToggle: () => void;
   onClose: () => void;
+  hemisphere?: 'NH' | 'SH';
 }) {
   const { Icon, label } = CATEGORY_META[category];
   const name = displayName(item, category);
   const subtitle = rowSubtitle(item, category);
   const bells = itemBells(item, category);
-  const months = itemMonths(item, category);
+  const months = itemMonths(item, category, hemisphere);
   const notes = itemNotes(item);
 
   return (

--- a/src/lib/store.ts
+++ b/src/lib/store.ts
@@ -3,11 +3,14 @@ import { persist } from 'zustand/middleware';
 import type { GameId } from './types';
 import { migrateStore } from './storeMigrations';
 
+export type Hemisphere = 'NH' | 'SH';
+
 export interface Town {
   id: string;
   name: string;
   playerName: string;
   gameId: GameId;
+  hemisphere: Hemisphere;
   createdAt: string;
 }
 
@@ -21,6 +24,7 @@ interface AppState {
 
   createTown: (name: string, playerName: string, gameId?: GameId) => Town;
   updateTown: (id: string, name: string, playerName: string) => void;
+  setTownHemisphere: (id: string, hemisphere: Hemisphere) => void;
   setActiveTown: (id: string) => void;
   deleteTown: (id: string) => void;
   toggle: (itemId: string) => void;
@@ -47,6 +51,7 @@ export const useAppStore = create<AppState>()(
           name,
           playerName,
           gameId,
+          hemisphere: 'NH',
           createdAt: new Date().toISOString(),
         };
         set(state => ({
@@ -61,6 +66,11 @@ export const useAppStore = create<AppState>()(
           towns: state.towns.map(t =>
             t.id === id ? { ...t, name, playerName } : t
           ),
+        })),
+
+      setTownHemisphere: (id, hemisphere) =>
+        set(state => ({
+          towns: state.towns.map(t => (t.id === id ? { ...t, hemisphere } : t)),
         })),
 
       setActiveTown: id => set({ activeTownId: id }),
@@ -136,7 +146,7 @@ export const useAppStore = create<AppState>()(
     }),
     {
       name: 'ac-web',
-      version: 2,
+      version: 3,
       migrate: migrateStore,
     }
   )

--- a/src/lib/storeMigrations.ts
+++ b/src/lib/storeMigrations.ts
@@ -49,7 +49,14 @@ export function migrateStore(persisted: unknown, fromVersion: number): unknown {
     };
   }
 
-  // Future: if (fromVersion < 3) { ... }
+  if (fromVersion < 3) {
+    // v2 → v3: backfill hemisphere: 'NH' on all towns
+    const towns = (state.towns as Town[] | undefined) ?? [];
+    state = {
+      ...state,
+      towns: towns.map(t => ({ ...t, hemisphere: t.hemisphere ?? 'NH' })),
+    };
+  }
 
   return state;
 }

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -63,6 +63,8 @@ export interface Fish {
   value: number | null;
   habitat: Habitat;
   months?: number[];
+  months_nh?: number[];
+  months_sh?: number[];
   hours?: number[];
   notes?: string;
 }
@@ -72,6 +74,8 @@ export interface BugItem {
   name: string;
   value: number | null;
   months?: number[];
+  months_nh?: number[];
+  months_sh?: number[];
   notes?: string;
 }
 

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -41,7 +41,7 @@ export const GAMES: Record<GameId, Game> = {
     shortName: 'New Leaf',
     year: 2012,
     platform: 'Nintendo 3DS',
-    hasHemispheres: true,
+    hasHemispheres: false,
   },
   ACNH: {
     id: 'ACNH',

--- a/src/lib/utils.test.ts
+++ b/src/lib/utils.test.ts
@@ -128,6 +128,27 @@ describe('itemMonths', () => {
   it('returns undefined for art', () => {
     expect(itemMonths(artItem, 'art')).toBeUndefined();
   });
+
+  it('returns months_nh when hemisphere is NH and months_nh is present', () => {
+    const nhFish = { ...fishItem, months_nh: [1, 2, 3], months_sh: [7, 8, 9] };
+    expect(itemMonths(nhFish, 'fish', 'NH')).toEqual([1, 2, 3]);
+  });
+
+  it('returns months_sh when hemisphere is SH and months_sh is present', () => {
+    const nhFish = { ...fishItem, months_nh: [1, 2, 3], months_sh: [7, 8, 9] };
+    expect(itemMonths(nhFish, 'fish', 'SH')).toEqual([7, 8, 9]);
+  });
+
+  it('falls back to months when months_nh is absent (non-hemisphere game)', () => {
+    expect(itemMonths(fishItem, 'fish', 'NH')).toEqual([
+      1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12,
+    ]);
+  });
+
+  it('falls back to months_nh when SH requested but months_sh absent', () => {
+    const nhOnlyFish = { ...fishItem, months_nh: [1, 2, 3] };
+    expect(itemMonths(nhOnlyFish, 'fish', 'SH')).toEqual([1, 2, 3]);
+  });
 });
 
 // ─── formatTimestamp ──────────────────────────────────────────────────────────

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -49,10 +49,14 @@ export function itemBells(item: AnyItem, category: CategoryId): number | null {
 
 export function itemMonths(
   item: AnyItem,
-  category: CategoryId
+  category: CategoryId,
+  hemisphere?: 'NH' | 'SH'
 ): number[] | undefined {
   if (category === 'fossils' || category === 'art') return undefined;
-  return (item as FishType | BugItem).months;
+  const critter = item as FishType | BugItem;
+  if (hemisphere === 'SH' && critter.months_sh) return critter.months_sh;
+  if (critter.months_nh) return critter.months_nh;
+  return critter.months;
 }
 
 export function itemNotes(item: AnyItem): string | undefined {


### PR DESCRIPTION
## Summary

- Adds a **Northern / Southern Hemisphere** setting to each town, stored in Zustand and persisted to localStorage. The toggle only appears in the museum header when the active town's game is ACNH (Animal Crossing: New Horizons) — the only game with hemisphere-specific critter availability.
- `itemMonths` now resolves `months_nh` / `months_sh` from critter JSON for ACNH; all other games (ACGCN, ACWW, ACCF, ACNL) continue using `months` with no behaviour change.
- Store migrated from persist v2 → v3 with a zero-data-loss backfill.

## What changed

### Data layer
- `Town` (in `store.ts`) gains `hemisphere: 'NH' | 'SH'` (default `'NH'`)
- New `setTownHemisphere(id, hemisphere)` store action
- `Fish` and `BugItem` in `types.ts` extended with `months_nh?: number[]` and `months_sh?: number[]` — matching the shape already present in `public/data/acnh/` JSON files
- `itemMonths(item, category, hemisphere?)` — optional third param; when present, prefers `months_nh`/`months_sh` over `months`; falls back gracefully when hemisphere fields are absent (i.e. all non-ACNH games)

### Store migration (v2 → v3)
`storeMigrations.ts` gains a `fromVersion < 3` block that maps over `state.towns` and backfills `hemisphere: t.hemisphere ?? 'NH'` on every existing town. Zustand persist version bumped to `3` in `store.ts`. Existing user data is fully preserved.

### UI — NH/SH pill toggle
`MuseumHeader` accepts three new optional props: `gameId`, `hemisphere`, and `onHemisphereChange`. When `GAMES[gameId].hasHemispheres` is true (only ACNH), a pill toggle (two buttons: NH / SH) renders inline with the existing header controls. `onHemisphereChange` calls `setTownHemisphere` in ACCanvas.

### `hasHemispheres` flag pattern
`GAMES` registry in `types.ts` has a `hasHemispheres: boolean` field. Only `ACNH` is `true` — ACNL uses standard `months` arrays like the other games and is correctly set to `false`. The toggle and `itemMonths` hemisphere resolution key off this flag, so if a future game ever adds hemisphere data it can be enabled with a single registry change.

### Prop threading
- `CollectibleRow` and `DetailModal` each accept `hemisphere?: 'NH' | 'SH'` and pass it to `itemMonths`
- `ACCanvas` reads `activeTown?.hemisphere` from the store and passes it down to all three components

## Decisions

- **`hasHemispheres` over `gameId === 'ACNH'`** — the `GAMES` registry already encoded this intent; it keeps the flag semantically clear and avoids a string literal check scattered across components.
- **All towns store hemisphere** — simpler than conditionally including the field; non-ACNH towns carry a `'NH'` value they never act on.
- **`itemMonths` fallback chain** — `months_sh` (if SH + present) → `months_nh` (if present) → `months`. This means a critter with only `months_nh` still shows correct data rather than going blank.

## Test plan

- `npm run build` — passes, no type errors
- `npm test` — 54 tests pass (4 new hemisphere cases in `utils.test.ts`)
- Manual (dev server):
  - ACGCN / ACWW / ACCF / ACNL town → no hemisphere toggle visible
  - ACNH town → NH/SH pills appear in header; toggling SH changes month counts in critter rows and detail modal
  - Setting persists after page reload (localStorage key `ac-web` v3)
  - Switching between towns preserves per-town hemisphere independently