### PR TITLE
chore: sync release/v0.8.1-alpha back to development

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to this project are documented here.
 
-## [v0.8.1] — In Progress
+## [v0.8.1-alpha] — 2026-04-30
 
 ### Added
 - `public/version-history.html` — styled version history &amp; roadmap page, now served at `/version-history.html` on the live site (previously untracked at repo root)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,7 +16,7 @@ See `docs/architecture.md` — deep architectural context (store schema, migrati
 ## Project Overview
 
 Animal Crossing multi-game companion web app. Tracks museum donations (fish, bugs, fossils, art) across multiple towns and games.
-Cozy parchment/GameCube museum aesthetic. **Current version: v0.8.0-alpha shipped 2026-04-29; v0.8.1 in progress**
+Cozy parchment/GameCube museum aesthetic. **Current version: v0.8.1-alpha shipped 2026-04-30; v0.9 in progress**
 Live at: https://animalcrossingwebapp.vercel.app | Dev preview: https://development-animalcrossingwebapp.vercel.app
 
 ## Commands

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "animalcrossingwebapp",
-  "version": "0.8.0-alpha",
+  "version": "0.8.1-alpha",
   "description": "Web companion app for tracking museum donations across all five Animal Crossing main-line games (GCN, WW, CF, NL, NH). Live at https://animalcrossingwebapp.vercel.app/",
   "type": "module",
   "main": "index.js",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -53,24 +53,29 @@ function App() {
         <Route path="*" element={<Navigate to="/" replace />} />
       </Routes>
       <Analytics />
-      {typeof window !== 'undefined' &&
-        window.location.hostname !== 'animalcrossingwebapp.vercel.app' && (
-          <div
-            style={{
-              position: 'fixed',
-              bottom: 8,
-              right: 10,
-              fontSize: 10,
-              color: '#5a4a35',
-              opacity: 0.5,
-              pointerEvents: 'none',
-            }}
-          >
-            v{import.meta.env.VITE_APP_VERSION}
-            {'·'}
-            {import.meta.env.VITE_GIT_BRANCH}
-          </div>
-        )}
+      {typeof window !== 'undefined' && (
+        <div
+          style={{
+            position: 'fixed',
+            bottom: 8,
+            right: 10,
+            fontSize: 10,
+            color: '#5a4a35',
+            opacity: 0.5,
+            pointerEvents: 'none',
+          }}
+        >
+          {window.location.hostname === 'animalcrossingwebapp.vercel.app' ? (
+            <>v{import.meta.env.VITE_APP_VERSION}</>
+          ) : (
+            <>
+              v{import.meta.env.VITE_APP_VERSION}
+              {' · '}
+              {import.meta.env.VITE_GIT_BRANCH}
+            </>
+          )}
+        </div>
+      )}
     </ErrorBoundary>
   );
 }


### PR DESCRIPTION
Back-merge of release prep commits from `release/v0.8.1-alpha` → `development`.

Syncs the version bump (`0.8.0-alpha` → `0.8.1-alpha`), CHANGELOG date stamp, CLAUDE.md version line, and App.tsx version footer update back to development so the branches stay in sync.

Content already reviewed and approved via PR #54. Merging once CI is green.