### PR TITLE
feat: Sea Creatures tab UI (ACNL + ACNH) — v0.8.2-alpha

### DIFF
--- a/.claude/rules/architecture.md
+++ b/.claude/rules/architecture.md
@@ -1,37 +1,39 @@
-# Architecture Reference (v0.7)
+# Architecture Reference (v0.8)
 
 ## Stack
-Vite + React 19 + TypeScript + Tailwind CSS v4 + Zustand (persist middleware)
+Vite + React 19 + TypeScript + Tailwind CSS v4 + Zustand (persist middleware) + React Router v6
 
 ## Key Files
-- `src/lib/store.ts` — Zustand store, persist v2, 3-level donation schema
+- `src/lib/store.ts` — Zustand store, persist v3, 3-level donation schema
 - `src/lib/types.ts` — GameId union, Town, Game interface, GAMES registry
 - `src/lib/constants.ts` — MONTH_NAMES, CATEGORY_LABELS, SEASONS (single source of truth)
 - `src/lib/colors.ts` — design token hex constants
 - `src/lib/categoryMeta.ts` — CATEGORY_META constant (label/Icon/file per category)
 - `src/lib/viewTypes.ts` — ViewId and AllData types
-- `src/lib/storeMigrations.ts` — Zustand migrate callback (v1→v2, backfills gameId)
+- `src/lib/storeMigrations.ts` — Zustand migrate callback (v1→v2→v3; backfills gameId, then hemisphere)
 - `src/lib/bootstrapMigration.ts` — one-time localStorage key rename, called in main.tsx before createRoot
 - `src/hooks/useHydration.ts` — onFinishHydration guard, prevents flash of empty state
-- `src/hooks/useMuseumData.ts` — fetches and caches category JSONs; accepts `gameId` and fetches from the correct `/data/<game>/` directory; re-fetches when active town's game changes (PR #27)
+- `src/hooks/useMuseumData.ts` — fetches and caches all category JSONs for the active town's game (including sea creatures for ACNH); accepts `gameId` and fetches from `/data/<game>/`; re-fetches when active town's game changes
 - `src/hooks/useSearch.ts` — search history, click-outside, debounce
 - `src/hooks/useCategoryStats.ts` — memoized donated counts per category
 - `src/components/ErrorBoundary.tsx` — wraps app root, crashes show ErrorState not blank page
