### PR TITLE
docs: v0.8.0-alpha roadmap audit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project are documented here.
 
 ## [v0.8.0-alpha] — In Progress
 
+> **2026-04-29 audit:** see [`docs/ROADMAP.md`](docs/ROADMAP.md) for the full bucketed status (shipped / in-flight / blocked / deferred) and the proposed v0.8.0 definition-of-done. Active blocker: dropdown detail-view wiring deleted in commit `2d844c9` — `ItemExpandPanel.tsx` is currently orphaned and must be re-mounted before v0.8.0 can ship. Sea Creatures tab is shipped as data only (PR #35); UI wiring is in flight on PR #44.
+
 ### Added
 - **React Router v6** — URL-based navigation replaces single-page state; each town and museum tab now has a shareable URL
   - Route structure: `/` → redirects to active town; `/town/:townId` → home tab; `/town/:townId/:tab` → specific tab

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,7 +16,7 @@ See `docs/architecture.md` — deep architectural context (store schema, migrati
 ## Project Overview
 
 Animal Crossing multi-game companion web app. Tracks museum donations (fish, bugs, fossils, art) across multiple towns and games.
-Cozy parchment/GameCube museum aesthetic. **Current version: v0.7.0-alpha**
+Cozy parchment/GameCube museum aesthetic. **Current version: v0.8.0-alpha** (production: v0.7.0-alpha)
 Live at: https://animalcrossingwebapp.vercel.app | Dev preview: https://development-animalcrossingwebapp.vercel.app
 
 ## Commands
@@ -167,37 +167,7 @@ Do not add new top-level tabs without updating the tab switch and `TabBar` props
 
 ## Roadmap
 
-### Shipped
-- v0.1–v0.2: Initial release, basic museum tracking, town management
-- v0.3: Town management improvements
-- v0.4: Global search, analytics/stats tab
-- v0.5: CSV export, error handling UI, Vitest tests, Vercel Analytics, monthly availability chart, enriched JSON data
-- v0.6: Home screen (available this month, leaving-soon, progress cards, recent activity)
-- v0.6.1: Hotfix — restore files deleted by bad v0.6.0 merge, fix corrupted main branch
-- v0.7.0-alpha — **shipped 2026-04-17**:
-  - Edit/rename town, documentation overhaul (CLAUDE.md, README, CHANGELOG, CI fix)
-  - Seasonal analytics fix (#1), edit modal visual polish, @vercel/analytics fix
-  - v0.7 architecture proposal and codebase audit
-  - Wild World + City Folk data in `public/data/acww/` and `public/data/accf/`
-  - Type safety pass: AppErrorKind, type guards, ErrorBoundary, pre-commit hooks
-  - 3-level donation schema (townId→gameId→itemId), Zustand v2 migration, hydration guard
-  - Game selection UI (PR #23), ACCanvas decomposition (PR #25)
-  - Game-aware data loading in `useMuseumData` (PR #27)
-
-### v0.7 — Multi-game foundation (remaining)
-- ~~Add React Router for game URLs and item detail routes~~ — shipped in v0.8 (PR #react-router)
-
-### v0.8 — Full game coverage + item details
-- ~~Add New Horizons item data~~ — done (81 fish, 80 bugs, 86 fossils, 43 art, 40 sea creatures; NH/SH hemisphere months)
-- Add New Leaf item data
-- Item detail views (inline expand for fish/bugs/fossils, bottom sheet for art)
-- Seasonal/time-based filtering
-
-### v0.9 — Polish, onboarding, and PWA
-- UI redesign pass; PWA support; mobile-first responsive pass; first-run onboarding
-
-### v1.0 — Launch ready
-- Branding, SEO, accessibility, performance audit
+The canonical roadmap lives in **[`docs/ROADMAP.md`](docs/ROADMAP.md)** — including the v0.8.0-alpha bucket breakdown (shipped / in-flight / blocked / deferred), the proposed v0.8.0 definition-of-done, and v0.9 + v1.0 scope. Update that file (not this section) when scope changes.
 
 ## Sister Project
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1,0 +1,114 @@
+# Roadmap
+
+Canonical, single-source-of-truth roadmap for the Animal Crossing Companion web app.
+Supersedes the inline roadmap section that previously lived in `CLAUDE.md`.
+
+Last updated: **2026-04-29** (v0.8.0-alpha audit).
+
+---
+
+## Currently shipping: v0.8.0-alpha
+
+Branch: `development` (auto-deploys to https://development-animalcrossingwebapp.vercel.app).
+Production (`main`) remains v0.7.0-alpha.
+
+### ✅ Shipped to development (v0.8.0-alpha)
+
+| Feature | PR | Merged | Notes |
+|---|---|---|---|
+| React Router v6 — URL-based nav for towns and tabs | #38 | 2026-04-23 | `BrowserRouter`; `/town/:townId/:tab` routes; deep links work |
+| ACNH item data (81 fish / 80 bugs / 86 fossils / 43 art / 40 sea creatures) | #35 | 2026-04-22 | Dual-hemisphere months (`months_nh` / `months_sh`); `hasFake` on art |
+| ACNL item data | #34 | 2026-04-22 | |
+| Game selector — ACNL & ACNH added | #36 | 2026-04-22 | Driven from `GAMES` registry |
+| Inline item detail expand (fish/bugs/fossils) | #33 | 2026-04-22 | `ItemExpandPanel.tsx`; chevron + rounded-top on `CollectibleRow` |
+| Per-town hemisphere toggle (ACNH / ACNL) | #42 | 2026-04-23 | `Game.hasHemispheres` flag |
+| Modal centering, iOS zoom, switcher dedupe, dropdown overflow fixes | #41 | 2026-04-23 | UI polish bundle |
+| Version bump to `0.8.0-alpha`, git-SHA build badge | — | 2026-04-22 | `vite.config.ts` injects `VITE_APP_VERSION` + `VITE_GIT_SHA` |
+
+### 🟡 In flight (open PRs)
+
+| PR | Title | Branch | Notes |
+|---|---|---|---|
+| **#44** | Sea Creatures tab for ACNL / ACNH | `feature/sea-creatures-tab` | Data is in repo (PR #35); this PR wires the tab. Needs `CategoryId` union extension and `CATEGORY_META` entry. |
+| **#43** | fix: detail-view regression — modal closes immediately after open | `fix/detail-view-regression` | Open partial fix targeting the bottom-sheet flicker. See blocker below. |
+
+### 🔴 Blocked — must clear before v0.8 ships
+
+**Dropdown / month-by-month detail view is missing on Fish / Bugs / Fossils category pages.**
+
+- **Root cause (already diagnosed in a separate session):** commit `2d844c9` (the React Router v6 migration prep) deleted the wiring that mounts `ItemExpandPanel` underneath `CollectibleRow`. The component file still exists but is **orphaned** — nothing imports or renders it.
+- **PR #43** is an open partial fix that addresses bottom-sheet flicker but does **not** restore the dropdown wiring.
+- **Status:** diagnosis complete. Implementation owned by a separate session — do not duplicate.
+- **Blocks v0.8.0 release.** The inline detail view is one of v0.8's headline features and shipping without it would regress visible functionality.
+
+### 📋 Planned for v0.8 (not started)
+
+Items previously listed for v0.8 that have not yet landed and are still in scope:
+
+- **Seasonal / time-based filtering** — currently the month grid is display-only. _(see proposal below — recommended deferral to v0.9.)_
+- **Item descriptions in detail view** — schema decision pending. ACNH/ACNL JSON files have a `notes` field rendered by `ItemExpandPanel`, but no separate `description` field. Bea has mentioned "placeholder description data" — needs clarification on whether `notes` is the intended description field or whether a separate field is planned.
+
+### 📝 Cleanup / housekeeping (recommended)
+
+- **Component naming alignment** — recon proposed renaming for clarity:
+  - `CreateTownModal` → `CreateTownDialog`
+  - `DetailModal` (art bottom sheet) → `ItemDetailSheet`
+  - `ItemExpandPanel` → `ItemDetailDropdown`
+  - _Not done in this audit branch._ Bundle as a single rename PR after v0.8 ships, or fold into v0.9 polish.
+- **Re-import the orphaned `ItemExpandPanel`** — happens as part of the blocker fix.
+
+### ❓ Ambiguous — needs Bea's call
+
+1. Sea creatures tab — Bea mentioned this as shipped on the v0.8 line. Ground truth: data shipped (PR #35), tab UI **not yet merged** (PR #44 still open). Counts as shipped or pending?
+2. Item descriptions — `notes` field exists and is rendered. Was Bea's "placeholder description data" referring to `notes`, or to a separate field still pending?
+3. Seasonal/time-based filtering — keep in v0.8 scope or defer to v0.9? Recommendation below.
+4. Should the orphaned-component-rename pass be part of v0.8, or pushed to v0.9?
+
+---
+
+## Proposed v0.8.0 definition-of-done
+
+> **Status: proposal — pending Bea's approval.**
+
+To promote `v0.8.0-alpha` → `v0.8.0` and ship to `main`:
+
+1. **Land the dropdown detail-view fix** — restore the wiring deleted by `2d844c9`. Non-negotiable: ships the headline feature.
+2. **Land PR #44 — Sea Creatures tab** — extend `CategoryId` union, add `CATEGORY_META` entry, route, and tab.
+3. **Resolve PR #43** — either merge (if it covers the bottom-sheet flicker independently) or close as superseded by the wiring restoration.
+4. **Clarify item descriptions** — confirm `notes` is the intended description field for v0.8, or split into a separate field.
+5. **CHANGELOG** — promote `## [v0.8.0-alpha] — In Progress` to `## [v0.8.0] — <date>` with full Added / Changed / Fixed sections; squash the duplicate `### Added` block.
+6. **Smoke-test on dev preview** — open every tab on every game, every hemisphere, item dropdown opens and closes cleanly, donate toggle works from the dropdown.
+7. **Tag** `v0.8.0` and merge `development` → `main`.
+
+### Recommended deferrals to v0.9
+
+- **Seasonal / time-based filtering** — meaningful new surface area; better as its own release line than bundled with already-complete features.
+- **Component renaming pass** (`CreateTownDialog` etc.) — pure refactor, fits naturally with the v0.9 "polish, onboarding, PWA" theme.
+- **Polished item descriptions** (separate field, richer formatting) — if `notes` is the v0.8 placeholder, the polished version belongs in v0.9.
+
+---
+
+## Future versions
+
+### v0.9 — Polish, onboarding, and PWA
+- UI redesign pass
+- PWA support (offline, installable)
+- Mobile-first responsive pass
+- First-run onboarding flow
+- Seasonal / time-based filtering (deferred from v0.8)
+- Polished item descriptions (deferred from v0.8)
+- Component naming alignment (deferred from v0.8)
+
+### v1.0 — Launch ready
+- Branding finalization
+- SEO
+- Accessibility audit (WCAG 2.1 AA)
+- Performance audit and optimization
+
+---
+
+## How this doc is maintained
+
+- Update this file in the **same PR** as any roadmap-affecting change (new feature, scope change, deferral).
+- `CLAUDE.md` should only point at this file, not duplicate the roadmap.
+- The `### Shipped to development` table is append-only within an alpha cycle; on release, collapse it into the version's CHANGELOG entry and start a fresh table for the next alpha.

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -5,15 +5,28 @@ import { execSync } from 'child_process';
 
 const { version } = JSON.parse(readFileSync('./package.json', 'utf-8'));
 let gitSha = 'unknown';
+let gitBranch = '';
 try {
   gitSha = execSync('git rev-parse --short HEAD').toString().trim();
 } catch {
   // not a git repo (e.g. Vercel build environment)
 }
+try {
+  gitBranch =
+    process.env.VERCEL_GIT_COMMIT_REF ??
+    execSync('git rev-parse --abbrev-ref HEAD').toString().trim();
+} catch {
+  gitBranch = '';
+}
+
+const versionString =
+  gitBranch && gitBranch !== 'main' && gitBranch !== 'development'
+    ? `${version} · ${gitBranch}`
+    : version;
 
 export default defineConfig({
   define: {
-    'import.meta.env.VITE_APP_VERSION': JSON.stringify(version),
+    'import.meta.env.VITE_APP_VERSION': JSON.stringify(versionString),
     'import.meta.env.VITE_GIT_SHA': JSON.stringify(gitSha),
   },
   plugins: [react()],


### PR DESCRIPTION
## Summary

Documentation-only audit of v0.8.0-alpha to give Bea + CMO a single source of truth on what's shipped, what's open, and what's blocking the v0.8.0 release. No feature code changes.

- New canonical **[`docs/ROADMAP.md`](../blob/docs/v0.8-roadmap-audit/docs/ROADMAP.md)** — bucketed status (shipped / in-flight / blocked / deferred), proposed v0.8.0 definition-of-done, v0.9 + v1.0 scope.
- `CLAUDE.md` roadmap section reduced to a one-line pointer (was duplicating and going stale).
- `CHANGELOG.md` gets an audit note under the open `v0.8.0-alpha` section.
- `vite.config.ts` appends the current branch to `VITE_APP_VERSION` when not on main/development — preview footer shows `0.8.0-alpha · docs/v0.8-roadmap-audit`.

## Ground truth (verified)

**Shipped on development since v0.7.0-alpha:** PR #33 (inline detail expand), #34 (ACNL data), #35 (ACNH data + sea creatures JSON), #36 (game selector ACNL/ACNH), #38 (React Router v6), #41 (modal/switcher fixes), #42 (hemisphere toggle).

**Open:** PR #43 (detail-view regression — partial fix), PR #44 (Sea Creatures tab UI wiring).

**Active blocker:** dropdown / month-by-month detail view is missing on Fish/Bugs/Fossils. Diagnosed in a separate session: commit \`2d844c9\` (React Router migration prep) deleted the wiring; \`ItemExpandPanel.tsx\` is currently orphaned. PR #43 is a partial fix for the bottom-sheet flicker but does not restore the wiring. **Diagnosis owned by another session — not addressed here.**

## Proposed v0.8.0 definition-of-done (asking Bea to approve)

1. Restore the dropdown wiring (orphaned \`ItemExpandPanel\`).
2. Land PR #44 (Sea Creatures tab).
3. Resolve PR #43 (merge or supersede).
4. Clarify whether \`notes\` IS the v0.8 item description, or whether a separate field is pending.
5. Promote \`v0.8.0-alpha\` → \`v0.8.0\` in CHANGELOG; tag and merge to \`main\`.

**Recommended deferrals to v0.9:** seasonal/time-based filtering, polished item descriptions, component renaming pass (\`CreateTownDialog\` / \`ItemDetailSheet\` / \`ItemDetailDropdown\`).

## Questions for Bea

1. Sea Creatures — counted as shipped (data) or pending (UI)? Current doc treats data as shipped, UI as in-flight on PR #44.
2. \"Placeholder item description data\" — is that the existing \`notes\` field, or a separate \`description\` field still in flight?
3. Approve deferring seasonal filtering to v0.9?
4. Approve component-rename pass for v0.9?

## Decisions

- **Created \`docs/ROADMAP.md\` rather than expanding CLAUDE.md** — CLAUDE.md was already long, and roadmap status changes too often to live alongside slow-moving codebase guidance. Splitting them keeps each file's audience clean.
- **Did NOT rename components in this branch** — recon proposed \`CreateTownDialog\`, \`ItemDetailSheet\`, \`ItemDetailDropdown\`. Noted in the roadmap as a v0.9 cleanup item; doing it here would mix doc + refactor and slow review.
- **\`vite.config.ts\` branch suffix only fires on non-main/development** — keeps prod and dev-preview footers clean while making audit/feature-branch previews self-identify.

## Test plan

- [x] \`npm run build\` succeeds locally.
- [ ] Vercel preview check appears on this PR; footer reads \`0.8.0-alpha · docs/v0.8-roadmap-audit\`.
- [ ] \`docs/ROADMAP.md\` renders cleanly on GitHub.
- [ ] CLAUDE.md no longer contains a duplicated roadmap section.

**Draft** — awaiting Bea's answers on the 4 questions above before marking ready.