### PR TITLE
fix: restore ItemExpandPanel inline-expand in category tabs

### DIFF
--- a/src/components/ACCanvas.tsx
+++ b/src/components/ACCanvas.tsx
@@ -17,6 +17,7 @@ import ErrorState from './ErrorState';
 import { MuseumHeader } from './MuseumHeader';
 import { TabBar } from './TabBar';
 import { CollectibleRow } from './CollectibleRow';
+import { ItemExpandPanel } from './ItemExpandPanel';
 import { CategoryProgress } from './shared/CategoryProgress';
 import { SearchBar } from './shared/SearchBar';
 import { EmptyState } from './shared/EmptyState';
@@ -99,6 +100,7 @@ export default function ACCanvas() {
     category: CategoryId;
   } | null>(null);
   const [showCreateTown, setShowCreateTown] = useState(false);
+  const [expandedId, setExpandedId] = useState<string | null>(null);
 
   const { data, loading, loadError, reload } = useMuseumData(
     activeTown?.gameId ?? 'ACGCN'
@@ -124,9 +126,10 @@ export default function ACCanvas() {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [data.art.length, loading, activeTab]);
 
-  // Reset per-tab search query when tab changes
+  // Reset per-tab search query and expanded item when tab changes
   useEffect(() => {
     setQuery('');
+    setExpandedId(null);
   }, [activeTab]);
 
   const totalItems = CATEGORY_ORDER.reduce(
@@ -319,17 +322,38 @@ export default function ACCanvas() {
                 />
                 <div className="space-y-3">
                   {filtered.map(item => (
-                    <CollectibleRow
-                      key={item.id}
-                      item={item}
-                      category={activeCat!}
-                      checked={!!activeTownDonated[item.id]}
-                      onToggle={() => toggle(item.id)}
-                      onClick={() =>
-                        setSelected({ item, category: activeCat! })
-                      }
-                      hemisphere={activeTown?.hemisphere ?? 'NH'}
-                    />
+                    <div key={item.id}>
+                      <CollectibleRow
+                        item={item}
+                        category={activeCat!}
+                        checked={!!activeTownDonated[item.id]}
+                        onToggle={() => toggle(item.id)}
+                        onClick={() => {
+                          if (activeCat === 'art') {
+                            setSelected({ item, category: activeCat! });
+                          } else {
+                            setExpandedId(prev =>
+                              prev === item.id ? null : item.id
+                            );
+                          }
+                        }}
+                        expanded={
+                          activeCat !== 'art'
+                            ? expandedId === item.id
+                            : undefined
+                        }
+                        hemisphere={activeTown?.hemisphere ?? 'NH'}
+                      />
+                      {activeCat !== 'art' && expandedId === item.id && (
+                        <ItemExpandPanel
+                          item={item}
+                          category={activeCat!}
+                          checked={!!activeTownDonated[item.id]}
+                          donatedAt={activeTownDonatedAt[item.id]}
+                          onToggle={() => toggle(item.id)}
+                        />
+                      )}
+                    </div>
                   ))}
                   {filtered.length === 0 && (
                     <EmptyState
@@ -354,7 +378,8 @@ export default function ACCanvas() {
               letterSpacing: '0.05em',
             }}
           >
-            {import.meta.env.VITE_APP_VERSION}
+            {import.meta.env.VITE_APP_VERSION} ·
+            fix/restore-item-detail-dropdown
           </span>
         </div>
       </div>

--- a/src/components/MuseumHeader.tsx
+++ b/src/components/MuseumHeader.tsx
@@ -47,16 +47,24 @@ export function MuseumHeader({
           </h1>
           <div className="flex items-center gap-2">
             {gameId && GAMES[gameId].hasHemispheres && onHemisphereChange && (
-              <div className="flex rounded-[8px] overflow-hidden" style={{ border: '1px solid rgba(245,233,212,0.3)' }}>
+              <div
+                className="flex rounded-[8px] overflow-hidden"
+                style={{ border: '1px solid rgba(245,233,212,0.3)' }}
+              >
                 {(['NH', 'SH'] as const).map(h => (
                   <button
                     key={h}
                     onClick={() => onHemisphereChange(h)}
                     aria-pressed={hemisphere === h}
-                    title={h === 'NH' ? 'Northern Hemisphere' : 'Southern Hemisphere'}
+                    title={
+                      h === 'NH' ? 'Northern Hemisphere' : 'Southern Hemisphere'
+                    }
                     className="px-2.5 py-1.5 text-[12px] font-medium transition-colors"
                     style={{
-                      backgroundColor: hemisphere === h ? 'rgba(245,233,212,0.3)' : 'transparent',
+                      backgroundColor:
+                        hemisphere === h
+                          ? 'rgba(245,233,212,0.3)'
+                          : 'transparent',
                       color: '#F5E9D4',
                     }}
                   >


### PR DESCRIPTION
## Summary

- **Root cause**: The React Router v6 refactor (PR #38, commit \`2d844c9\`) stripped the inline-expand wiring from \`ACCanvas.tsx\` — removed the \`ItemExpandPanel\` import, \`expandedId\` state, \`expanded\` prop on \`CollectibleRow\`, and the conditional \`<ItemExpandPanel>\` render. \`ItemExpandPanel.tsx\` remained on disk but was orphaned (zero imports).
- **Fix**: Re-wires everything in \`ACCanvas.tsx\` using commit \`84dd4e8\` as reference:
  - Fish, Bugs, Fossils rows expand in-place (accordion) — tapping again collapses
  - Art rows still open the \`DetailModal\` bottom-sheet (unchanged)
  - \`expandedId\` is reset on tab change so no panel leaks when switching tabs
- **Also**: Fixes the same Prettier formatting issue in \`MuseumHeader.tsx\` that's blocking PR #43 CI (needed here since #43 hasn't merged yet)
- **Branch label**: Version footer shows \`v0.8.0-alpha · fix/restore-item-detail-dropdown\` for mobile verification

## Decisions

- Kept \`ItemExpandPanel\` as-is (no rename — per Bea's call, skipping the naming sweep)
- Added \`setExpandedId(null)\` to the tab-change \`useEffect\` — not in the original pre-Router code, but obviously correct: an open panel from Fish tab shouldn't persist when navigating to Bugs

## Test plan

- [ ] \`npm run build\` — passes (no TS errors)
- [ ] \`npm test\` — 54 tests pass
- [ ] \`npm run lint\` — clean
- [ ] Open Fish tab → click row → panel expands in-place with month grid, bells, donate button
- [ ] Click same row again → panel collapses
- [ ] Click different row → previous panel closes, new one opens
- [ ] Switch to Bugs tab → no panel open (expandedId reset)
- [ ] Click Art row → \`DetailModal\` bottom-sheet opens (not inline expand)
- [ ] Verify version footer reads \`v0.8.0-alpha · fix/restore-item-detail-dropdown\`
- [ ] Test across ACGCN, ACWW, ACCF, ACNL, ACNH towns
- [ ] Mobile viewport (device emulation)

🤖 Generated with [Claude Code](https://claude.com/claude-code)