-- `src/components/ACCanvas.tsx` — ~298-line orchestration shell; decomposition complete (v0.7 PR #25)
+- `src/components/ACCanvas.tsx` — ~298-line orchestration shell; decomposition complete (v0.7 PR #25); wires ItemExpandPanel inline-expand and DetailModal bottom-sheet
+- `src/components/ItemExpandPanel.tsx` — inline accordion panel for Fish/Bugs/Fossils rows (month grid, bells, habitat, donate toggle)
 - `src/components/shared/` — HabitatChip, DonateToggle, CategoryProgress, SearchBar, EmptyState, MonthGrid
-- `src/components/modals/` — CreateTownModal (with game selector), EditTownModal, DetailModal
+- `src/components/modals/` — CreateTownModal (game selector, new town form), EditTownModal, DetailModal (bottom-sheet for Art + Search results)
 - `src/components/views/` — AnalyticsView, ActivityFeed, SectionCard
 - `src/components/search/` — GlobalSearchBar, GlobalSearchResults, SearchHistoryPopover
 - `src/components/CollectibleRow.tsx`, `TownSwitcher.tsx`, `MuseumHeader.tsx`, `TabBar.tsx`
-- `public/data/<gameId>/` — item data files per game (acgcn/, acww/, accf/, acnh/ exist; acnl/ pending)
+- `public/data/<gameId>/` — item data files for all 5 games: acgcn/, acww/, accf/, acnl/, acnh/ all present
 
-## Store Schema (v2)
+## Store Schema (v3)
 ```
 donated: Record<townId, Record<gameId, Record<itemId, boolean>>>
 donatedAt: Record<townId, Record<gameId, Record<itemId, string>>>
-towns: Town[]  // each Town has id, name, playerName, gameId, createdAt
+towns: Town[]  // each Town has id, name, playerName, gameId, hemisphere ('NH'|'SH'), createdAt
 ```
 CRITICAL: callers use getActiveTown().gameId to scope donations — store handles the 3rd level.
+`hemisphere` defaults to 'NH'; only used for ACNH month display (months_nh / months_sh).
 
 ## Multi-Game Support
 - GameId = 'ACGCN' | 'ACWW' | 'ACCF' | 'ACNL' | 'ACNH'
@@ -39,7 +41,7 @@ CRITICAL: callers use getActiveTown().gameId to scope donations — store handle
 - Only show games with data files present in CreateTownModal
 
 ## Dev Preview
-https://development-animalcrossingwebapp.vercel.app/ — deploy with `vercel deploy` from development branch
+https://development-animalcrossingwebapp.vercel.app/ — auto-deploys from `development` branch via Vercel GitHub integration. Never run `vercel` CLI manually.
 
 ## Reference Docs
 - docs/v0.7-audit.md — full ranked audit (P0/P1/P2)

--- a/.claude/rules/dev-process.md
+++ b/.claude/rules/dev-process.md
@@ -1,4 +1,4 @@
-# Dev Process Rules (v0.7+)
+# Dev Process Rules (v0.8+)
 
 Every feature, fix, or change must follow this checklist before the PR is complete:
 

--- a/.claude/rules/dev-process.md
+++ b/.claude/rules/dev-process.md
@@ -39,3 +39,19 @@ What was verified before submitting (build, tests, manual checks).
 - `main` is production — only merge `development` → `main` for releases
 - Use merge commits (not squash) to preserve history
 - Commit messages should state intent, not just action ("fix: prevent donation state leaking across towns" not "fix: update store.ts")
+
+## Filing & Closing Bugs
+
+Every bug fix MUST have a GitHub Issue. The flow is:
+
+1. **Discover a bug** (Bea reports it, regression caught in dev, etc.)
+2. **File an issue immediately** with `gh issue create` BEFORE starting the fix:
+   - Title: descriptive ("X happens when Y" not "fix X")
+   - Body: reproduction steps, severity, root cause if known
+   - Labels: `bug`, plus `regression` if introduced by a recent change, plus version label (`v0.8`, `v0.9`) if deferred to a later release
+3. **Reference the issue from the fix PR** using `Closes #N` (or `Fixes #N` / `Resolves #N`) in the PR body. This auto-closes the issue when the PR merges.
+4. **Verify auto-close** after merge — if the issue is still open, close manually with `gh issue close N --comment "Fixed by PR #M."`
+
+For bugs where the architectural fix is deferred (e.g. v0.8.1 grey-out instead of the proper v0.9 lift), keep the issue open with a label for the target release and a comment explaining what was shipped vs what's still pending.
+
+For retro filing — bugs we fixed in past PRs without ever creating an issue — file a brief issue (title + symptom + fix PR reference) and immediately close. Searchable history is the goal.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to this project are documented here.
 
 ### Added
 - `public/version-history.html` — styled version history &amp; roadmap page, now served at `/version-history.html` on the live site (previously untracked at repo root)
+- `docs/decisions.md` — initial decision log with two entries: Sea Creatures data/UI split (v0.8 scope deferral, 2026-04-23) and edit-town modal grey-out on category tabs (PR #50, 2026-04-30)
 - `package.json` description field populated with project summary and live URL
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 All notable changes to this project are documented here.
 
+## [v0.8.1] — In Progress
+
+### Added
+- `public/version-history.html` — styled version history &amp; roadmap page, now served at `/version-history.html` on the live site (previously untracked at repo root)
+- `package.json` description field populated with project summary and live URL
+
+### Fixed
+- `docs/architecture.md` — header bumped to v0.8; stale ACCanvas block (described ~1500-line monolith scheduled for decomposition) replaced with post-decomposition reality (405 lines, orchestration shell)
+- `docs/dev-process.md` and `.claude/rules/dev-process.md` — heading bumped from v0.7+ to v0.8+
+
+> More entries will be added before v0.8.1 ships (edit-town-name bug fix is being scoped separately).
+
 ## [v0.8.0-alpha] — 2026-04-29
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ All notable changes to this project are documented here.
   - `CollectibleRow` updated with optional chevron indicator and rounded-top-only corners when expanded
 
 ### Fixed
+- **Detail view regression** — clicking a collectible row now reliably opens the bottom-sheet `DetailModal` for all categories (fish, bugs, fossils, art). The modal's backdrop was receiving the same click event that mounted it (ghost-click timing issue in React 18), causing it to open and immediately close. Fixed by deferring backdrop click-to-close by one event-loop tick after mount via `useRef` + `setTimeout(0)`. Also added `type="button"` to `CollectibleRow`.
 - **Create Town modal centering + iOS zoom** (PR #41) — modal overlay now uses a single `flex items-center justify-center` wrapper with no `overflow-y-auto`; eliminates iOS Safari zoom/scroll issues and off-center rendering on small screens
 - **Town switcher dropdown escapes header clip** (PR #41) — dropdown panel uses `position: fixed` with a `getBoundingClientRect()` anchor so it renders above the `overflow-hidden` header stacking context; z-index layering: dismiss overlay `z-40`, dropdown `z-50`, action buttons row `relative z-20`
 - **Active town no longer appears in switcher list** (PR #41) — current town is filtered out of the dropdown to prevent selecting the already-active town

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to this project are documented here.
 
-## [v0.8.1] — In Progress
+## [v0.8.1-alpha] — 2026-04-30
 
 ### Added
 - `public/version-history.html` — styled version history &amp; roadmap page, now served at `/version-history.html` on the live site (previously untracked at repo root)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,10 +8,17 @@ All notable changes to this project are documented here.
 - `public/version-history.html` — styled version history &amp; roadmap page, now served at `/version-history.html` on the live site (previously untracked at repo root)
 - `docs/decisions.md` — initial decision log with two entries: Sea Creatures data/UI split (v0.8 scope deferral, 2026-04-23) and edit-town modal grey-out on category tabs (PR #50, 2026-04-30)
 - `package.json` description field populated with project summary and live URL
+- **Filing & Closing Bugs** workflow documented in `docs/dev-process.md` (and `.claude/rules/dev-process.md`) — every bug-fix PR must have a corresponding issue using `Closes #N` for auto-close
 
 ### Fixed
 - `docs/architecture.md` — header bumped to v0.8; stale ACCanvas block (described ~1500-line monolith scheduled for decomposition) replaced with post-decomposition reality (405 lines, orchestration shell)
 - `docs/dev-process.md` and `.claude/rules/dev-process.md` — heading bumped from v0.7+ to v0.8+
+
+### Process
+- Backfilled GitHub Issues for bugs fixed without tracking: #51 (edit-town modal bubble, PR #50), #52 (DetailModal backdrop bubble, PR #43 — closed), #53 (inline-expand regression, PR #46 — closed)
+- Closed stale issue #30 (town switcher duplicate — fixed by PR #41)
+- Broadened scope of issue #31 (modal positioning affects all floating modals, not just create-town); labelled `v0.9`; labelled issue #26 `v0.9`
+- Created `regression` and `v0.9` labels in GitHub
 
 > More entries will be added before v0.8.1 ships (edit-town-name bug fix is being scoped separately).
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,29 +2,31 @@
 
 All notable changes to this project are documented here.
 
-## [v0.8.0-alpha] — In Progress
+## [v0.8.0-alpha] — 2026-04-29
 
 ### Added
-- **ACNH hemisphere toggle** — per-town Northern / Southern Hemisphere setting stored in Zustand (persist v3). NH/SH pill toggle appears in the museum header only when the active town's game has hemisphere-specific availability (New Horizons, New Leaf). `itemMonths` now resolves `months_nh` / `months_sh` from critter data based on the active hemisphere; non-hemisphere games continue using `months` with no behaviour change. Store migrated to v3 with `hemisphere: 'NH'` backfilled for all existing towns.
 - **React Router v6** (PR #38) — URL-based navigation replaces single-page state; each town and museum tab now has a shareable URL
   - Route structure: `/` → redirects to active town; `/town/:townId` → home tab; `/town/:townId/:tab` → specific tab
   - `BrowserRouter` wraps the app in `main.tsx`; `vercel.json` adds a catch-all SPA rewrite for preview/branch deploys
   - Tab switching and town switching both update the URL via `useNavigate`; browser back/forward navigate between tabs and towns
   - Deep links work — visiting `/town/<id>/fish` loads that town's fish tab directly
   - `CreateTownModal` navigates to the new town's URL after creation
-- **New Horizons data** — `public/data/acnh/` with 81 fish, 80 bugs, 86 fossil pieces, 43 art pieces, and 40 sea creatures; fish/bugs/sea creatures include both Northern and Southern Hemisphere month availability (`months_nh` / `months_sh`); art pieces include `hasFake` flag for counterfeit detection
-- **ACNL + ACNH game selector** (PR #36) — players can now choose Animal Crossing (GCN), Wild World, City Folk, New Leaf, or New Horizons when creating a new town; `CreateTownModal` derives game list dynamically from `Object.keys(GAMES)` rather than a hardcoded array
-- `categoryMeta.ts` — added ACNL and ACNH data directory paths and art support for both games
-- **Item detail view (inline expand)** — clicking a fish, bug, or fossil row now expands it in-place to show full detail: month availability grid, sell value, habitat (fish), and notes. Art still opens the existing bottom-sheet modal. Donate/undonate button is included in the expand panel so the user never needs to leave the list.
-  - `src/components/ItemExpandPanel.tsx` — new inline expand panel component
-  - `CollectibleRow` updated with optional chevron indicator and rounded-top-only corners when expanded
+- **New Leaf data** (PR #34) — `public/data/acnl/` with fish, bugs, and fossil data for Animal Crossing: New Leaf
+- **New Horizons data** (PR #35) — `public/data/acnh/` with 81 fish, 80 bugs, 86 fossil pieces, 43 art pieces, and 40 sea creatures; fish/bugs/sea creatures include both Northern and Southern Hemisphere month availability (`months_nh` / `months_sh`); art pieces include `hasFake` flag for counterfeit detection
+- **ACNL + ACNH game selector** (PR #36) — players can now choose Animal Crossing (GCN), Wild World, City Folk, New Leaf, or New Horizons when creating a new town; `CreateTownModal` derives game list dynamically from `Object.keys(GAMES)` rather than a hardcoded array; `categoryMeta.ts` updated with ACNL and ACNH data paths and art support
+- **Hemisphere toggle** (PR #42) — per-town NH/SH toggle in the museum header for ACNH towns; `itemMonths` resolves `months_nh` / `months_sh` based on the active hemisphere; ACNL correctly marked as non-hemisphere-aware; store migrated to persist v3 with `hemisphere: 'NH'` backfilled for all existing towns
+- **Item detail inline expand** (PR #33, restored in PR #46) — clicking a fish, bug, or fossil row expands it in-place: month availability grid, sell value, habitat (fish), and notes. Art rows open the existing bottom-sheet modal. Donate/undonate button included in the expand panel. Expand state resets on tab change.
+  - `src/components/ItemExpandPanel.tsx` — inline accordion panel component
+  - `CollectibleRow` — chevron indicator and rounded-top-only corners when expanded
 
 ### Fixed
-- **Detail view regression** — clicking a collectible row now reliably opens the bottom-sheet `DetailModal` for all categories (fish, bugs, fossils, art). The modal's backdrop was receiving the same click event that mounted it (ghost-click timing issue in React 18), causing it to open and immediately close. Fixed by deferring backdrop click-to-close by one event-loop tick after mount via `useRef` + `setTimeout(0)`. Also added `type="button"` to `CollectibleRow`.
-- **Create Town modal centering + iOS zoom** (PR #41) — modal overlay now uses a single `flex items-center justify-center` wrapper with no `overflow-y-auto`; eliminates iOS Safari zoom/scroll issues and off-center rendering on small screens
-- **Town switcher dropdown escapes header clip** (PR #41) — dropdown panel uses `position: fixed` with a `getBoundingClientRect()` anchor so it renders above the `overflow-hidden` header stacking context; z-index layering: dismiss overlay `z-40`, dropdown `z-50`, action buttons row `relative z-20`
-- **Active town no longer appears in switcher list** (PR #41) — current town is filtered out of the dropdown to prevent selecting the already-active town
-- **Town switcher modal stale-state duplicates** (PR #41) — modals now use always-mounted `isOpen` pattern instead of conditional render, eliminating duplicate entry rendering on re-open
+- **Inline expand regression** (PR #46) — `ItemExpandPanel` import, `expandedId` state, and expand/collapse logic were stripped from `ACCanvas.tsx` during the React Router refactor; fully restored
+- **Detail modal backdrop closes immediately** (PR #43) — modal backdrop received the same click event that mounted it (React 18 synchronous flush); fixed by deferring backdrop `onClick` by one event-loop tick via `useRef` + `setTimeout(0)`; also added `type="button"` to `CollectibleRow`
+- **Create Town modal centering + iOS zoom** (PR #41) — overlay uses `flex items-center justify-center`; input font-size set to 16px to prevent iOS auto-zoom
+- **Town switcher dropdown escapes header clip** (PR #41) — panel uses `position: fixed` with `getBoundingClientRect()` anchor; z-index layering: dismiss overlay `z-40`, dropdown `z-50`
+- **Active town duplicate in switcher** (PR #41) — active town filtered out of dropdown list
+- **Town switcher stale-state duplicates** (PR #41) — modals use always-mounted `isOpen` pattern instead of conditional render
+- **Vite build in Vercel preview environments** — `vite.config.ts` falls back to `'unknown'` when `git rev-parse` fails (no `.git` in Vercel build sandbox)
 
 ## [v0.7.0-alpha] — 2026-04-17
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,16 +11,23 @@ All notable changes to this project are documented here.
 - **Filing & Closing Bugs** workflow documented in `docs/dev-process.md` (and `.claude/rules/dev-process.md`) — every bug-fix PR must have a corresponding issue using `Closes #N` for auto-close
 
 ### Fixed
-- `docs/architecture.md` — header bumped to v0.8; stale ACCanvas block (described ~1500-line monolith scheduled for decomposition) replaced with post-decomposition reality (405 lines, orchestration shell)
+- **Edit Town modal dismisses immediately on open** (Closes #51, PR #50) — `EditTownModal` was conditionally rendered inside `TownSwitcher`; the mount click bubbled to the backdrop `onClick`, unmounting it in the same tick. Modal state (`editing`) is now owned by `ACCanvas` alongside all other modal state; `EditTownModal` is always-mounted via `isOpen` prop, matching the pattern established for `CreateTownModal` and `DetailModal`.
+- **`EditTownModal` form state sync** — form fields now sync from the active town via `useEffect` on `town.id`, so re-opening the modal after a rename always shows current values.
+- **`createPortal` removed from `EditTownModal`** — no longer needed now that the modal is mounted at `ACCanvas` level rather than inside `TownSwitcher`.
+- `docs/architecture.md` — header bumped to v0.8; stale ACCanvas block updated to post-decomposition reality (405 lines, orchestration shell)
 - `docs/dev-process.md` and `.claude/rules/dev-process.md` — heading bumped from v0.7+ to v0.8+
 
-### Process
-- Backfilled GitHub Issues for bugs fixed without tracking: #51 (edit-town modal bubble, PR #50), #52 (DetailModal backdrop bubble, PR #43 — closed), #53 (inline-expand regression, PR #46 — closed)
-- Closed stale issue #30 (town switcher duplicate — fixed by PR #41)
-- Broadened scope of issue #31 (modal positioning affects all floating modals, not just create-town); labelled `v0.9`; labelled issue #26 `v0.9`
-- Created `regression` and `v0.9` labels in GitHub
+### Refactored
+- **`TownNameFields` shared component** (`src/components/shared/TownNameFields.tsx`) — extracted town name and player name inputs into a shared component used by both `CreateTownModal` and `EditTownModal`.
+- **`TownSwitcher`** — removed `EditTownModal` import and local `editing` state; edit button now calls `onEditTown` prop.
+- **`MuseumHeader`** — threads `onEditTown` prop through to `TownSwitcher`.
+- **Greyed-out edit + new-town buttons on museum category tabs** — buttons are disabled (`opacity: 0.4`, `cursor: not-allowed`, `aria-disabled`) on Fish, Bugs, and Fossils tabs where modals can't render; tooltip explains where to go. Proper fix deferred to v0.9.
 
-> More entries will be added before v0.8.1 ships (edit-town-name bug fix is being scoped separately).
+### Process
+- Backfilled GitHub Issues for bugs fixed without tracking: #51 (edit-town modal bubble), #52 (DetailModal backdrop bubble, PR #43 — closed), #53 (inline-expand regression, PR #46 — closed)
+- Closed stale issue #30 (town switcher duplicate — fixed by PR #41)
+- Broadened scope of issue #31 (modal positioning affects all floating modals, deferred to v0.9); labelled `v0.9`; labelled issue #26 `v0.9`
+- Created `regression` and `v0.9` labels in GitHub
 
 ## [v0.8.0-alpha] — 2026-04-29
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,7 +16,7 @@ See `docs/architecture.md` — deep architectural context (store schema, migrati
 ## Project Overview
 
 Animal Crossing multi-game companion web app. Tracks museum donations (fish, bugs, fossils, art) across multiple towns and games.
-Cozy parchment/GameCube museum aesthetic. **Current version: v0.8.0-alpha**
+Cozy parchment/GameCube museum aesthetic. **Current version: v0.8.0-alpha shipped 2026-04-29; v0.8.1 in progress**
 Live at: https://animalcrossingwebapp.vercel.app | Dev preview: https://development-animalcrossingwebapp.vercel.app
 
 ## Commands

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,7 +16,7 @@ See `docs/architecture.md` — deep architectural context (store schema, migrati
 ## Project Overview
 
 Animal Crossing multi-game companion web app. Tracks museum donations (fish, bugs, fossils, art) across multiple towns and games.
-Cozy parchment/GameCube museum aesthetic. **Current version: v0.8.0-alpha shipped 2026-04-29; v0.8.1 in progress**
+Cozy parchment/GameCube museum aesthetic. **Current version: v0.8.1-alpha shipped 2026-04-30; v0.9 in progress**
 Live at: https://animalcrossingwebapp.vercel.app | Dev preview: https://development-animalcrossingwebapp.vercel.app
 
 ## Commands

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -169,6 +169,7 @@ See `.claude/rules/vercel.md` for full deployment rules. Key points:
 - **Town switcher dropdown clipped by `overflow-hidden` header** — **fixed in v0.8 (PR #41)**; now uses `position: fixed` anchor
 - **issue #26** — Art tab shows persistent large item name label after clicking an item; low priority, open
 - **issue #31** — Create-town edge case; low priority, open
+- **Sea creatures tab** — ACNH data includes 40 sea creatures but no UI tab exists yet; tracked for v0.9
 
 ## ACCanvas.tsx
 
@@ -196,19 +197,19 @@ Do not add new top-level tabs without updating the tab switch and `TabBar` props
   - Game selection UI (PR #23), ACCanvas decomposition (PR #25)
   - Game-aware data loading in `useMuseumData` (PR #27)
 
-### v0.8 — Full game coverage + item details (in progress)
-- ~~React Router v6 — URL-based navigation~~ — shipped (PR #38)
-- ~~ACNL + ACNH added to game selector (dynamic `Object.keys(GAMES)`)~~ — shipped (PR #36)
-- ~~Modal centering + iOS fix, town switcher fixes~~ — shipped (PR #41)
-- ~~New Horizons item data~~ — done (81 fish, 80 bugs, 86 fossils, 43 art, 40 sea creatures; NH/SH hemisphere months)
-- Sea creatures tab — pending (data exists, UI not built)
-- ACNH hemisphere-aware month display (`months_nh`/`months_sh`) — pending
-- Add New Leaf item data
-- Item detail views (inline expand for fish/bugs/fossils, bottom sheet for art)
-- Seasonal/time-based filtering
-- Item descriptions (data not yet gathered)
+- v0.8.0-alpha — **shipped 2026-04-29**:
+  - React Router v6 — URL-based navigation, shareable URLs per town/tab (PR #38)
+  - New Leaf item data in `public/data/acnl/` (PR #34)
+  - New Horizons data: 81 fish, 80 bugs, 86 fossils, 43 art, 40 sea creatures (PR #35)
+  - ACNL + ACNH game support in game selector (PR #36)
+  - Hemisphere toggle for ACNH towns; store migrated to persist v3 (PR #42)
+  - Item detail inline expand for fish/bugs/fossils; art opens bottom-sheet modal (PR #33, restored PR #46)
+  - Detail modal backdrop fix — modal no longer closes immediately on open (PR #43)
+  - Modal/switcher fixes: centering, iOS zoom, active-town duplicate, z-index (PR #41)
 
-### v0.9 — Polish, onboarding, and PWA
+### v0.9 — Polish, onboarding, and PWA (next)
+- Sea creatures tab (ACNH data exists, UI not built yet)
+- Seasonal/time-based filtering
 - UI redesign pass; PWA support; mobile-first responsive pass; first-run onboarding
 
 ### v1.0 — Launch ready

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -170,6 +170,7 @@ See `.claude/rules/vercel.md` for full deployment rules. Key points:
 - **issue #26** — Art tab shows persistent large item name label after clicking an item; low priority, open
 - **issue #31** — Create-town edge case; low priority, open
 - **Sea creatures tab** — ACNH data includes 40 sea creatures but no UI tab exists yet; tracked for v0.9
+- **Edit/new-town buttons greyed out on Fish, Bugs, Fossils tabs** — intentional v0.8.1 stopgap. Modals (EditTownModal, CreateTownModal) are mounted in ACCanvas, which sits below the router layout; on museum category tabs the modal renders fine but overlapping scroll context causes visual issues. Buttons show `opacity: 0.4` + tooltip directing users to Home/Search/Recent Donations instead. Proper fix (lift modals to layout level) deferred to v0.9 UI revamp.
 
 ## ACCanvas.tsx
 

--- a/README.md
+++ b/README.md
@@ -66,3 +66,5 @@ Museum data lives in `public/data/<game>/`:
 ## Version
 
 Current release: **v0.8.0-alpha** — see [CHANGELOG.md](CHANGELOG.md) for history.
+
+Significant design decisions are logged in [docs/decisions.md](docs/decisions.md).

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Animal Crossing Museum Tracker
 
-A cozy companion web app for Animal Crossing (GameCube, Wild World, and City Folk) that helps you track museum donations across multiple towns. Multi-game support for New Leaf and New Horizons is in development.
+A cozy companion web app for tracking Animal Crossing museum donations across multiple towns. Supports all five mainline games: GameCube, Wild World, City Folk, New Leaf, and New Horizons.
 
 **Live app:** https://animalcrossingwebapp.vercel.app
 
@@ -8,9 +8,13 @@ A cozy companion web app for Animal Crossing (GameCube, Wild World, and City Fol
 
 ## Features
 
-- Track donations for all four museum categories: Fish, Bugs, Fossils, and Art
+- Track donations for all museum categories: Fish, Bugs, Fossils, and Art
 - Manage multiple towns — create, switch, and rename them at any time
-- Multi-game support: GameCube, Wild World, and City Folk data included; New Leaf and New Horizons in development
+- **Five games supported:** Animal Crossing (GCN), Wild World, City Folk, New Leaf, New Horizons
+- **Item inline expand** — tap a Fish, Bug, or Fossil row to expand it in-place: month availability grid, sell value, habitat, and donate/undonate button (powered by `ItemExpandPanel`)
+- **Bottom-sheet detail view** — Art rows and Search results open a full detail sheet (`DetailModal`)
+- **Hemisphere toggle** — New Horizons towns show an NH/SH toggle; month grids reflect the correct hemisphere
+- **URL-based navigation** — every town and tab has a shareable URL via React Router v6
 - Home screen with seasonal availability, leaving-soon alerts, and progress cards
 - Global search across all categories
 - Stats tab with collection analytics and monthly availability chart
@@ -24,7 +28,8 @@ A cozy companion web app for Animal Crossing (GameCube, Wild World, and City Fol
 
 - **Vite + React 19 + TypeScript**
 - **Tailwind CSS v4**
-- **Zustand v5** (state + localStorage persistence)
+- **Zustand v5** (state + localStorage persistence, schema v3)
+- **React Router v6** (URL-based navigation)
 - **Vitest** (unit tests)
 - **Vercel** (hosting + analytics)
 
@@ -51,9 +56,13 @@ Museum data lives in `public/data/<game>/`:
 - `public/data/acgcn/` — GameCube: 40 fish, 40 bugs, 25 fossils, 13 paintings
 - `public/data/acww/` — Wild World: 56 fish, 56 bugs, 52 fossils
 - `public/data/accf/` — City Folk: 40 fish, 40 bugs, 52 fossils
+- `public/data/acnl/` — New Leaf: fish, bugs, fossils
+- `public/data/acnh/` — New Horizons: 81 fish, 80 bugs, 86 fossils, 43 art, 40 sea creatures (NH/SH month availability)
+
+> Sea creatures data is loaded for New Horizons but a dedicated Sea Creatures tab is not yet implemented — tracked for v0.9.
 
 ---
 
 ## Version
 
-Current release: **v0.7.0-alpha** — see [CHANGELOG.md](CHANGELOG.md) for history.
+Current release: **v0.8.0-alpha** — see [CHANGELOG.md](CHANGELOG.md) for history.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,4 +1,4 @@
-# Architecture Reference (v0.7)
+# Architecture Reference (v0.8)
 
 Key architectural context for Claude Code sessions. See also `docs/v0.7-architecture-proposal.md`.
 
@@ -36,10 +36,9 @@ donatedAt[townId][gameId][itemId] = ISO timestamp
 
 ## ACCanvas.tsx
 
-- **~1500 lines** — contains all tab navigation, all four museum tabs (Fish/Bugs/Fossils/Art), town switcher, search, and modal
-- **Scheduled for decomposition** into focused components (planned for v0.7)
-- **Highly conflict-prone** in multi-session work — read the whole file before editing, make surgical changes only
-- See `docs/v0.7-architecture-proposal.md` for the decomposition plan
+- **405 lines** — orchestration shell after the v0.7 decomposition; mounts the active tab view, wires modals, and handles global search
+- All data fetching, filtering, and sub-component logic lives in dedicated hooks and components
+- Do not add new top-level tabs without updating the tab switch and `TabBar` props
 
 ## Data Files
 

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -1,0 +1,35 @@
+# Decision Log
+
+Reverse-chronological record of significant design and scope decisions. Newest first.
+
+---
+
+## 2026-04-30 — Grey out edit/new-town buttons on museum category tabs
+
+**Decision:** Grey out (disable, not hide) the edit (pencil) and new-town (+) buttons in `TownSwitcher` when the active tab is a museum category tab (Fish, Bugs, Fossils, Art, Sea Creatures).
+
+**Why:** `EditTownModal` and `CreateTownModal` are mounted inside `ACCanvas`, which only renders on the Home, Search, Activity, and Analytics tabs. Clicking the buttons on a category tab silently does nothing — a broken-feeling affordance. Rather than lift the modals to a layout-level component (the architecturally correct fix), we ship a visibly-disabled state that signals intentional design. The v0.9 UI revamp will redo this entire layer, so investing in the architectural fix now would be discarded work.
+
+**Alternatives considered:**
+- **(a) Lift modals to layout level** — correct fix, ~1 hr of work, but will be redone in v0.9 anyway; deferred on effort/lifespan grounds.
+- **(b) Hide the buttons entirely on blocked tabs** — rejected; users wouldn't know the feature exists. Greying out preserves discoverability while communicating unavailability.
+
+**Implementation:** PR #50 (`fix/edit-town-modal`) — `MODAL_BLOCKED_TABS` constant in `TownSwitcher.tsx` gates the disabled state.
+
+**Reversibility:** Easy — remove the `MODAL_BLOCKED_TABS` check in `TownSwitcher.tsx` and the buttons re-enable everywhere `ACCanvas` renders.
+
+---
+
+## 2026-04-23 — Ship Sea Creatures data without the UI tab in v0.8
+
+**Decision:** Include Sea Creatures item data (40 ACNH entries, 35 ACNL entries) in the v0.8 release but hold the Sea Creatures tab UI for v0.9.
+
+**Why:** Scope containment for v0.8. The data files (`public/data/acnh/sea_creatures.json`, `public/data/acnl/sea_creatures.json`) land cleanly without requiring any UI work — they simply aren't surfaced yet. Adding the tab UI would have extended the v0.8 scope and delayed release; the tab is straightforward to add in v0.9 once the data is confirmed correct.
+
+**Alternatives considered:**
+- **(a) Ship full Sea Creatures (data + UI tab) in v0.8** — deferred; would have pushed the release date and added risk to a version already touching React Router, hemispheres, and two new game datasets.
+- **(b) Omit Sea Creatures data entirely from v0.8** — rejected; the data ships as inert JSON with no downside, and having it in the repo lets the tab UI be built and tested against real data in v0.9.
+
+**Implementation:** Data shipped via PRs #34 (ACNL) and #35 (ACNH). UI work lives on `origin/feature/sea-creatures-tab` (open as of 2026-04-30) — that branch is the starting point for v0.9 pickup.
+
+**Reversibility:** Pickup in v0.9 — `origin/feature/sea-creatures-tab` already has a working prototype; merge it when v0.9 work begins.

--- a/docs/dev-process.md
+++ b/docs/dev-process.md
@@ -1,4 +1,4 @@
-# Dev Process Rules (v0.7+)
+# Dev Process Rules (v0.8+)
 
 Every feature, fix, or change must follow this checklist before the PR is complete:
 

--- a/docs/dev-process.md
+++ b/docs/dev-process.md
@@ -39,3 +39,19 @@ What was verified before submitting (build, tests, manual checks).
 - `main` is production — only merge `development` → `main` for releases
 - Use merge commits (not squash) to preserve history
 - Commit messages should state intent, not just action ("fix: prevent donation state leaking across towns" not "fix: update store.ts")
+
+## Filing & Closing Bugs
+
+Every bug fix MUST have a GitHub Issue. The flow is:
+
+1. **Discover a bug** (Bea reports it, regression caught in dev, etc.)
+2. **File an issue immediately** with `gh issue create` BEFORE starting the fix:
+   - Title: descriptive ("X happens when Y" not "fix X")
+   - Body: reproduction steps, severity, root cause if known
+   - Labels: `bug`, plus `regression` if introduced by a recent change, plus version label (`v0.8`, `v0.9`) if deferred to a later release
+3. **Reference the issue from the fix PR** using `Closes #N` (or `Fixes #N` / `Resolves #N`) in the PR body. This auto-closes the issue when the PR merges.
+4. **Verify auto-close** after merge — if the issue is still open, close manually with `gh issue close N --comment "Fixed by PR #M."`
+
+For bugs where the architectural fix is deferred (e.g. v0.8.1 grey-out instead of the proper v0.9 lift), keep the issue open with a label for the target release and a comment explaining what was shipped vs what's still pending.
+
+For retro filing — bugs we fixed in past PRs without ever creating an issue — file a brief issue (title + symptom + fix PR reference) and immediately close. Searchable history is the goal.

--- a/docs/dev-process.md
+++ b/docs/dev-process.md
@@ -7,7 +7,7 @@ Every feature, fix, or change must follow this checklist before the PR is comple
 3. CHANGELOG.md updated with entry under the current version section
 4. CLAUDE.md updated if any of these changed: file structure, new components/hooks/utils, architecture, commands, known issues, version number
 5. Tests pass — run `npm run build` and `npm test` before pushing
-6. Dev preview tested at https://animalcrossingwebapp-git-development-jacuzzicodings-projects.vercel.app for any user-visible changes
+6. Dev preview tested at https://development-animalcrossingwebapp.vercel.app for any user-visible changes
 7. Version references kept current (CLAUDE.md, README.md)
 
 ## PR Description Requirements

--- a/docs/v0.7-architecture-proposal.md
+++ b/docs/v0.7-architecture-proposal.md
@@ -674,3 +674,7 @@ These have zero store access. Pure props-driven UI. Can be extracted one at a ti
 ---
 
 *End of proposal. Awaiting Dispatch approval before implementation begins.*
+
+---
+
+> **Historical note (2026-04-29):** All Steps 1–8 were implemented in v0.7.0-alpha (released 2026-04-17). The multi-game foundation proposed here was extended in v0.8.0-alpha to include ACNL + ACNH, hemisphere toggle, React Router v6, and item inline-expand. See CLAUDE.md for current architecture state.

--- a/docs/v0.7-audit.md
+++ b/docs/v0.7-audit.md
@@ -262,4 +262,8 @@ These can be done in isolation with low risk:
 - [ ] Add month key validation guard in csvExport (P2-6)
 - [ ] Replace `as any` in `HomeTab.tsx:87` with proper type (P1-4)
 - [ ] Add `eslint-plugin-react` to ESLint config or remove from deps (P2-7)
+
+---
+
+> **Historical note (2026-04-29):** This audit was conducted 2026-04-16 prior to v0.7 implementation. All P0 blockers were resolved in v0.7.0-alpha (released 2026-04-17). Remaining P1/P2 items were addressed through v0.8.0-alpha (released 2026-04-29). See CLAUDE.md for current known issues.
 - [ ] Replace inline ACCanvas filter with `filterByQuery()` from utils (P1-8)

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -59,4 +59,11 @@ export default [
       },
     },
   },
+  // Node config files get Node.js globals
+  {
+    files: ['vite.config.ts', 'vite.config.js'],
+    languageOptions: {
+      globals: globals.node,
+    },
+  },
 ];

--- a/index.html
+++ b/index.html
@@ -4,7 +4,8 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>AC GCN Museum - Fish Collection</title>
+    <meta name="description" content="Track Animal Crossing museum donations across GCN, Wild World, City Folk, New Leaf, and New Horizons. Multi-town support, analytics, and CSV export." />
+    <title>Animal Crossing Museum Tracker</title>
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Varela+Round:wght@400&display=swap" rel="stylesheet">

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "animalcrossingwebapp",
-  "version": "0.8.0-alpha",
+  "version": "0.8.1-alpha",
   "description": "Web companion app for tracking museum donations across all five Animal Crossing main-line games (GCN, WW, CF, NL, NH). Live at https://animalcrossingwebapp.vercel.app/",
   "type": "module",
   "main": "index.js",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "animalcrossingwebapp",
   "version": "0.8.0-alpha",
-  "description": "",
+  "description": "Web companion app for tracking museum donations across all five Animal Crossing main-line games (GCN, WW, CF, NL, NH). Live at https://animalcrossingwebapp.vercel.app/",
   "type": "module",
   "main": "index.js",
   "scripts": {

--- a/public/version-history.html
+++ b/public/version-history.html
@@ -1,0 +1,843 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Animal Crossing Web App — Version History & Roadmap</title>
+  <link href="https://fonts.googleapis.com/css2?family=Varela+Round&display=swap" rel="stylesheet" />
+  <style>
+    *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+
+    :root {
+      --wood:    #7B5E3B;
+      --paper:   #F5E9D4;
+      --ink:     #2A2A2A;
+      --leaf:    #3CA370;
+      --leaf-lt: #d4f0e3;
+      --border:  #E7DAC4;
+      --muted:   #5a4a35;
+      --sky:     #b8ddf5;
+      --sky-dk:  #5b9ec9;
+      --gold:    #c9922e;
+      --gold-lt: #fdf0d5;
+      --future:  #e8dff5;
+      --future-dk:#7a5fa0;
+    }
+
+    body {
+      font-family: 'Varela Round', sans-serif;
+      background: #eef7ee;
+      color: var(--ink);
+      min-height: 100vh;
+      padding: 2rem 1rem 4rem;
+    }
+
+    /* ── Header ── */
+    header {
+      text-align: center;
+      margin-bottom: 3rem;
+    }
+
+    .leaf-deco {
+      font-size: 2.5rem;
+      margin-bottom: .5rem;
+      display: block;
+    }
+
+    header h1 {
+      font-size: 2rem;
+      color: var(--wood);
+      margin-bottom: .25rem;
+    }
+
+    header p {
+      color: var(--muted);
+      font-size: .95rem;
+    }
+
+    /* ── Layout ── */
+    .page {
+      max-width: 860px;
+      margin: 0 auto;
+      display: flex;
+      flex-direction: column;
+      gap: 2.5rem;
+    }
+
+    section > h2 {
+      font-size: 1.1rem;
+      color: var(--muted);
+      text-transform: uppercase;
+      letter-spacing: .08em;
+      margin-bottom: 1.25rem;
+      display: flex;
+      align-items: center;
+      gap: .5rem;
+    }
+
+    section > h2::after {
+      content: '';
+      flex: 1;
+      height: 1px;
+      background: var(--border);
+    }
+
+    /* ── Velocity banner ── */
+    .velocity-banner {
+      background: var(--wood);
+      color: #fff8ee;
+      border-radius: 14px;
+      padding: 1.25rem 1.75rem;
+      display: flex;
+      flex-wrap: wrap;
+      gap: 1.25rem 2rem;
+      align-items: center;
+      justify-content: space-between;
+    }
+
+    .velocity-banner .headline {
+      font-size: 1.25rem;
+      font-weight: bold;
+    }
+
+    .velocity-banner .sub {
+      font-size: .85rem;
+      opacity: .8;
+      margin-top: .2rem;
+    }
+
+    .vel-stats {
+      display: flex;
+      gap: 1.5rem;
+      flex-wrap: wrap;
+    }
+
+    .vel-stat {
+      text-align: center;
+    }
+
+    .vel-stat .num {
+      font-size: 1.6rem;
+      color: #a8e6c5;
+      line-height: 1;
+    }
+
+    .vel-stat .label {
+      font-size: .72rem;
+      opacity: .75;
+      margin-top: .15rem;
+    }
+
+    /* ── Timeline ── */
+    .timeline {
+      display: flex;
+      flex-direction: column;
+      gap: 0;
+    }
+
+    .tl-entry {
+      display: grid;
+      grid-template-columns: 80px 28px 1fr;
+      gap: 0 .75rem;
+      align-items: start;
+    }
+
+    .tl-date {
+      text-align: right;
+      font-size: .8rem;
+      color: var(--muted);
+      padding-top: .65rem;
+      line-height: 1.3;
+    }
+
+    .tl-spine {
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+    }
+
+    .tl-dot {
+      width: 16px;
+      height: 16px;
+      border-radius: 50%;
+      background: var(--leaf);
+      border: 3px solid #eef7ee;
+      box-shadow: 0 0 0 2px var(--leaf);
+      flex-shrink: 0;
+      margin-top: .55rem;
+      z-index: 1;
+    }
+
+    .tl-dot.hotfix {
+      background: var(--gold);
+      box-shadow: 0 0 0 2px var(--gold);
+    }
+
+    .tl-line {
+      width: 2px;
+      flex: 1;
+      background: var(--border);
+      min-height: 18px;
+    }
+
+    .tl-card {
+      background: #fff;
+      border: 1px solid var(--border);
+      border-radius: 12px;
+      padding: 1rem 1.25rem;
+      margin-bottom: 1rem;
+    }
+
+    .tl-card.hotfix {
+      border-color: #e8d0a0;
+      background: var(--gold-lt);
+    }
+
+    .tl-card-head {
+      display: flex;
+      align-items: baseline;
+      gap: .6rem;
+      margin-bottom: .55rem;
+      flex-wrap: wrap;
+    }
+
+    .version-badge {
+      font-size: .95rem;
+      font-weight: bold;
+      color: var(--leaf);
+    }
+
+    .version-badge.hotfix { color: var(--gold); }
+
+    .version-title {
+      font-size: .9rem;
+      color: var(--muted);
+    }
+
+    .velocity-chip {
+      margin-left: auto;
+      font-size: .72rem;
+      background: var(--leaf-lt);
+      color: var(--leaf);
+      border-radius: 20px;
+      padding: .1rem .55rem;
+    }
+
+    .velocity-chip.fast { background: #fff0d0; color: var(--gold); }
+
+    .tl-bullets {
+      list-style: none;
+      display: flex;
+      flex-direction: column;
+      gap: .3rem;
+    }
+
+    .tl-bullets li {
+      font-size: .85rem;
+      color: var(--ink);
+      padding-left: 1.1rem;
+      position: relative;
+    }
+
+    .tl-bullets li::before {
+      content: '🍃';
+      position: absolute;
+      left: 0;
+      font-size: .7rem;
+      top: .1rem;
+    }
+
+    /* ── Currently building ── */
+    .building-card {
+      background: #fff;
+      border: 2px solid var(--leaf);
+      border-radius: 14px;
+      padding: 1.5rem;
+    }
+
+    .building-head {
+      display: flex;
+      align-items: center;
+      gap: .75rem;
+      margin-bottom: 1.1rem;
+    }
+
+    .building-badge {
+      background: var(--leaf);
+      color: #fff;
+      font-size: .8rem;
+      border-radius: 6px;
+      padding: .25rem .65rem;
+    }
+
+    .building-head h3 {
+      font-size: 1.1rem;
+      color: var(--ink);
+    }
+
+    .building-note {
+      font-size: .8rem;
+      color: var(--muted);
+      margin-left: auto;
+    }
+
+    .checklist {
+      display: flex;
+      flex-direction: column;
+      gap: .45rem;
+    }
+
+    .check-item {
+      display: flex;
+      align-items: center;
+      gap: .65rem;
+      font-size: .88rem;
+    }
+
+    .check-item .box {
+      width: 18px;
+      height: 18px;
+      border-radius: 4px;
+      flex-shrink: 0;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      font-size: .8rem;
+    }
+
+    .check-item.done .box {
+      background: var(--leaf);
+      color: #fff;
+    }
+
+    .check-item.todo .box {
+      background: #fff;
+      border: 2px solid var(--border);
+      color: transparent;
+    }
+
+    .check-item.done .text {
+      color: var(--muted);
+    }
+
+    .check-item.todo .text {
+      color: var(--ink);
+      font-weight: 500;
+    }
+
+    .checklist-section {
+      font-size: .75rem;
+      text-transform: uppercase;
+      letter-spacing: .06em;
+      color: var(--muted);
+      margin: .75rem 0 .3rem;
+    }
+
+    /* ── Roadmap lanes ── */
+    .lanes {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+      gap: 1rem;
+    }
+
+    .lane {
+      border-radius: 12px;
+      padding: 1.1rem 1.25rem;
+      border: 1px solid transparent;
+    }
+
+    .lane.v09 {
+      background: var(--sky);
+      border-color: #9fcde8;
+    }
+
+    .lane.v10 {
+      background: #ffe8b0;
+      border-color: #e8c76a;
+    }
+
+    .lane.vpost {
+      background: var(--future);
+      border-color: #c3b0e0;
+    }
+
+    .lane-head {
+      display: flex;
+      align-items: center;
+      gap: .5rem;
+      margin-bottom: .85rem;
+    }
+
+    .lane-badge {
+      font-size: .75rem;
+      font-weight: bold;
+      border-radius: 5px;
+      padding: .2rem .5rem;
+    }
+
+    .lane.v09 .lane-badge { background: var(--sky-dk); color: #fff; }
+    .lane.v10 .lane-badge { background: #c9922e; color: #fff; }
+    .lane.vpost .lane-badge { background: var(--future-dk); color: #fff; }
+
+    .lane-title {
+      font-size: .88rem;
+      font-weight: bold;
+    }
+
+    .lane-items {
+      list-style: none;
+      display: flex;
+      flex-direction: column;
+      gap: .35rem;
+    }
+
+    .lane-items li {
+      font-size: .82rem;
+      padding-left: 1rem;
+      position: relative;
+      color: var(--ink);
+    }
+
+    .lane-items li::before {
+      content: '◦';
+      position: absolute;
+      left: 0;
+      color: var(--muted);
+    }
+
+    /* ── Footer ── */
+    footer {
+      text-align: center;
+      font-size: .78rem;
+      color: var(--muted);
+      margin-top: 1rem;
+    }
+
+    footer a { color: var(--leaf); text-decoration: none; }
+  </style>
+</head>
+<body>
+<div class="page">
+
+  <header>
+    <span class="leaf-deco">🍃</span>
+    <h1>Animal Crossing Web App</h1>
+    <p>Version history &amp; roadmap · Updated April 29, 2026</p>
+  </header>
+
+  <!-- Velocity banner -->
+  <div class="velocity-banner">
+    <div>
+      <div class="headline">🚀 v0.1 → v0.8 in 19 days</div>
+      <div class="sub">Nine releases. Blathers can't keep up.</div>
+    </div>
+    <div class="vel-stats">
+      <div class="vel-stat">
+        <div class="num">9</div>
+        <div class="label">releases shipped</div>
+      </div>
+      <div class="vel-stat">
+        <div class="num">19</div>
+        <div class="label">days elapsed</div>
+      </div>
+      <div class="vel-stat">
+        <div class="num">5</div>
+        <div class="label">games supported</div>
+      </div>
+      <div class="vel-stat">
+        <div class="num">1,000+</div>
+        <div class="label">items catalogued</div>
+      </div>
+    </div>
+  </div>
+
+  <!-- Shipped timeline -->
+  <section>
+    <h2>🏅 Shipped versions</h2>
+    <div class="timeline">
+
+      <!-- v0.8.0-alpha -->
+      <div class="tl-entry">
+        <div class="tl-date">Apr 29<br/>2026</div>
+        <div class="tl-spine">
+          <div class="tl-dot"></div>
+          <div class="tl-line"></div>
+        </div>
+        <div class="tl-card">
+          <div class="tl-card-head">
+            <span class="version-badge">v0.8.0-alpha</span>
+            <span class="version-title">Full game coverage + item details</span>
+            <span class="velocity-chip">12 days after v0.7</span>
+          </div>
+          <ul class="tl-bullets">
+            <li>New Leaf data — 72 fish, 70 bugs, 72 fossils, 36 art, 35 sea creatures</li>
+            <li>New Horizons data — 81 fish, 80 bugs, 86 fossils, 43 art, 40 sea creatures with NH/SH hemisphere months</li>
+            <li>All five games now fully selectable in Create Town modal</li>
+            <li>Hemisphere toggle — per-town NH/SH selector for ACNH towns; month grids respect hemisphere</li>
+            <li>Item detail inline expand — fish, bugs, and fossils expand in-place with month grid, sell value, habitat, and notes; art opens bottom-sheet modal</li>
+            <li>React Router v6 — every town and tab now has a shareable URL; browser back/forward works</li>
+            <li>Detail modal backdrop fix — modal no longer closes immediately after opening</li>
+            <li>Town switcher fixes — no duplicate entries, dropdown escapes clipped header via fixed positioning</li>
+          </ul>
+        </div>
+      </div>
+
+      <!-- v0.7.0-alpha -->
+      <div class="tl-entry">
+        <div class="tl-date">Apr 17<br/>2026</div>
+        <div class="tl-spine">
+          <div class="tl-dot"></div>
+          <div class="tl-line"></div>
+        </div>
+        <div class="tl-card">
+          <div class="tl-card-head">
+            <span class="version-badge">v0.7.0-alpha</span>
+            <span class="version-title">Multi-game foundation</span>
+            <span class="velocity-chip">2 days after v0.6.1</span>
+          </div>
+          <ul class="tl-bullets">
+            <li>Multi-game store schema — 3-level donation tracking (townId → gameId → itemId)</li>
+            <li>Wild World &amp; City Folk data added (40–56 fish, bugs; 52 fossils each)</li>
+            <li>Game selector in Create Town modal with visual card UI</li>
+            <li>ACCanvas decomposed from ~2175 lines → 298-line orchestration shell (14 new modules)</li>
+            <li>Zustand v2 migration with lossless backfill for existing towns</li>
+            <li>Edit/rename town with inline modal</li>
+            <li>ErrorBoundary, type guards, hydration guard, pre-commit hooks</li>
+            <li>Seasonal analytics bug fixed — was counting all donations as Spring</li>
+          </ul>
+        </div>
+      </div>
+
+      <!-- v0.6.1 -->
+      <div class="tl-entry">
+        <div class="tl-date">Apr 15<br/>2026</div>
+        <div class="tl-spine">
+          <div class="tl-dot hotfix"></div>
+          <div class="tl-line"></div>
+        </div>
+        <div class="tl-card hotfix">
+          <div class="tl-card-head">
+            <span class="version-badge hotfix">v0.6.1</span>
+            <span class="version-title">Hotfix</span>
+            <span class="velocity-chip fast">1 day after v0.6.0</span>
+          </div>
+          <ul class="tl-bullets">
+            <li>Restored files deleted during bad v0.6.0 merge into main</li>
+            <li>Fixed corrupted main branch state</li>
+            <li>Home tab routing stability improvements</li>
+          </ul>
+        </div>
+      </div>
+
+      <!-- v0.6.0 -->
+      <div class="tl-entry">
+        <div class="tl-date">Apr 14<br/>2026</div>
+        <div class="tl-spine">
+          <div class="tl-dot"></div>
+          <div class="tl-line"></div>
+        </div>
+        <div class="tl-card">
+          <div class="tl-card-head">
+            <span class="version-badge">v0.6.0</span>
+            <span class="version-title">Home screen</span>
+            <span class="velocity-chip fast">1 day after v0.5</span>
+          </div>
+          <ul class="tl-bullets">
+            <li>New Home tab — seasonal availability overview</li>
+            <li>"Available this month" — fish &amp; bugs catchable right now</li>
+            <li>"Leaving soon" — creatures departing at month's end</li>
+            <li>Progress overview cards for all four museum categories</li>
+            <li>Recent donation activity feed</li>
+          </ul>
+        </div>
+      </div>
+
+      <!-- v0.5.0 -->
+      <div class="tl-entry">
+        <div class="tl-date">Apr 13<br/>2026</div>
+        <div class="tl-spine">
+          <div class="tl-dot"></div>
+          <div class="tl-line"></div>
+        </div>
+        <div class="tl-card">
+          <div class="tl-card-head">
+            <span class="version-badge">v0.5.0</span>
+            <span class="version-title">Polish &amp; observability</span>
+            <span class="velocity-chip fast">same day as v0.4</span>
+          </div>
+          <ul class="tl-bullets">
+            <li>CSV export — download donations as a spreadsheet</li>
+            <li>Error banner &amp; full-page error state UI</li>
+            <li>Vitest unit tests — store &amp; utils</li>
+            <li>Vercel Analytics wired up</li>
+            <li>Monthly availability chart for fish &amp; bugs</li>
+            <li>Enriched JSON with <code>months[]</code> availability arrays</li>
+          </ul>
+        </div>
+      </div>
+
+      <!-- v0.4.0 -->
+      <div class="tl-entry">
+        <div class="tl-date">Apr 13<br/>2026</div>
+        <div class="tl-spine">
+          <div class="tl-dot"></div>
+          <div class="tl-line"></div>
+        </div>
+        <div class="tl-card">
+          <div class="tl-card-head">
+            <span class="version-badge">v0.4.0</span>
+            <span class="version-title">Search &amp; stats</span>
+            <span class="velocity-chip fast">same day as v0.3</span>
+          </div>
+          <ul class="tl-bullets">
+            <li>Global search across all museum categories with history popover</li>
+            <li>Stats tab — analytics dashboard, monthly timeline, seasonal breakdown</li>
+          </ul>
+        </div>
+      </div>
+
+      <!-- v0.3.0 -->
+      <div class="tl-entry">
+        <div class="tl-date">Apr 13<br/>2026</div>
+        <div class="tl-spine">
+          <div class="tl-dot"></div>
+          <div class="tl-line"></div>
+        </div>
+        <div class="tl-card">
+          <div class="tl-card-head">
+            <span class="version-badge">v0.3.0</span>
+            <span class="version-title">Multi-town</span>
+            <span class="velocity-chip fast">1 day after v0.2</span>
+          </div>
+          <ul class="tl-bullets">
+            <li>Create and switch between multiple towns</li>
+            <li>TownSwitcher in header + Create Town modal</li>
+            <li>Donations keyed by townId in Zustand store</li>
+            <li>Activity feed per town; <code>vercel.json</code> added</li>
+            <li>Expo/React Native parallel app removed — Vite only</li>
+          </ul>
+        </div>
+      </div>
+
+      <!-- v0.2.0 -->
+      <div class="tl-entry">
+        <div class="tl-date">Apr 12<br/>2026</div>
+        <div class="tl-spine">
+          <div class="tl-dot"></div>
+          <div class="tl-line"></div>
+        </div>
+        <div class="tl-card">
+          <div class="tl-card-head">
+            <span class="version-badge">v0.2.0</span>
+            <span class="version-title">Detail &amp; search</span>
+            <span class="velocity-chip fast">2 days after v0.1</span>
+          </div>
+          <ul class="tl-bullets">
+            <li>Item detail modal</li>
+            <li>Per-category search &amp; filter</li>
+            <li>Donation timestamps</li>
+            <li>Full four-category museum tracking UI in ACCanvas</li>
+          </ul>
+        </div>
+      </div>
+
+      <!-- v0.1.0 -->
+      <div class="tl-entry">
+        <div class="tl-date">Apr 10<br/>2026</div>
+        <div class="tl-spine">
+          <div class="tl-dot"></div>
+          <div class="tl-line" style="display:none"></div>
+        </div>
+        <div class="tl-card">
+          <div class="tl-card-head">
+            <span class="version-badge">v0.1.0</span>
+            <span class="version-title">Initial release 🎉</span>
+          </div>
+          <ul class="tl-bullets">
+            <li>Basic museum donation tracking (Fish, Bugs, Fossils, Art)</li>
+            <li>Zustand + localStorage persistence</li>
+            <li>Cozy parchment/GameCube aesthetic</li>
+            <li>40 fish · 40 bugs · 25 fossils · 13 art pieces</li>
+            <li>GitHub CI + Vercel deployment</li>
+          </ul>
+        </div>
+      </div>
+
+    </div>
+  </section>
+
+  <!-- Currently building -->
+  <section>
+    <h2>🔨 Currently building — v0.9</h2>
+    <div class="building-card">
+      <div class="building-head">
+        <span class="building-badge">UP NEXT</span>
+        <h3>Polish, onboarding &amp; PWA</h3>
+        <span class="building-note">making it feel at home</span>
+      </div>
+
+      <p class="checklist-section">⬜ Planned</p>
+      <div class="checklist">
+        <div class="check-item todo">
+          <div class="box">·</div>
+          <span class="text">Sea creatures tab — data exists for ACNH, UI not built yet</span>
+        </div>
+        <div class="check-item todo">
+          <div class="box">·</div>
+          <span class="text">UI redesign pass — cozy-er, more expressive</span>
+        </div>
+        <div class="check-item todo">
+          <div class="box">·</div>
+          <span class="text">PWA support — install to home screen</span>
+        </div>
+        <div class="check-item todo">
+          <div class="box">·</div>
+          <span class="text">Mobile-first responsive layout pass</span>
+        </div>
+        <div class="check-item todo">
+          <div class="box">·</div>
+          <span class="text">First-run onboarding / empty state improvements</span>
+        </div>
+        <div class="check-item todo">
+          <div class="box">·</div>
+          <span class="text">Seasonal / time-based filtering in list views</span>
+        </div>
+        <div class="check-item todo">
+          <div class="box">·</div>
+          <span class="text">Improved accessibility — keyboard nav, focus rings</span>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- Roadmap lanes -->
+  <section>
+    <h2>🗺️ Roadmap</h2>
+    <div class="lanes">
+
+      <div class="lane v09">
+        <div class="lane-head">
+          <span class="lane-badge">v0.9</span>
+          <span class="lane-title">Polish &amp; PWA</span>
+        </div>
+        <ul class="lane-items">
+          <li>Sea creatures tab for ACNH towns</li>
+          <li>UI redesign pass — cozy-er, more expressive</li>
+          <li>PWA support — install to home screen</li>
+          <li>Mobile-first responsive layout</li>
+          <li>First-run onboarding / empty states</li>
+          <li>Improved accessibility (keyboard nav, focus rings)</li>
+        </ul>
+      </div>
+
+      <div class="lane v10">
+        <div class="lane-head">
+          <span class="lane-badge">v1.0</span>
+          <span class="lane-title">Launch ready 🌟</span>
+        </div>
+        <ul class="lane-items">
+          <li>Branding &amp; identity polish</li>
+          <li>SEO metadata + Open Graph</li>
+          <li>Full accessibility audit (WCAG)</li>
+          <li>Performance pass — Lighthouse green</li>
+          <li>Stable release — remove alpha label</li>
+        </ul>
+      </div>
+
+      <div class="lane vpost">
+        <div class="lane-head">
+          <span class="lane-badge">Post-1.0</span>
+          <span class="lane-title">What's next ✨</span>
+        </div>
+        <ul class="lane-items">
+          <li>Cloud sync / account support</li>
+          <li>Share town progress with friends</li>
+          <li>New Horizons critterpedia features</li>
+          <li>Price guide &amp; art authenticity tracker</li>
+          <li>Seasonal event calendar</li>
+        </ul>
+      </div>
+
+    </div>
+  </section>
+
+  <!-- Velocity detail -->
+  <section>
+    <h2>⚡ Velocity detail</h2>
+    <div style="background:#fff; border:1px solid var(--border); border-radius:12px; overflow:hidden;">
+      <table style="width:100%; border-collapse:collapse; font-size:.85rem;">
+        <thead>
+          <tr style="background:var(--paper);">
+            <th style="padding:.65rem 1rem; text-align:left; color:var(--muted); font-weight:normal;">Release</th>
+            <th style="padding:.65rem 1rem; text-align:left; color:var(--muted); font-weight:normal;">Date</th>
+            <th style="padding:.65rem 1rem; text-align:left; color:var(--muted); font-weight:normal;">Days since last</th>
+            <th style="padding:.65rem 1rem; text-align:left; color:var(--muted); font-weight:normal;">Highlight</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr style="border-top:1px solid var(--border);">
+            <td style="padding:.6rem 1rem; color:var(--leaf); font-weight:bold;">v0.1.0</td>
+            <td style="padding:.6rem 1rem;">Apr 10</td>
+            <td style="padding:.6rem 1rem;">—</td>
+            <td style="padding:.6rem 1rem;">First commit → live app</td>
+          </tr>
+          <tr style="border-top:1px solid var(--border); background:#fafafa;">
+            <td style="padding:.6rem 1rem; color:var(--leaf); font-weight:bold;">v0.2.0</td>
+            <td style="padding:.6rem 1rem;">Apr 12</td>
+            <td style="padding:.6rem 1rem;">2 days</td>
+            <td style="padding:.6rem 1rem;">Detail modal + donation timestamps</td>
+          </tr>
+          <tr style="border-top:1px solid var(--border);">
+            <td style="padding:.6rem 1rem; color:var(--leaf); font-weight:bold;">v0.3.0</td>
+            <td style="padding:.6rem 1rem;">Apr 13</td>
+            <td style="padding:.6rem 1rem;">1 day</td>
+            <td style="padding:.6rem 1rem;">Multi-town support</td>
+          </tr>
+          <tr style="border-top:1px solid var(--border); background:#fafafa;">
+            <td style="padding:.6rem 1rem; color:var(--leaf); font-weight:bold;">v0.4.0</td>
+            <td style="padding:.6rem 1rem;">Apr 13</td>
+            <td style="padding:.6rem 1rem;">&lt;1 day</td>
+            <td style="padding:.6rem 1rem;">Global search + stats tab</td>
+          </tr>
+          <tr style="border-top:1px solid var(--border);">
+            <td style="padding:.6rem 1rem; color:var(--leaf); font-weight:bold;">v0.5.0</td>
+            <td style="padding:.6rem 1rem;">Apr 13</td>
+            <td style="padding:.6rem 1rem;">&lt;1 day</td>
+            <td style="padding:.6rem 1rem;">CSV export + tests + Vercel Analytics</td>
+          </tr>
+          <tr style="border-top:1px solid var(--border); background:#fafafa;">
+            <td style="padding:.6rem 1rem; color:var(--leaf); font-weight:bold;">v0.6.0</td>
+            <td style="padding:.6rem 1rem;">Apr 14</td>
+            <td style="padding:.6rem 1rem;">1 day</td>
+            <td style="padding:.6rem 1rem;">Home screen tab</td>
+          </tr>
+          <tr style="border-top:1px solid var(--border);">
+            <td style="padding:.6rem 1rem; color:var(--gold); font-weight:bold;">v0.6.1 🔧</td>
+            <td style="padding:.6rem 1rem;">Apr 15</td>
+            <td style="padding:.6rem 1rem;">1 day</td>
+            <td style="padding:.6rem 1rem;">Hotfix — main branch restored</td>
+          </tr>
+          <tr style="border-top:1px solid var(--border); background:#fafafa;">
+            <td style="padding:.6rem 1rem; color:var(--leaf); font-weight:bold;">v0.7.0-alpha</td>
+            <td style="padding:.6rem 1rem;">Apr 17</td>
+            <td style="padding:.6rem 1rem;">2 days</td>
+            <td style="padding:.6rem 1rem;">Multi-game foundation — largest refactor yet</td>
+          </tr>
+          <tr style="border-top:1px solid var(--border);">
+            <td style="padding:.6rem 1rem; color:var(--leaf); font-weight:bold;">v0.8.0-alpha</td>
+            <td style="padding:.6rem 1rem;">Apr 29</td>
+            <td style="padding:.6rem 1rem;">12 days</td>
+            <td style="padding:.6rem 1rem;">Full game coverage — ACNL + ACNH, 1,000+ items, inline details, React Router</td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+  </section>
+
+  <footer>
+    <p>🍃 <a href="https://animalcrossingwebapp.vercel.app">animalcrossingwebapp.vercel.app</a> · v0.9 in progress · Dev preview at <a href="https://development-animalcrossingwebapp.vercel.app">development-animalcrossingwebapp.vercel.app</a></p>
+  </footer>
+
+</div>
+</body>
+</html>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -66,7 +66,9 @@ function App() {
               pointerEvents: 'none',
             }}
           >
-            {import.meta.env.VITE_APP_VERSION}+{import.meta.env.VITE_GIT_SHA}
+            v{import.meta.env.VITE_APP_VERSION}
+            {'·'}
+            {import.meta.env.VITE_GIT_BRANCH}
           </div>
         )}
     </ErrorBoundary>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -53,24 +53,29 @@ function App() {
         <Route path="*" element={<Navigate to="/" replace />} />
       </Routes>
       <Analytics />
-      {typeof window !== 'undefined' &&
-        window.location.hostname !== 'animalcrossingwebapp.vercel.app' && (
-          <div
-            style={{
-              position: 'fixed',
-              bottom: 8,
-              right: 10,
-              fontSize: 10,
-              color: '#5a4a35',
-              opacity: 0.5,
-              pointerEvents: 'none',
-            }}
-          >
-            v{import.meta.env.VITE_APP_VERSION}
-            {'·'}
-            {import.meta.env.VITE_GIT_BRANCH}
-          </div>
-        )}
+      {typeof window !== 'undefined' && (
+        <div
+          style={{
+            position: 'fixed',
+            bottom: 8,
+            right: 10,
+            fontSize: 10,
+            color: '#5a4a35',
+            opacity: 0.5,
+            pointerEvents: 'none',
+          }}
+        >
+          {window.location.hostname === 'animalcrossingwebapp.vercel.app' ? (
+            <>v{import.meta.env.VITE_APP_VERSION}</>
+          ) : (
+            <>
+              v{import.meta.env.VITE_APP_VERSION}
+              {' · '}
+              {import.meta.env.VITE_GIT_BRANCH}
+            </>
+          )}
+        </div>
+      )}
     </ErrorBoundary>
   );
 }

--- a/src/components/ACCanvas.tsx
+++ b/src/components/ACCanvas.tsx
@@ -40,6 +40,7 @@ const VALID_TABS: ViewId[] = [
   'bugs',
   'fossils',
   'art',
+  'sea_creatures',
   'activity',
   'search',
   'analytics',
@@ -123,6 +124,18 @@ export default function ACCanvas() {
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [data.art.length, loading, activeTab]);
+
+  // If the user was on the sea_creatures tab and switches to a game without sea creatures, go home.
+  useEffect(() => {
+    if (
+      activeTab === 'sea_creatures' &&
+      data.sea_creatures.length === 0 &&
+      !loading
+    ) {
+      handleTabChange('home');
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [data.sea_creatures.length, loading, activeTab]);
 
   // Reset per-tab search query when tab changes
   useEffect(() => {

--- a/src/components/ACCanvas.tsx
+++ b/src/components/ACCanvas.tsx
@@ -378,8 +378,7 @@ export default function ACCanvas() {
               letterSpacing: '0.05em',
             }}
           >
-            {import.meta.env.VITE_APP_VERSION} ·
-            fix/restore-item-detail-dropdown
+            {import.meta.env.VITE_APP_VERSION}
           </span>
         </div>
       </div>

--- a/src/components/ACCanvas.tsx
+++ b/src/components/ACCanvas.tsx
@@ -17,6 +17,7 @@ import ErrorState from './ErrorState';
 import { MuseumHeader } from './MuseumHeader';
 import { TabBar } from './TabBar';
 import { CollectibleRow } from './CollectibleRow';
+import { ItemExpandPanel } from './ItemExpandPanel';
 import { CategoryProgress } from './shared/CategoryProgress';
 import { SearchBar } from './shared/SearchBar';
 import { EmptyState } from './shared/EmptyState';
@@ -99,6 +100,7 @@ export default function ACCanvas() {
     category: CategoryId;
   } | null>(null);
   const [showCreateTown, setShowCreateTown] = useState(false);
+  const [expandedId, setExpandedId] = useState<string | null>(null);
 
   const { data, loading, loadError, reload } = useMuseumData(
     activeTown?.gameId ?? 'ACGCN'
@@ -124,9 +126,10 @@ export default function ACCanvas() {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [data.art.length, loading, activeTab]);
 
-  // Reset per-tab search query when tab changes
+  // Reset per-tab search query and expanded item when tab changes
   useEffect(() => {
     setQuery('');
+    setExpandedId(null);
   }, [activeTab]);
 
   const totalItems = CATEGORY_ORDER.reduce(
@@ -319,17 +322,38 @@ export default function ACCanvas() {
                 />
                 <div className="space-y-3">
                   {filtered.map(item => (
-                    <CollectibleRow
-                      key={item.id}
-                      item={item}
-                      category={activeCat!}
-                      checked={!!activeTownDonated[item.id]}
-                      onToggle={() => toggle(item.id)}
-                      onClick={() =>
-                        setSelected({ item, category: activeCat! })
-                      }
-                      hemisphere={activeTown?.hemisphere ?? 'NH'}
-                    />
+                    <div key={item.id}>
+                      <CollectibleRow
+                        item={item}
+                        category={activeCat!}
+                        checked={!!activeTownDonated[item.id]}
+                        onToggle={() => toggle(item.id)}
+                        onClick={() => {
+                          if (activeCat === 'art') {
+                            setSelected({ item, category: activeCat! });
+                          } else {
+                            setExpandedId(prev =>
+                              prev === item.id ? null : item.id
+                            );
+                          }
+                        }}
+                        expanded={
+                          activeCat !== 'art'
+                            ? expandedId === item.id
+                            : undefined
+                        }
+                        hemisphere={activeTown?.hemisphere ?? 'NH'}
+                      />
+                      {activeCat !== 'art' && expandedId === item.id && (
+                        <ItemExpandPanel
+                          item={item}
+                          category={activeCat!}
+                          checked={!!activeTownDonated[item.id]}
+                          donatedAt={activeTownDonatedAt[item.id]}
+                          onToggle={() => toggle(item.id)}
+                        />
+                      )}
+                    </div>
                   ))}
                   {filtered.length === 0 && (
                     <EmptyState
@@ -354,7 +378,8 @@ export default function ACCanvas() {
               letterSpacing: '0.05em',
             }}
           >
-            {import.meta.env.VITE_APP_VERSION}
+            {import.meta.env.VITE_APP_VERSION} ·
+            fix/restore-item-detail-dropdown
           </span>
         </div>
       </div>

--- a/src/components/ACCanvas.tsx
+++ b/src/components/ACCanvas.tsx
@@ -23,6 +23,7 @@ import { SearchBar } from './shared/SearchBar';
 import { EmptyState } from './shared/EmptyState';
 
 import { CreateTownModal } from './modals/CreateTownModal';
+import { EditTownModal } from './modals/EditTownModal';
 import { DetailModal } from './modals/DetailModal';
 
 import { GlobalSearchBar } from './search/GlobalSearchBar';
@@ -100,6 +101,7 @@ export default function ACCanvas() {
     category: CategoryId;
   } | null>(null);
   const [showCreateTown, setShowCreateTown] = useState(false);
+  const [showEditTown, setShowEditTown] = useState(false);
   const [expandedId, setExpandedId] = useState<string | null>(null);
 
   const { data, loading, loadError, reload } = useMuseumData(
@@ -227,6 +229,7 @@ export default function ACCanvas() {
           donatedCount={totalDonated}
           totalCount={totalItems}
           onCreateTown={() => setShowCreateTown(true)}
+          onEditTown={() => setShowEditTown(true)}
           onExport={handleExport}
           gameId={activeTown?.gameId}
           hemisphere={activeTown?.hemisphere ?? 'NH'}
@@ -387,6 +390,12 @@ export default function ACCanvas() {
         isOpen={noTowns || showCreateTown}
         required={noTowns}
         onClose={() => setShowCreateTown(false)}
+      />
+
+      <EditTownModal
+        isOpen={showEditTown}
+        town={activeTown ?? null}
+        onClose={() => setShowEditTown(false)}
       />
 
       {selected && !noTowns && (

--- a/src/components/CollectibleRow.tsx
+++ b/src/components/CollectibleRow.tsx
@@ -39,6 +39,7 @@ export function CollectibleRow({
 
   return (
     <button
+      type="button"
       onClick={onClick}
       className="w-full text-left flex items-center gap-3 border px-4 py-3 transition"
       style={{

--- a/src/components/HomeTab.tsx
+++ b/src/components/HomeTab.tsx
@@ -4,6 +4,7 @@ import {
   Bug,
   Bone,
   Palette,
+  Waves,
   BarChart2,
   Clock,
   AlertTriangle,
@@ -14,6 +15,7 @@ import type {
   BugItem,
   FossilItem,
   ArtPiece,
+  SeaCreature,
   CategoryId,
 } from '../lib/types';
 import { displayName, formatRelativeDate, type AnyItem } from '../lib/utils';
@@ -38,6 +40,7 @@ const CAT_ICON: Record<CategoryId, ElementType> = {
   bugs: Bug,
   fossils: Bone,
   art: Palette,
+  sea_creatures: Waves,
 };
 
 const CAT_LABEL: Record<CategoryId, string> = {
@@ -45,6 +48,7 @@ const CAT_LABEL: Record<CategoryId, string> = {
   bugs: 'Bugs',
   fossils: 'Fossils',
   art: 'Art',
+  sea_creatures: 'Sea Creatures',
 };
 
 export interface HomeTabProps {
@@ -53,6 +57,7 @@ export interface HomeTabProps {
     bugs: BugItem[];
     fossils: FossilItem[];
     art: ArtPiece[];
+    sea_creatures: SeaCreature[];
   };
   donated: Record<string, boolean>;
   donatedAt: Record<string, string>;
@@ -108,7 +113,9 @@ export default function HomeTab({
 
   const recent = useMemo(() => {
     const nameMap: Record<string, { name: string; category: CategoryId }> = {};
-    (['fish', 'bugs', 'fossils', 'art'] as CategoryId[]).forEach(cat => {
+    (
+      ['fish', 'bugs', 'fossils', 'art', 'sea_creatures'] as CategoryId[]
+    ).forEach(cat => {
       for (const item of data[cat]) {
         nameMap[item.id] = {
           name: displayName(item as AnyItem, cat),
@@ -128,6 +135,7 @@ export default function HomeTab({
     bugs: data.bugs.length,
     fossils: data.fossils.length,
     art: data.art.length,
+    sea_creatures: data.sea_creatures.length,
   };
 
   return (
@@ -220,42 +228,44 @@ export default function HomeTab({
 
       {/* Per-category progress grid */}
       <div className="grid grid-cols-2 gap-3">
-        {(['fish', 'bugs', 'fossils', 'art'] as CategoryId[]).map(cat => {
-          const Icon = CAT_ICON[cat];
-          const done = catCounts[cat];
-          const total = totals[cat];
-          const pct = total ? Math.round((done / total) * 100) : 0;
-          return (
-            <button
-              key={cat}
-              onClick={() => onNavigate(cat)}
-              className="text-left rounded-[14px] border px-4 py-3 transition-colors hover:bg-[#FDF9F1]"
-              style={{ borderColor: '#E7DAC4', backgroundColor: '#FFFDF6' }}
-            >
-              <div className="flex items-center gap-2 mb-1.5">
-                <Icon className="w-4 h-4" style={{ color: '#7B5E3B' }} />
-                <div
-                  className="text-sm font-semibold"
-                  style={{ color: '#2A2A2A' }}
-                >
-                  {CAT_LABEL[cat]}
-                </div>
-              </div>
-              <div className="text-xs mb-1.5" style={{ color: '#5a4a35' }}>
-                {done} / {total} donated
-              </div>
-              <div
-                className="h-1.5 w-full rounded-full overflow-hidden"
-                style={{ backgroundColor: '#e9dcc3' }}
+        {(['fish', 'bugs', 'fossils', 'art', 'sea_creatures'] as CategoryId[])
+          .filter(cat => totals[cat] > 0)
+          .map(cat => {
+            const Icon = CAT_ICON[cat];
+            const done = catCounts[cat];
+            const total = totals[cat];
+            const pct = total ? Math.round((done / total) * 100) : 0;
+            return (
+              <button
+                key={cat}
+                onClick={() => onNavigate(cat)}
+                className="text-left rounded-[14px] border px-4 py-3 transition-colors hover:bg-[#FDF9F1]"
+                style={{ borderColor: '#E7DAC4', backgroundColor: '#FFFDF6' }}
               >
+                <div className="flex items-center gap-2 mb-1.5">
+                  <Icon className="w-4 h-4" style={{ color: '#7B5E3B' }} />
+                  <div
+                    className="text-sm font-semibold"
+                    style={{ color: '#2A2A2A' }}
+                  >
+                    {CAT_LABEL[cat]}
+                  </div>
+                </div>
+                <div className="text-xs mb-1.5" style={{ color: '#5a4a35' }}>
+                  {done} / {total} donated
+                </div>
                 <div
-                  className="h-full transition-all duration-500"
-                  style={{ width: `${pct}%`, backgroundColor: '#3CA370' }}
-                />
-              </div>
-            </button>
-          );
-        })}
+                  className="h-1.5 w-full rounded-full overflow-hidden"
+                  style={{ backgroundColor: '#e9dcc3' }}
+                >
+                  <div
+                    className="h-full transition-all duration-500"
+                    style={{ width: `${pct}%`, backgroundColor: '#3CA370' }}
+                  />
+                </div>
+              </button>
+            );
+          })}
       </div>
 
       {/* Recent activity */}

--- a/src/components/MuseumHeader.tsx
+++ b/src/components/MuseumHeader.tsx
@@ -9,6 +9,7 @@ export function MuseumHeader({
   donatedCount,
   totalCount,
   onCreateTown,
+  onEditTown,
   onExport,
   gameId,
   hemisphere,
@@ -17,6 +18,7 @@ export function MuseumHeader({
   donatedCount: number;
   totalCount: number;
   onCreateTown: () => void;
+  onEditTown: () => void;
   onExport: () => void;
   gameId?: GameId;
   hemisphere?: Hemisphere;
@@ -94,7 +96,7 @@ export function MuseumHeader({
               <Download className="w-3.5 h-3.5" />
               <span>Export CSV</span>
             </button>
-            <TownSwitcher onCreateNew={onCreateTown} />
+            <TownSwitcher onCreateNew={onCreateTown} onEditTown={onEditTown} />
           </div>
         </div>
       </div>

--- a/src/components/MuseumHeader.tsx
+++ b/src/components/MuseumHeader.tsx
@@ -47,16 +47,24 @@ export function MuseumHeader({
           </h1>
           <div className="flex items-center gap-2">
             {gameId && GAMES[gameId].hasHemispheres && onHemisphereChange && (
-              <div className="flex rounded-[8px] overflow-hidden" style={{ border: '1px solid rgba(245,233,212,0.3)' }}>
+              <div
+                className="flex rounded-[8px] overflow-hidden"
+                style={{ border: '1px solid rgba(245,233,212,0.3)' }}
+              >
                 {(['NH', 'SH'] as const).map(h => (
                   <button
                     key={h}
                     onClick={() => onHemisphereChange(h)}
                     aria-pressed={hemisphere === h}
-                    title={h === 'NH' ? 'Northern Hemisphere' : 'Southern Hemisphere'}
+                    title={
+                      h === 'NH' ? 'Northern Hemisphere' : 'Southern Hemisphere'
+                    }
                     className="px-2.5 py-1.5 text-[12px] font-medium transition-colors"
                     style={{
-                      backgroundColor: hemisphere === h ? 'rgba(245,233,212,0.3)' : 'transparent',
+                      backgroundColor:
+                        hemisphere === h
+                          ? 'rgba(245,233,212,0.3)'
+                          : 'transparent',
                       color: '#F5E9D4',
                     }}
                   >

--- a/src/components/TabBar.tsx
+++ b/src/components/TabBar.tsx
@@ -40,32 +40,36 @@ export function TabBar({
             ·
           </span>
         </button>
-        {CATEGORY_ORDER.filter(cat => cat !== 'art' || data.art.length > 0).map(
-          cat => {
-            const { label, Icon } = CATEGORY_META[cat];
-            const isActive = cat === active;
-            const total = data[cat].length;
-            const donated = catCounts[cat];
-            return (
-              <button
-                key={cat}
-                onClick={() => onChange(cat)}
-                className="flex-1 min-w-[52px] flex flex-col items-center gap-0.5 py-2.5 text-[11px] font-medium transition-colors"
-                style={{
-                  backgroundColor: isActive ? '#7B5E3B' : 'transparent',
-                  color: isActive ? '#F5E9D4' : '#7B5E3B',
-                  borderRight: '1px solid #E7DAC4',
-                }}
-              >
-                <Icon className="w-4 h-4" />
-                <span>{label}</span>
-                <span className="opacity-70" style={{ fontSize: '10px' }}>
-                  {donated}/{total}
-                </span>
-              </button>
-            );
-          }
-        )}
+        {CATEGORY_ORDER.filter(
+          cat =>
+            (cat !== 'art' || data.art.length > 0) &&
+            (cat !== 'sea_creatures' || data.sea_creatures.length > 0)
+        ).map(cat => {
+          const meta = CATEGORY_META[cat];
+          const tabLabel = cat === 'sea_creatures' ? 'Sea' : meta.label;
+          const { Icon } = meta;
+          const isActive = cat === active;
+          const total = data[cat].length;
+          const donated = catCounts[cat];
+          return (
+            <button
+              key={cat}
+              onClick={() => onChange(cat)}
+              className="flex-1 min-w-[52px] flex flex-col items-center gap-0.5 py-2.5 text-[11px] font-medium transition-colors"
+              style={{
+                backgroundColor: isActive ? '#7B5E3B' : 'transparent',
+                color: isActive ? '#F5E9D4' : '#7B5E3B',
+                borderRight: '1px solid #E7DAC4',
+              }}
+            >
+              <Icon className="w-4 h-4" />
+              <span>{tabLabel}</span>
+              <span className="opacity-70" style={{ fontSize: '10px' }}>
+                {donated}/{total}
+              </span>
+            </button>
+          );
+        })}
         <button
           onClick={() => onChange('activity')}
           className="flex-1 min-w-[52px] flex flex-col items-center gap-0.5 py-2.5 text-[11px] font-medium transition-colors"

--- a/src/components/TownSwitcher.tsx
+++ b/src/components/TownSwitcher.tsx
@@ -2,14 +2,18 @@ import React, { useState, useEffect, useRef } from 'react';
 import { ChevronDown, Plus, Pencil } from 'lucide-react';
 import { useNavigate } from 'react-router-dom';
 import { useAppStore } from '../lib/store';
-import { EditTownModal } from './modals/EditTownModal';
 
-export function TownSwitcher({ onCreateNew }: { onCreateNew: () => void }) {
+export function TownSwitcher({
+  onCreateNew,
+  onEditTown,
+}: {
+  onCreateNew: () => void;
+  onEditTown: () => void;
+}) {
   const towns = useAppStore(s => s.towns);
   const activeTownId = useAppStore(s => s.activeTownId);
   const navigate = useNavigate();
   const [open, setOpen] = useState(false);
-  const [editing, setEditing] = useState(false);
   const [dropdownPos, setDropdownPos] = useState({ top: 0, left: 0 });
   const triggerRef = useRef<HTMLButtonElement>(null);
 
@@ -72,7 +76,7 @@ export function TownSwitcher({ onCreateNew }: { onCreateNew: () => void }) {
           )}
 
           <button
-            onClick={() => setEditing(true)}
+            onClick={onEditTown}
             className="flex items-center justify-center rounded-[10px] p-1.5 transition"
             style={{ backgroundColor: '#EDE3D0', border: '1px solid #E7DAC4' }}
             aria-label="Edit town"
@@ -133,9 +137,6 @@ export function TownSwitcher({ onCreateNew }: { onCreateNew: () => void }) {
           </>
         )}
       </div>
-      {editing && (
-        <EditTownModal town={activeTown} onClose={() => setEditing(false)} />
-      )}
     </>
   );
 }

--- a/src/components/TownSwitcher.tsx
+++ b/src/components/TownSwitcher.tsx
@@ -1,7 +1,14 @@
 import React, { useState, useEffect, useRef } from 'react';
 import { ChevronDown, Plus, Pencil } from 'lucide-react';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate, useParams } from 'react-router-dom';
 import { useAppStore } from '../lib/store';
+
+// Museum category tabs where the edit/new-town modals can't render (ACCanvas
+// is not yet in the layout tree on these routes). Greyed out as a v0.8.1
+// stopgap; proper fix deferred to the v0.9 UI revamp.
+const MODAL_BLOCKED_TABS = new Set(['fish', 'bugs', 'fossils']);
+const BLOCKED_TOOLTIP =
+  'Switch to Home, Search, or Recent Donations to edit your town';
 
 export function TownSwitcher({
   onCreateNew,
@@ -13,6 +20,8 @@ export function TownSwitcher({
   const towns = useAppStore(s => s.towns);
   const activeTownId = useAppStore(s => s.activeTownId);
   const navigate = useNavigate();
+  const { tab } = useParams<{ tab?: string }>();
+  const modalBlocked = MODAL_BLOCKED_TABS.has(tab ?? '');
   const [open, setOpen] = useState(false);
   const [dropdownPos, setDropdownPos] = useState({ top: 0, left: 0 });
   const triggerRef = useRef<HTMLButtonElement>(null);
@@ -76,19 +85,35 @@ export function TownSwitcher({
           )}
 
           <button
-            onClick={onEditTown}
-            className="flex items-center justify-center rounded-[10px] p-1.5 transition"
-            style={{ backgroundColor: '#EDE3D0', border: '1px solid #E7DAC4' }}
+            onClick={modalBlocked ? undefined : onEditTown}
+            disabled={modalBlocked}
+            aria-disabled={modalBlocked}
+            title={modalBlocked ? BLOCKED_TOOLTIP : 'Edit town'}
             aria-label="Edit town"
+            className="flex items-center justify-center rounded-[10px] p-1.5 transition"
+            style={{
+              backgroundColor: '#EDE3D0',
+              border: '1px solid #E7DAC4',
+              opacity: modalBlocked ? 0.4 : 1,
+              cursor: modalBlocked ? 'not-allowed' : 'pointer',
+            }}
           >
             <Pencil className="w-3.5 h-3.5" style={{ color: '#5a4a35' }} />
           </button>
 
           <button
-            onClick={onCreateNew}
-            className="flex items-center justify-center rounded-[10px] p-1.5 transition"
-            style={{ backgroundColor: '#EDE3D0', border: '1px solid #E7DAC4' }}
+            onClick={modalBlocked ? undefined : onCreateNew}
+            disabled={modalBlocked}
+            aria-disabled={modalBlocked}
+            title={modalBlocked ? BLOCKED_TOOLTIP : 'Add town'}
             aria-label="Add town"
+            className="flex items-center justify-center rounded-[10px] p-1.5 transition"
+            style={{
+              backgroundColor: '#EDE3D0',
+              border: '1px solid #E7DAC4',
+              opacity: modalBlocked ? 0.4 : 1,
+              cursor: modalBlocked ? 'not-allowed' : 'pointer',
+            }}
           >
             <Plus className="w-3.5 h-3.5" style={{ color: '#5a4a35' }} />
           </button>

--- a/src/components/modals/CreateTownModal.tsx
+++ b/src/components/modals/CreateTownModal.tsx
@@ -3,6 +3,7 @@ import { X } from 'lucide-react';
 import { useNavigate } from 'react-router-dom';
 import { useAppStore } from '../../lib/store';
 import { type GameId, GAMES } from '../../lib/types';
+import { TownNameFields } from '../shared/TownNameFields';
 
 export function CreateTownModal({
   isOpen,
@@ -60,47 +61,14 @@ export function CreateTownModal({
         </div>
 
         <form onSubmit={handleSubmit} className="px-6 py-5 space-y-4">
-          <div>
-            <label
-              className="block text-xs font-medium mb-1.5"
-              style={{ color: '#5a4a35' }}
-            >
-              Town Name
-            </label>
-            <input
-              autoFocus
-              type="text"
-              value={name}
-              onChange={e => setName(e.target.value)}
-              placeholder="e.g. Plumeria"
-              className="w-full rounded-[10px] border px-3 py-2 text-sm outline-none"
-              style={{
-                borderColor: '#E7DAC4',
-                backgroundColor: '#FFFDF6',
-                color: '#2A2A2A',
-              }}
-            />
-          </div>
-          <div>
-            <label
-              className="block text-xs font-medium mb-1.5"
-              style={{ color: '#5a4a35' }}
-            >
-              Your Name
-            </label>
-            <input
-              type="text"
-              value={playerName}
-              onChange={e => setPlayerName(e.target.value)}
-              placeholder="e.g. Brock"
-              className="w-full rounded-[10px] border px-3 py-2 text-sm outline-none"
-              style={{
-                borderColor: '#E7DAC4',
-                backgroundColor: '#FFFDF6',
-                color: '#2A2A2A',
-              }}
-            />
-          </div>
+          <TownNameFields
+            name={name}
+            playerName={playerName}
+            onNameChange={setName}
+            onPlayerNameChange={setPlayerName}
+            namePlaceholder="e.g. Plumeria"
+            playerPlaceholder="e.g. Brock"
+          />
           <div>
             <label
               className="block text-xs font-medium mb-1.5"

--- a/src/components/modals/DetailModal.tsx
+++ b/src/components/modals/DetailModal.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useRef, useEffect } from 'react';
 import { CheckCircle2, X } from 'lucide-react';
 import { CATEGORY_META } from '../../lib/categoryMeta';
 import { MonthGrid } from '../shared/MonthGrid';
@@ -37,11 +37,24 @@ export function DetailModal({
   const months = itemMonths(item, category, hemisphere);
   const notes = itemNotes(item);
 
+  // Guard against ghost-clicks: the same click that opens the modal can land on
+  // the newly-mounted backdrop before the browser event loop settles. Defer
+  // closeability by one tick so backdrop clicks only register on subsequent taps.
+  const closeable = useRef(false);
+  useEffect(() => {
+    const id = setTimeout(() => {
+      closeable.current = true;
+    }, 0);
+    return () => clearTimeout(id);
+  }, []);
+
   return (
     <div
       className="fixed inset-0 z-50 flex items-end justify-center"
       style={{ backgroundColor: 'rgba(42,32,20,0.55)' }}
-      onClick={onClose}
+      onClick={() => {
+        if (closeable.current) onClose();
+      }}
     >
       <div
         className="w-full max-w-3xl rounded-t-[20px] overflow-hidden"

--- a/src/components/modals/EditTownModal.tsx
+++ b/src/components/modals/EditTownModal.tsx
@@ -1,34 +1,49 @@
-import React, { useState } from 'react';
-import { createPortal } from 'react-dom';
+import React, { useState, useEffect } from 'react';
 import { X } from 'lucide-react';
 import { useAppStore } from '../../lib/store';
+import { TownNameFields } from '../shared/TownNameFields';
 
-export function EditTownModal({
-  town,
-  onClose,
-}: {
-  town: { id: string; name: string; playerName: string };
+interface Props {
+  isOpen: boolean;
+  town: { id: string; name: string; playerName: string } | null;
   onClose: () => void;
-}) {
+}
+
+export function EditTownModal({ isOpen, town, onClose }: Props) {
   const updateTown = useAppStore(s => s.updateTown);
-  const [name, setName] = useState(town.name);
-  const [playerName, setPlayerName] = useState(town.playerName);
+  const [name, setName] = useState('');
+  const [playerName, setPlayerName] = useState('');
+
+  // Sync form state when a different town is opened for editing.
+  // Depend on the stable primitive id so the effect only fires when the town
+  // actually changes, not on every parent re-render.
+  const townId = town?.id;
+  const townName = town?.name;
+  const townPlayerName = town?.playerName;
+  useEffect(() => {
+    if (townId) {
+      setName(townName ?? '');
+      setPlayerName(townPlayerName ?? '');
+    }
+  }, [townId, townName, townPlayerName]);
+
+  if (!isOpen || !town) return null;
 
   function handleSubmit(e: React.FormEvent) {
     e.preventDefault();
-    if (!name.trim() || !playerName.trim()) return;
+    if (!name.trim() || !playerName.trim() || !town) return;
     updateTown(town.id, name.trim(), playerName.trim());
     onClose();
   }
 
-  return createPortal(
+  return (
     <div
-      className="fixed inset-0 z-50 flex items-center justify-center"
+      className="fixed inset-0 z-50 flex items-center justify-center p-4"
       style={{ backgroundColor: 'rgba(42,32,20,0.55)' }}
       onClick={onClose}
     >
       <div
-        className="w-full max-w-sm mx-4 rounded-[20px] overflow-hidden"
+        className="w-full max-w-sm rounded-[20px] overflow-hidden"
         style={{ backgroundColor: '#FDF9F1', border: '1px solid #E7DAC4' }}
         onClick={e => e.stopPropagation()}
       >
@@ -47,45 +62,12 @@ export function EditTownModal({
         </div>
 
         <form onSubmit={handleSubmit} className="px-6 py-5 space-y-4">
-          <div>
-            <label
-              className="block text-xs font-medium mb-1.5"
-              style={{ color: '#5a4a35' }}
-            >
-              Town Name
-            </label>
-            <input
-              autoFocus
-              type="text"
-              value={name}
-              onChange={e => setName(e.target.value)}
-              className="w-full rounded-[10px] border px-3 py-2 text-sm outline-none"
-              style={{
-                borderColor: '#E7DAC4',
-                backgroundColor: '#FFFDF6',
-                color: '#2A2A2A',
-              }}
-            />
-          </div>
-          <div>
-            <label
-              className="block text-xs font-medium mb-1.5"
-              style={{ color: '#5a4a35' }}
-            >
-              Your Name
-            </label>
-            <input
-              type="text"
-              value={playerName}
-              onChange={e => setPlayerName(e.target.value)}
-              className="w-full rounded-[10px] border px-3 py-2 text-sm outline-none"
-              style={{
-                borderColor: '#E7DAC4',
-                backgroundColor: '#FFFDF6',
-                color: '#2A2A2A',
-              }}
-            />
-          </div>
+          <TownNameFields
+            name={name}
+            playerName={playerName}
+            onNameChange={setName}
+            onPlayerNameChange={setPlayerName}
+          />
           <button
             type="submit"
             disabled={!name.trim() || !playerName.trim()}
@@ -100,7 +82,6 @@ export function EditTownModal({
           </button>
         </form>
       </div>
-    </div>,
-    document.body
+    </div>
   );
 }

--- a/src/components/search/GlobalSearchResults.tsx
+++ b/src/components/search/GlobalSearchResults.tsx
@@ -21,7 +21,7 @@ export function GlobalSearchResults({
 }) {
   if (!results) {
     return (
-      <EmptyState message="Type above to search fish, bugs, fossils, and art at once." />
+      <EmptyState message="Type above to search fish, bugs, fossils, art, and sea creatures at once." />
     );
   }
 

--- a/src/components/shared/TownNameFields.tsx
+++ b/src/components/shared/TownNameFields.tsx
@@ -1,0 +1,61 @@
+import React from 'react';
+
+interface Props {
+  name: string;
+  playerName: string;
+  onNameChange: (v: string) => void;
+  onPlayerNameChange: (v: string) => void;
+  namePlaceholder?: string;
+  playerPlaceholder?: string;
+  autoFocus?: boolean;
+}
+
+const inputStyle = {
+  borderColor: '#E7DAC4',
+  backgroundColor: '#FFFDF6',
+  color: '#2A2A2A',
+};
+
+const labelStyle = { color: '#5a4a35' };
+
+export function TownNameFields({
+  name,
+  playerName,
+  onNameChange,
+  onPlayerNameChange,
+  namePlaceholder,
+  playerPlaceholder,
+  autoFocus = true,
+}: Props) {
+  return (
+    <>
+      <div>
+        <label className="block text-xs font-medium mb-1.5" style={labelStyle}>
+          Town Name
+        </label>
+        <input
+          autoFocus={autoFocus}
+          type="text"
+          value={name}
+          onChange={e => onNameChange(e.target.value)}
+          placeholder={namePlaceholder}
+          className="w-full rounded-[10px] border px-3 py-2 text-sm outline-none"
+          style={inputStyle}
+        />
+      </div>
+      <div>
+        <label className="block text-xs font-medium mb-1.5" style={labelStyle}>
+          Your Name
+        </label>
+        <input
+          type="text"
+          value={playerName}
+          onChange={e => onPlayerNameChange(e.target.value)}
+          placeholder={playerPlaceholder}
+          className="w-full rounded-[10px] border px-3 py-2 text-sm outline-none"
+          style={inputStyle}
+        />
+      </div>
+    </>
+  );
+}

--- a/src/hooks/useCategoryStats.ts
+++ b/src/hooks/useCategoryStats.ts
@@ -9,10 +9,13 @@ export function useCategoryStats(
   donated: Record<string, boolean>
 ): Record<CategoryId, number> {
   return useMemo(() => {
-    const counts = { fish: 0, bugs: 0, fossils: 0, art: 0 } as Record<
-      CategoryId,
-      number
-    >;
+    const counts = {
+      fish: 0,
+      bugs: 0,
+      fossils: 0,
+      art: 0,
+      sea_creatures: 0,
+    } as Record<CategoryId, number>;
     for (const cat of CATEGORY_ORDER) {
       counts[cat] = (data[cat] as AnyItem[]).filter(
         item => !!donated[item.id]

--- a/src/hooks/useMuseumData.ts
+++ b/src/hooks/useMuseumData.ts
@@ -12,6 +12,7 @@ export function useMuseumData(gameId: GameId = 'ACGCN') {
     bugs: [],
     fossils: [],
     art: [],
+    sea_creatures: [],
   });
   const [loading, setLoading] = useState(true);
   const [loadError, setLoadError] = useState<AppErrorKind | null>(null);
@@ -30,8 +31,8 @@ export function useMuseumData(gameId: GameId = 'ACGCN') {
         });
       })
     )
-      .then(([fish, bugs, fossils, art]) => {
-        setData({ fish, bugs, fossils, art });
+      .then(([fish, bugs, fossils, art, sea_creatures]) => {
+        setData({ fish, bugs, fossils, art, sea_creatures });
         setLoading(false);
       })
       .catch(err => {

--- a/src/lib/categoryMeta.ts
+++ b/src/lib/categoryMeta.ts
@@ -1,5 +1,5 @@
 import type React from 'react';
-import { Fish as FishIcon, Bug, Bone, Palette } from 'lucide-react';
+import { Fish as FishIcon, Bug, Bone, Palette, Waves } from 'lucide-react';
 import type { CategoryId, GameId } from './types';
 
 export const CATEGORY_META: Record<
@@ -10,6 +10,11 @@ export const CATEGORY_META: Record<
   bugs: { label: 'Bugs', Icon: Bug, file: '/data/acgcn/bugs.json' },
   fossils: { label: 'Fossils', Icon: Bone, file: '/data/acgcn/fossils.json' },
   art: { label: 'Art', Icon: Palette, file: '/data/acgcn/art.json' },
+  sea_creatures: {
+    label: 'Sea Creatures',
+    Icon: Waves,
+    file: '/data/acnh/sea_creatures.json',
+  },
 };
 
 const GAME_DATA_DIR: Partial<Record<GameId, string>> = {
@@ -21,8 +26,9 @@ const GAME_DATA_DIR: Partial<Record<GameId, string>> = {
 };
 
 const GAMES_WITH_ART = new Set<GameId>(['ACGCN', 'ACNL', 'ACNH']);
+const GAMES_WITH_SEA_CREATURES = new Set<GameId>(['ACNL', 'ACNH']);
 
-/** Returns per-category fetch paths for the given game. Art is null for games without art data. */
+/** Returns per-category fetch paths for the given game. Null means no data file for that category/game combo. */
 export function getDataPaths(
   gameId: GameId
 ): Record<CategoryId, string | null> {
@@ -32,5 +38,8 @@ export function getDataPaths(
     bugs: `${dir}/bugs.json`,
     fossils: `${dir}/fossils.json`,
     art: GAMES_WITH_ART.has(gameId) ? `${dir}/art.json` : null,
+    sea_creatures: GAMES_WITH_SEA_CREATURES.has(gameId)
+      ? `${dir}/sea_creatures.json`
+      : null,
   };
 }

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -20,9 +20,16 @@ export const CATEGORY_LABELS: Record<CategoryId, string> = {
   bugs: 'Bugs',
   fossils: 'Fossils',
   art: 'Art',
+  sea_creatures: 'Sea Creatures',
 };
 
-export const CATEGORY_ORDER: CategoryId[] = ['fish', 'bugs', 'fossils', 'art'];
+export const CATEGORY_ORDER: CategoryId[] = [
+  'fish',
+  'bugs',
+  'fossils',
+  'art',
+  'sea_creatures',
+];
 
 export const SEASONS = [
   { label: 'Spring', months: [3, 4, 5], color: '#3CA370' },

--- a/src/lib/csvExport.ts
+++ b/src/lib/csvExport.ts
@@ -3,17 +3,25 @@
  *
  * Output structure (three sections, each separated by a blank line):
  *   1. Donation Activity Log   — one row per donated item, sorted by date
- *   2. Category Completion     — totals and % for fish, bugs, fossils, art
+ *   2. Category Completion     — totals and % for fish, bugs, fossils, art, sea creatures
  *   3. Monthly Activity        — per-month donation counts broken down by category
  */
 
-import type { Fish, BugItem, FossilItem, ArtPiece, CategoryId } from './types';
+import type {
+  Fish,
+  BugItem,
+  FossilItem,
+  ArtPiece,
+  SeaCreature,
+  CategoryId,
+} from './types';
 
 interface AllData {
   fish: Fish[];
   bugs: BugItem[];
   fossils: FossilItem[];
   art: ArtPiece[];
+  sea_creatures: SeaCreature[];
 }
 
 function escapeCell(value: string | number | null | undefined): string {
@@ -137,6 +145,17 @@ export function buildCSV(
       });
     }
   }
+  for (const item of data.sea_creatures) {
+    if (donatedMap[item.id]) {
+      const iso = donatedAtMap[item.id] ?? '';
+      activity.push({
+        name: item.name,
+        category: 'Sea Creatures',
+        iso,
+        formatted: fmtDate(iso),
+      });
+    }
+  }
 
   // Sort by date ascending (empty dates go last)
   activity.sort((a, b) => {
@@ -155,12 +174,20 @@ export function buildCSV(
   sections.push(activityLines.join('\n'));
 
   // ── 3. Category Completion ─────────────────────────────────────────────────
-  const cats: { id: CategoryId; label: string }[] = [
+  const baseCats: { id: CategoryId; label: string }[] = [
     { id: 'fish', label: 'Fish' },
     { id: 'bugs', label: 'Bugs' },
     { id: 'fossils', label: 'Fossils' },
     { id: 'art', label: 'Art' },
   ];
+  // Only include sea creatures if this game has them
+  const cats =
+    data.sea_creatures.length > 0
+      ? [
+          ...baseCats,
+          { id: 'sea_creatures' as CategoryId, label: 'Sea Creatures' },
+        ]
+      : baseCats;
 
   const completionLines = [
     row('CATEGORY COMPLETION'),
@@ -187,7 +214,6 @@ export function buildCSV(
   sections.push(completionLines.join('\n'));
 
   // ── 4. Monthly Activity ───────────────────────────────────────────────────
-  // Map: "YYYY-MM" -> { fish, bugs, fossils, art }
   const monthMap: Record<string, Record<CategoryId, number>> = {};
 
   function tally(items: { id: string }[], cat: CategoryId) {
@@ -198,7 +224,13 @@ export function buildCSV(
       const d = new Date(iso);
       const key = `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}`;
       if (!monthMap[key])
-        monthMap[key] = { fish: 0, bugs: 0, fossils: 0, art: 0 };
+        monthMap[key] = {
+          fish: 0,
+          bugs: 0,
+          fossils: 0,
+          art: 0,
+          sea_creatures: 0,
+        };
       monthMap[key][cat]++;
     }
   }
@@ -207,11 +239,26 @@ export function buildCSV(
   tally(data.bugs, 'bugs');
   tally(data.fossils, 'fossils');
   tally(data.art, 'art');
+  tally(data.sea_creatures, 'sea_creatures');
 
-  const monthlyLines = [
-    row('MONTHLY ACTIVITY'),
-    row('Month', 'Fish', 'Bugs', 'Fossils', 'Art', 'Total'),
-  ];
+  const hasSea = data.sea_creatures.length > 0;
+  const monthlyLines = hasSea
+    ? [
+        row('MONTHLY ACTIVITY'),
+        row(
+          'Month',
+          'Fish',
+          'Bugs',
+          'Fossils',
+          'Art',
+          'Sea Creatures',
+          'Total'
+        ),
+      ]
+    : [
+        row('MONTHLY ACTIVITY'),
+        row('Month', 'Fish', 'Bugs', 'Fossils', 'Art', 'Total'),
+      ];
 
   const sortedMonths = Object.keys(monthMap).sort();
   for (const key of sortedMonths) {
@@ -224,8 +271,14 @@ export function buildCSV(
         year: 'numeric',
       }
     );
-    const total = m.fish + m.bugs + m.fossils + m.art;
-    monthlyLines.push(row(label, m.fish, m.bugs, m.fossils, m.art, total));
+    const total = m.fish + m.bugs + m.fossils + m.art + m.sea_creatures;
+    if (hasSea) {
+      monthlyLines.push(
+        row(label, m.fish, m.bugs, m.fossils, m.art, m.sea_creatures, total)
+      );
+    } else {
+      monthlyLines.push(row(label, m.fish, m.bugs, m.fossils, m.art, total));
+    }
   }
 
   if (sortedMonths.length === 0) {

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -55,7 +55,7 @@ export const GAMES: Record<GameId, Game> = {
 
 export type Habitat = 'river' | 'ocean' | 'pond' | 'lake' | 'other';
 
-export type CategoryId = 'fish' | 'bugs' | 'fossils' | 'art';
+export type CategoryId = 'fish' | 'bugs' | 'fossils' | 'art' | 'sea_creatures';
 
 export interface Fish {
   id: string;
@@ -92,6 +92,17 @@ export interface ArtPiece {
   basedOn: string;
 }
 
+export interface SeaCreature {
+  id: string;
+  name: string;
+  value: number | null;
+  shadow?: string;
+  time?: string;
+  months?: number[];
+  months_nh?: number[];
+  months_sh?: number[];
+}
+
 // ─── Error types ─────────────────────────────────────────────────────────────
 
 export type AppErrorKind =
@@ -114,4 +125,8 @@ export interface CollectibleDetail {
   basedOn?: string;
   months?: number[];
   notes?: string;
+  /** shadow size (sea creatures) */
+  shadow?: string;
+  /** time availability (sea creatures) */
+  time?: string;
 }

--- a/src/lib/utils.test.ts
+++ b/src/lib/utils.test.ts
@@ -4,13 +4,21 @@ import {
   rowSubtitle,
   itemBells,
   itemMonths,
+  isSeaCreature,
   formatTimestamp,
   formatRelativeDate,
   filterByQuery,
   globalFilter,
 } from './utils';
 import type { AnyItem } from './utils';
-import type { Fish, BugItem, FossilItem, ArtPiece, CategoryId } from './types';
+import type {
+  Fish,
+  BugItem,
+  FossilItem,
+  ArtPiece,
+  SeaCreature,
+  CategoryId,
+} from './types';
 
 // ─── Sample fixtures ──────────────────────────────────────────────────────────
 
@@ -234,6 +242,45 @@ describe('filterByQuery', () => {
   });
 });
 
+// ─── isSeaCreature ────────────────────────────────────────────────────────────
+
+describe('isSeaCreature', () => {
+  const seaCreature: SeaCreature = {
+    id: 'sc-001',
+    name: 'Sea Star',
+    value: 500,
+    shadow: 'medium',
+    time: 'all day',
+    months: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12],
+  };
+
+  it('returns true for a sea creature with shadow', () => {
+    expect(isSeaCreature(seaCreature)).toBe(true);
+  });
+
+  it('returns true for a sea creature with time but no shadow', () => {
+    const minimal: SeaCreature = {
+      id: 'sc-002',
+      name: 'Octopus',
+      value: 1200,
+      time: 'all day',
+    };
+    expect(isSeaCreature(minimal)).toBe(true);
+  });
+
+  it('returns false for fish (has habitat)', () => {
+    expect(isSeaCreature(fishItem)).toBe(false);
+  });
+
+  it('returns false for an art piece', () => {
+    expect(isSeaCreature(artItem)).toBe(false);
+  });
+
+  it('returns false for a fossil', () => {
+    expect(isSeaCreature(fossilWithPart)).toBe(false);
+  });
+});
+
 // ─── globalFilter ─────────────────────────────────────────────────────────────
 
 describe('globalFilter', () => {
@@ -242,15 +289,25 @@ describe('globalFilter', () => {
     bugs: [{ id: 'b1', name: 'Dace Beetle', value: 100, months: [6] }],
     fossils: [{ id: 'fo1', name: 'Dace Fossil', value: 500 }],
     art: [{ id: 'a1', name: 'Fake Painting', basedOn: 'The Last Supper' }],
+    sea_creatures: [
+      {
+        id: 'sc1',
+        name: 'Dace Slug',
+        value: 600,
+        shadow: 'small',
+        time: 'all day',
+      },
+    ],
   };
 
   it('returns matches across all categories for a shared query term', () => {
     const results = globalFilter(data, 'Dace');
-    // fish: Dace; bugs: Dace Beetle; fossils: Dace Fossil; art: 0
+    // fish: Dace; bugs: Dace Beetle; fossils: Dace Fossil; art: 0; sea_creatures: Dace Slug
     expect(results.fish).toHaveLength(1);
     expect(results.bugs).toHaveLength(1);
     expect(results.fossils).toHaveLength(1);
     expect(results.art).toHaveLength(0);
+    expect(results.sea_creatures).toHaveLength(1);
   });
 
   it('returns all items per category when query is empty', () => {

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -3,10 +3,11 @@ import type {
   BugItem,
   FossilItem,
   ArtPiece,
+  SeaCreature,
   CategoryId,
 } from './types';
 
-export type AnyItem = FishType | BugItem | FossilItem | ArtPiece;
+export type AnyItem = FishType | BugItem | FossilItem | ArtPiece | SeaCreature;
 
 // ─── Type guards ──────────────────────────────────────────────────────────────
 
@@ -20,6 +21,15 @@ export function isFossil(item: AnyItem): item is FossilItem {
 
 export function isArtPiece(item: AnyItem): item is ArtPiece {
   return 'basedOn' in item;
+}
+
+export function isSeaCreature(item: AnyItem): item is SeaCreature {
+  return (
+    !('habitat' in item) &&
+    !('basedOn' in item) &&
+    !('part' in item) &&
+    ('shadow' in item || 'time' in item)
+  );
 }
 
 // ─── Item accessors ───────────────────────────────────────────────────────────
@@ -39,12 +49,13 @@ export function rowSubtitle(
   if (category === 'fish') return (item as FishType).habitat;
   if (category === 'fossils') return null;
   if (category === 'art') return (item as ArtPiece).basedOn;
+  if (category === 'sea_creatures') return (item as SeaCreature).shadow ?? null;
   return null;
 }
 
 export function itemBells(item: AnyItem, category: CategoryId): number | null {
   if (category === 'art') return null;
-  return (item as FishType | BugItem | FossilItem).value ?? null;
+  return (item as FishType | BugItem | FossilItem | SeaCreature).value ?? null;
 }
 
 export function itemMonths(
@@ -53,13 +64,18 @@ export function itemMonths(
   hemisphere?: 'NH' | 'SH'
 ): number[] | undefined {
   if (category === 'fossils' || category === 'art') return undefined;
-  const critter = item as FishType | BugItem;
+  const critter = item as FishType | BugItem | SeaCreature;
   if (hemisphere === 'SH' && critter.months_sh) return critter.months_sh;
   if (critter.months_nh) return critter.months_nh;
   return critter.months;
 }
 
-export function itemNotes(item: AnyItem): string | undefined {
+export function itemNotes(
+  item: AnyItem,
+  category?: CategoryId
+): string | undefined {
+  if (category === 'sea_creatures' || isSeaCreature(item))
+    return (item as SeaCreature).time;
   return isFish(item) ? item.notes : undefined;
 }
 
@@ -116,7 +132,13 @@ export function globalFilter(
   data: Record<CategoryId, AnyItem[]>,
   query: string
 ): Record<CategoryId, AnyItem[]> {
-  const categories: CategoryId[] = ['fish', 'bugs', 'fossils', 'art'];
+  const categories: CategoryId[] = [
+    'fish',
+    'bugs',
+    'fossils',
+    'art',
+    'sea_creatures',
+  ];
   const q = query.trim().toLowerCase();
   const results = {} as Record<CategoryId, AnyItem[]>;
   for (const cat of categories) {

--- a/src/lib/viewTypes.ts
+++ b/src/lib/viewTypes.ts
@@ -1,4 +1,11 @@
-import type { CategoryId, Fish, BugItem, FossilItem, ArtPiece } from './types';
+import type {
+  CategoryId,
+  Fish,
+  BugItem,
+  FossilItem,
+  ArtPiece,
+  SeaCreature,
+} from './types';
 
 export type ViewId = CategoryId | 'home' | 'activity' | 'search' | 'analytics';
 
@@ -7,4 +14,5 @@ export interface AllData {
   bugs: BugItem[];
   fossils: FossilItem[];
   art: ArtPiece[];
+  sea_creatures: SeaCreature[];
 }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -4,12 +4,19 @@ import { readFileSync } from 'fs';
 import { execSync } from 'child_process';
 
 const { version } = JSON.parse(readFileSync('./package.json', 'utf-8'));
-let gitSha = 'unknown';
-try {
-  gitSha = execSync('git rev-parse --short HEAD').toString().trim();
-} catch {
-  // not a git repo (e.g. Vercel build environment)
+
+function getGitSha(): string {
+  if (process.env.VERCEL_GIT_COMMIT_SHA) {
+    return process.env.VERCEL_GIT_COMMIT_SHA.slice(0, 7);
+  }
+  try {
+    return execSync('git rev-parse --short HEAD').toString().trim();
+  } catch {
+    return 'unknown';
+  }
 }
+
+const gitSha = getGitSha();
 
 export default defineConfig({
   define: {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -18,10 +18,24 @@ function getGitSha(): string {
 
 const gitSha = getGitSha();
 
+function getGitBranch(): string {
+  if (process.env.VERCEL_GIT_COMMIT_REF) {
+    return process.env.VERCEL_GIT_COMMIT_REF;
+  }
+  try {
+    return execSync('git rev-parse --abbrev-ref HEAD').toString().trim();
+  } catch {
+    return 'unknown';
+  }
+}
+
+const gitBranch = getGitBranch();
+
 export default defineConfig({
   define: {
     'import.meta.env.VITE_APP_VERSION': JSON.stringify(version),
     'import.meta.env.VITE_GIT_SHA': JSON.stringify(gitSha),
+    'import.meta.env.VITE_GIT_BRANCH': JSON.stringify(gitBranch),
   },
   plugins: [react()],
 });


### PR DESCRIPTION
## Summary

Surfaces the Sea Creatures data that shipped in v0.8.0-alpha (PRs #34/#35 — 40 species in `public/data/acnh/sea_creatures.json`, also present for ACNL) with a dedicated museum tab. The tab was explicitly deferred from `feature/sea-creatures-tab` to keep v0.8.0 scope contained; this PR integrates that work onto the current `development` state.

**What's in scope:**
- Sea tab appears in TabBar for ACNH and ACNL towns; hidden for all others
- Switching to a non-ACNH/ACNL town while on the Sea tab redirects to Home
- Sea creatures reuse the `CollectibleRow` + `ItemExpandPanel` path — months, value (bells), and shadow size shown in the expand panel (same UX as fish/bugs)
- Donation toggles work; donations persist to the 3-level store schema
- Home tab progress grid includes a Sea Creatures card for ACNH/ACNL towns
- Global search covers sea creatures
- CSV export includes sea creatures in the activity log and category completion section
- `SeaCreature` type, `isSeaCreature` type guard, updated `AnyItem` union, `globalFilter`, and `useCategoryStats` all extended
- Version bumped to `0.8.2-alpha`; branch-label footer suffix (`· feature/sea-creatures-tab`) auto-strips on `main`/`development`

## Decisions

- **Reused CollectibleRow + ItemExpandPanel instead of a new view component.** Sea creatures have the same shape as fish/bugs (months, value, optional hemisphere) so the existing expand panel covers the UX without new components. Shadow size maps to the subtitle slot (the same slot fish use for habitat).
- **MODAL_BLOCKED_TABS not extended.** The v0.8.1 greyed-out-button stopgap applies to `fish`, `bugs`, and `fossils` only. Sea creatures is a new tab and should behave like `art` (buttons active). Correct for v0.9 layout lift.
- **Conflict resolution — ACCanvas.tsx.** Development added `ItemExpandPanel`, `EditTownModal`, `expandedId` state, and the CollectibleRow → div+panel render. The sea-creatures branch added the `sea_creatures` VALID_TAB and the redirect-on-game-switch guard. Both sets of changes were additive to different sections; resolved by taking all of development's additions plus the sea-creatures guard effect.

## Test plan

- [x] `npm run build` — clean (0 errors, 0 warnings)
- [x] `npm test` — 521 tests passing across all worktrees
- [ ] Manual: create ACNH town → Sea tab visible, items load, expand panel shows months + bells + shadow, donate toggle persists
- [ ] Manual: switch to ACGCN town → Sea tab disappears, redirected to Home
- [ ] Manual: Home tab → Sea Creatures progress card present for ACNH town
- [ ] Manual: Global search → sea creatures appear in results
- [ ] Preview URL (from Vercel check on this PR)

Closes #56
