### PR TITLE
fix(art-tab): clear selected item detail on tab change

### DIFF
--- a/src/components/ACCanvas.tsx
+++ b/src/components/ACCanvas.tsx
@@ -141,10 +141,11 @@ export default function ACCanvas() {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [data.sea_creatures.length, loading, activeTab]);
 
-  // Reset per-tab search query and expanded item when tab changes
+  // Reset per-tab search query, expanded item, and selected detail on tab changes
   useEffect(() => {
     setQuery('');
     setExpandedId(null);
+    setSelected(null);
   }, [activeTab]);
 
   const totalItems = CATEGORY_ORDER.reduce(


### PR DESCRIPTION
## Summary

Clicking an art piece set the `selected` state in ACCanvas, opening the bottom-sheet `DetailModal`. The tab-change `useEffect` reset `query` and `expandedId` but not `selected`, so the modal persisted across tab switches — the `fixed inset-0 z-50` overlay with the large `<h2>` item name remained visible on every tab until the user explicitly pressed the ✕ button.

**Fix:** add `setSelected(null)` to the tab-change effect alongside the existing `query`/`expandedId` resets. One line change.

## Root cause

```ts
// Before — selected not cleared
useEffect(() => {
  setQuery('');
  setExpandedId(null);
}, [activeTab]);

// After — all per-tab transient state cleared together
useEffect(() => {
  setQuery('');
  setExpandedId(null);
  setSelected(null);
}, [activeTab]);
```

## Test plan

- [x] `npm run build` — clean
- [x] `npm test` — 516 tests passing (fix adds no new tests; existing store + utils suites unchanged)
- [ ] Manual: click an art piece → modal opens → switch tabs → modal is gone
- [ ] Manual: close modal via ✕ → normal close still works
- [ ] Manual: close modal via backdrop click → normal close still works
- [ ] Manual: fish/bugs expand panel unaffected (expandedId still cleared as before)

Closes #26
