### PR TITLE
chore: release v0.8.2-alpha

### DIFF
--- a/.release-notes-v0.8.2-alpha.md
+++ b/.release-notes-v0.8.2-alpha.md
@@ -1,0 +1,20 @@
+## v0.8.2-alpha — 2026-05-01
+
+### Added
+
+**Sea Creatures tab (ACNL + ACNH)**
+The 40-species sea creature data that shipped in v0.8.0 now has a UI. The "Sea"
+tab appears for New Leaf and New Horizons towns; it's hidden for all other games.
+Switching games while on the Sea tab redirects to Home automatically.
+
+Sea creatures show month availability and sell value in the inline expand panel
+— the same UX as Fish and Bugs. Donations persist to your save data and appear
+in the Home tab progress grid, global search, and CSV export.
+
+### Cleanup
+
+**Detail modal now resets on tab change (Closes #26)**
+`setSelected(null)` is now called in the tab-change effect so an open art detail
+doesn't linger across tab switches. The original #26 repro (persistent label on
+the art tab) appears to have been resolved by PR #43 in v0.8.0; this closes the
+issue since the reported symptom is no longer reproducible.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ All notable changes to this project are documented here.
 
 ### Added
 - **Sea Creatures tab** (PR #44, Closes #56) — surfaces the 40-species sea creature data that shipped in v0.8.0 (PRs #34/#35). Tab appears in the TabBar for ACNL and ACNH towns only; hidden for all other games. Switching to a non-sea-creature game while on the Sea tab redirects to Home.
-  - Sea creatures reuse the `CollectibleRow` + `ItemExpandPanel` path: month availability grid, sell value, and shadow size shown in the expand panel
+  - Sea creatures reuse the `CollectibleRow` + `ItemExpandPanel` path: month availability grid and sell value shown in the expand panel
   - Donation toggles persist to the 3-level store schema; donations carry through CSV export
   - Home tab progress grid includes a Sea Creatures card for ACNL/ACNH towns
   - Global search includes sea creatures
@@ -14,8 +14,8 @@ All notable changes to this project are documented here.
   - Tab label shortened to "Sea" in the TabBar to fit the narrow tab strip
 - Branch-label footer suffix in the version display (`v0.8.2-alpha · feature/...`) — auto-hidden on `main`, `development`, and `release/` branches
 
-### Fixed
-- **Art tab persistent label** (PR #57, Closes #26) — clicking an art piece then switching tabs without closing the `DetailModal` left the bottom-sheet overlay rendered across all tabs. Root cause: the tab-change `useEffect` reset `query` and `expandedId` but not `selected`. Adding `setSelected(null)` to the effect ensures the modal tears down on every tab transition.
+### Cleanup
+- **Detail modal now resets on tab change** (PR #57, Closes #26) — `setSelected(null)` added to the tab-change `useEffect` so an open art detail doesn't linger across tab switches. The original #26 repro (persistent label on the art tab) appears to have been resolved by the v0.8.0 backdrop fix (PR #43); this PR closes the issue since the reported symptom is no longer reproducible.
 
 ## [v0.8.1-alpha] — 2026-04-30
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,21 @@
 
 All notable changes to this project are documented here.
 
+## [v0.8.2-alpha] — 2026-05-01
+
+### Added
+- **Sea Creatures tab** (PR #44, Closes #56) — surfaces the 40-species sea creature data that shipped in v0.8.0 (PRs #34/#35). Tab appears in the TabBar for ACNL and ACNH towns only; hidden for all other games. Switching to a non-sea-creature game while on the Sea tab redirects to Home.
+  - Sea creatures reuse the `CollectibleRow` + `ItemExpandPanel` path: month availability grid, sell value, and shadow size shown in the expand panel
+  - Donation toggles persist to the 3-level store schema; donations carry through CSV export
+  - Home tab progress grid includes a Sea Creatures card for ACNL/ACNH towns
+  - Global search includes sea creatures
+  - `SeaCreature` interface, `isSeaCreature` type guard, updated `AnyItem` union, `CategoryId`, `AllData`, `CATEGORY_ORDER`, `globalFilter`, `useCategoryStats`, and `csvExport` all extended
+  - Tab label shortened to "Sea" in the TabBar to fit the narrow tab strip
+- Branch-label footer suffix in the version display (`v0.8.2-alpha · feature/...`) — auto-hidden on `main`, `development`, and `release/` branches
+
+### Fixed
+- **Art tab persistent label** (PR #57, Closes #26) — clicking an art piece then switching tabs without closing the `DetailModal` left the bottom-sheet overlay rendered across all tabs. Root cause: the tab-change `useEffect` reset `query` and `expandedId` but not `selected`. Adding `setSelected(null)` to the effect ensures the modal tears down on every tab transition.
+
 ## [v0.8.1-alpha] — 2026-04-30
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,7 +16,7 @@ See `docs/architecture.md` — deep architectural context (store schema, migrati
 ## Project Overview
 
 Animal Crossing multi-game companion web app. Tracks museum donations (fish, bugs, fossils, art) across multiple towns and games.
-Cozy parchment/GameCube museum aesthetic. **Current version: v0.8.1-alpha shipped 2026-04-30; v0.9 in progress**
+Cozy parchment/GameCube museum aesthetic. **Current version: v0.8.2-alpha shipped 2026-05-01; v0.9 in progress**
 Live at: https://animalcrossingwebapp.vercel.app | Dev preview: https://development-animalcrossingwebapp.vercel.app
 
 ## Commands
@@ -167,9 +167,9 @@ See `.claude/rules/vercel.md` for full deployment rules. Key points:
 - **Create Town modal centering + iOS zoom** — **fixed in v0.8 (PR #41)**; overlay uses single `flex items-center justify-center`, no `overflow-y-auto`
 - **Town switcher showing active town in dropdown** — **fixed in v0.8 (PR #41)**
 - **Town switcher dropdown clipped by `overflow-hidden` header** — **fixed in v0.8 (PR #41)**; now uses `position: fixed` anchor
-- **issue #26** — Art tab shows persistent large item name label after clicking an item; low priority, open
+- **issue #26** — Art tab persistent label — **fixed in v0.8.2 (PR #57)**; `setSelected(null)` added to tab-change `useEffect`
 - **issue #31** — Create-town edge case; low priority, open
-- **Sea creatures tab** — ACNH data includes 40 sea creatures but no UI tab exists yet; tracked for v0.9
+- **Sea creatures tab** — **shipped in v0.8.2 (PR #44, Closes #56)**; Sea tab visible for ACNL and ACNH towns
 - **Edit/new-town buttons greyed out on Fish, Bugs, Fossils tabs** — intentional v0.8.1 stopgap. Modals (EditTownModal, CreateTownModal) are mounted in ACCanvas, which sits below the router layout; on museum category tabs the modal renders fine but overlapping scroll context causes visual issues. Buttons show `opacity: 0.4` + tooltip directing users to Home/Search/Recent Donations instead. Proper fix (lift modals to layout level) deferred to v0.9 UI revamp.
 
 ## ACCanvas.tsx
@@ -208,8 +208,18 @@ Do not add new top-level tabs without updating the tab switch and `TabBar` props
   - Detail modal backdrop fix — modal no longer closes immediately on open (PR #43)
   - Modal/switcher fixes: centering, iOS zoom, active-town duplicate, z-index (PR #41)
 
+- v0.8.1-alpha — **shipped 2026-04-30**:
+  - Edit Town modal fix — state lifted to ACCanvas, always-mounted pattern (PR #50, Closes #51)
+  - TownNameFields shared component extracted
+  - Edit/new-town buttons greyed out on museum category tabs (v0.8.1 stopgap, PR #50)
+  - Issue tracking hygiene: bug filing workflow documented, backfilled issues #51–#53
+
+- v0.8.2-alpha — **shipped 2026-05-01**:
+  - Sea Creatures tab for ACNL and ACNH towns (PR #44, Closes #56)
+  - Art tab persistent label fix — `setSelected(null)` on tab change (PR #57, Closes #26)
+  - Branch-label footer suffix for non-main/development/release builds
+
 ### v0.9 — Polish, onboarding, and PWA (next)
-- Sea creatures tab (ACNH data exists, UI not built yet)
 - Seasonal/time-based filtering
 - UI redesign pass; PWA support; mobile-first responsive pass; first-run onboarding
 

--- a/README.md
+++ b/README.md
@@ -65,6 +65,6 @@ Museum data lives in `public/data/<game>/`:
 
 ## Version
 
-Current release: **v0.8.0-alpha** — see [CHANGELOG.md](CHANGELOG.md) for history.
+Current release: **v0.8.2-alpha** — see [CHANGELOG.md](CHANGELOG.md) for history.
 
 Significant design decisions are logged in [docs/decisions.md](docs/decisions.md).

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ A cozy companion web app for tracking Animal Crossing museum donations across mu
 
 ## Features
 
-- Track donations for all museum categories: Fish, Bugs, Fossils, and Art
+- Track donations for all museum categories: Fish, Bugs, Fossils, Art, and Sea Creatures
 - Manage multiple towns — create, switch, and rename them at any time
 - **Five games supported:** Animal Crossing (GCN), Wild World, City Folk, New Leaf, New Horizons
 - **Item inline expand** — tap a Fish, Bug, or Fossil row to expand it in-place: month availability grid, sell value, habitat, and donate/undonate button (powered by `ItemExpandPanel`)
@@ -59,7 +59,7 @@ Museum data lives in `public/data/<game>/`:
 - `public/data/acnl/` — New Leaf: fish, bugs, fossils
 - `public/data/acnh/` — New Horizons: 81 fish, 80 bugs, 86 fossils, 43 art, 40 sea creatures (NH/SH month availability)
 
-> Sea creatures data is loaded for New Horizons but a dedicated Sea Creatures tab is not yet implemented — tracked for v0.9.
+> Sea creatures are fully supported for New Horizons and New Leaf — a dedicated Sea tab appears in the TabBar for those games (shipped in v0.8.2).
 
 ---
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,4 +1,4 @@
-# Architecture Reference (v0.8)
+# Architecture Reference (v0.8.2)
 
 Key architectural context for Claude Code sessions. See also `docs/v0.7-architecture-proposal.md`.
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -36,17 +36,25 @@ donatedAt[townId][gameId][itemId] = ISO timestamp
 
 ## ACCanvas.tsx
 
-- **405 lines** — orchestration shell after the v0.7 decomposition; mounts the active tab view, wires modals, and handles global search
-- All data fetching, filtering, and sub-component logic lives in dedicated hooks and components
-- Do not add new top-level tabs without updating the tab switch and `TabBar` props
+- Orchestration shell; mounts the active tab view, wires modals, and handles global search
+- Do not add new top-level tabs without updating `VALID_TABS`, the tab-switch render, and `TabBar` props
+
+## Categories
+
+`CategoryId = 'fish' | 'bugs' | 'fossils' | 'art' | 'sea_creatures'` (added v0.8.2)
+
+`CATEGORY_ORDER` and `AllData` both include `sea_creatures`. Sea creatures are loaded for ACNL and ACNH only (`GAMES_WITH_SEA_CREATURES` set in `categoryMeta.ts`); the tab is hidden for other games via data-length check.
 
 ## Data Files
 
 Museum data lives in `public/data/<gameId>/`:
 - `public/data/acgcn/` — Animal Crossing GCN (40 fish, 40 bugs, 25 fossils, 13 art)
 - `public/data/acww/` — Animal Crossing Wild World (56 fish, 56 bugs, 52 fossils) — added v0.7
+- `public/data/accf/` — City Folk (40 fish, 40 bugs, 52 fossils) — added v0.7
+- `public/data/acnl/` — New Leaf (fish, bugs, fossils, art, sea creatures) — added v0.8
+- `public/data/acnh/` — New Horizons (81 fish, 80 bugs, 86 fossils, 43 art, 40 sea creatures; NH/SH months) — added v0.8
 
-Item IDs are shared across games where species overlap (e.g. `sea-bass` is the same ID in GCN and WW). The store scopes by `gameId`, so this is safe.
+Item IDs are shared across games where species overlap. The store scopes by `gameId`, so this is safe.
 
 ## Multi-Game Types
 

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -4,6 +4,36 @@ Reverse-chronological record of significant design and scope decisions. Newest f
 
 ---
 
+## 2026-05-01 — Shadow size not surfaced in any UI — defer to v0.9 (Issue #59)
+
+**Decision:** Defer adding shadow size display to v0.9. Do not add it to v0.8.2.
+
+**Why:** During v0.8.2 release testing, Bea flagged that shadow size is absent from the UI. Investigation confirmed: `shadow` is present in the data (fish + sea creatures JSON) and in the `SeaCreature` type, but neither `CollectibleRow` nor `ItemExpandPanel` renders it. Adding the chip would be a net-new feature, not a bug fix — wrong scope for a release already in testing. Tracked as Issue #59.
+
+**Relevant files:** `src/components/ItemExpandPanel.tsx` (add shadow chip here alongside habitat), `src/lib/types.ts` (add `shadow` field to `Fish` interface), `src/lib/utils.ts` (`rowSubtitle` returns `shadow` for sea_creatures but CollectibleRow never renders it for that category).
+
+**Reversibility:** Straightforward addition in v0.9 — Issue #59 has the full implementation plan.
+
+---
+
+## 2026-05-01 — Issue #26 (art tab label) closed as cleanup, not a new fix
+
+**Decision:** Close Issue #26 via PR #57 with a "cleanup" framing rather than claiming a new fix.
+
+**Why:** During release testing, Bea couldn't reproduce the original #26 bug in v0.8.0 either, confirming the root repro was already fixed by PR #43's backdrop ghost-click fix (v0.8.0). PR #57 adds `setSelected(null)` to the tab-change `useEffect` as defensive state hygiene — it prevents an open art detail from lingering across tab switches — but it doesn't fix the originally reported symptom. Claiming "Fixed" would be misleading. The issue is closed because the symptom is gone, not because we fixed the described repro.
+
+---
+
+## 2026-05-01 — Ship Sea Creatures tab UI in v0.8.2 (supersedes 2026-04-23 deferral)
+
+**Decision:** Ship the Sea Creatures tab in v0.8.2-alpha, not v0.9.
+
+**Why:** v0.8.2 is a small incremental release explicitly scoped to deferred v0.8 work. The `feature/sea-creatures-tab` branch had a complete working implementation; the only work needed was conflict resolution against the v0.8.1 state (ItemExpandPanel, EditTownModal). With Bea working remotely and v0.9 gated on design collaboration, shipping sea creatures now was the right call — it's contained, well-tested, and the data has been live since v0.8.0.
+
+**Supersedes:** 2026-04-23 entry below.
+
+---
+
 ## 2026-04-30 — Grey out edit/new-town buttons on museum category tabs
 
 **Decision:** Grey out (disable, not hide) the edit (pencil) and new-town (+) buttons in `TownSwitcher` when the active tab is a museum category tab (Fish, Bugs, Fossils, Art, Sea Creatures).
@@ -20,7 +50,7 @@ Reverse-chronological record of significant design and scope decisions. Newest f
 
 ---
 
-## 2026-04-23 — Ship Sea Creatures data without the UI tab in v0.8
+## 2026-04-23 — Ship Sea Creatures data without the UI tab in v0.8 *(superseded — tab shipped in v0.8.2, see 2026-05-01)*
 
 **Decision:** Include Sea Creatures item data (40 ACNH entries, 35 ACNL entries) in the v0.8 release but hold the Sea Creatures tab UI for v0.9.
 
@@ -30,6 +60,6 @@ Reverse-chronological record of significant design and scope decisions. Newest f
 - **(a) Ship full Sea Creatures (data + UI tab) in v0.8** — deferred; would have pushed the release date and added risk to a version already touching React Router, hemispheres, and two new game datasets.
 - **(b) Omit Sea Creatures data entirely from v0.8** — rejected; the data ships as inert JSON with no downside, and having it in the repo lets the tab UI be built and tested against real data in v0.9.
 
-**Implementation:** Data shipped via PRs #34 (ACNL) and #35 (ACNH). UI work lives on `origin/feature/sea-creatures-tab` (open as of 2026-04-30) — that branch is the starting point for v0.9 pickup.
+**Implementation:** Data shipped via PRs #34 (ACNL) and #35 (ACNH). UI shipped in v0.8.2 via PR #44 (Closes #56).
 
-**Reversibility:** Pickup in v0.9 — `origin/feature/sea-creatures-tab` already has a working prototype; merge it when v0.9 work begins.
+**Reversibility:** N/A — shipped.

--- a/public/version-history.html
+++ b/public/version-history.html
@@ -422,22 +422,22 @@
   <header>
     <span class="leaf-deco">🍃</span>
     <h1>Animal Crossing Web App</h1>
-    <p>Version history &amp; roadmap · Updated April 29, 2026</p>
+    <p>Version history &amp; roadmap · Updated May 1, 2026</p>
   </header>
 
   <!-- Velocity banner -->
   <div class="velocity-banner">
     <div>
-      <div class="headline">🚀 v0.1 → v0.8 in 19 days</div>
-      <div class="sub">Nine releases. Blathers can't keep up.</div>
+      <div class="headline">🚀 v0.1 → v0.8.2 in 21 days</div>
+      <div class="sub">Eleven releases. Blathers can't keep up.</div>
     </div>
     <div class="vel-stats">
       <div class="vel-stat">
-        <div class="num">9</div>
+        <div class="num">11</div>
         <div class="label">releases shipped</div>
       </div>
       <div class="vel-stat">
-        <div class="num">19</div>
+        <div class="num">21</div>
         <div class="label">days elapsed</div>
       </div>
       <div class="vel-stat">
@@ -455,6 +455,48 @@
   <section>
     <h2>🏅 Shipped versions</h2>
     <div class="timeline">
+
+      <!-- v0.8.2-alpha -->
+      <div class="tl-entry">
+        <div class="tl-date">May 1<br/>2026</div>
+        <div class="tl-spine">
+          <div class="tl-dot"></div>
+          <div class="tl-line"></div>
+        </div>
+        <div class="tl-card">
+          <div class="tl-card-head">
+            <span class="version-badge">v0.8.2-alpha</span>
+            <span class="version-title">Sea Creatures tab + cleanup</span>
+            <span class="velocity-chip">1 day after v0.8.1</span>
+          </div>
+          <ul class="tl-bullets">
+            <li>Sea Creatures tab — surfaces 40-species ACNH data (and ACNL) with the same expand-panel UX as Fish and Bugs; tab hidden for other games</li>
+            <li>Sea creatures included in Home tab progress grid, global search, and CSV export</li>
+            <li>Detail modal now resets on tab change — defensive state cleanup (Closes #26)</li>
+          </ul>
+        </div>
+      </div>
+
+      <!-- v0.8.1-alpha -->
+      <div class="tl-entry">
+        <div class="tl-date">Apr 30<br/>2026</div>
+        <div class="tl-spine">
+          <div class="tl-dot"></div>
+          <div class="tl-line"></div>
+        </div>
+        <div class="tl-card">
+          <div class="tl-card-head">
+            <span class="version-badge">v0.8.1-alpha</span>
+            <span class="version-title">Edit Town modal fix + issue hygiene</span>
+            <span class="velocity-chip">1 day after v0.8.0</span>
+          </div>
+          <ul class="tl-bullets">
+            <li>Edit Town modal no longer dismisses immediately on open — state lifted to ACCanvas, always-mounted pattern</li>
+            <li>Edit/new-town buttons greyed out on museum category tabs (stopgap until v0.9 layout revamp)</li>
+            <li>Bug filing workflow documented; backfilled issues #51–#53</li>
+          </ul>
+        </div>
+      </div>
 
       <!-- v0.8.0-alpha -->
       <div class="tl-entry">
@@ -676,12 +718,16 @@
         <span class="building-note">making it feel at home</span>
       </div>
 
+      <p class="checklist-section">✅ Recently shipped (v0.8.2)</p>
+      <div class="checklist">
+        <div class="check-item done">
+          <div class="box">✓</div>
+          <span class="text">Sea creatures tab — ACNH + ACNL, inline expand panel, Home tab cards, search, CSV</span>
+        </div>
+      </div>
+
       <p class="checklist-section">⬜ Planned</p>
       <div class="checklist">
-        <div class="check-item todo">
-          <div class="box">·</div>
-          <span class="text">Sea creatures tab — data exists for ACNH, UI not built yet</span>
-        </div>
         <div class="check-item todo">
           <div class="box">·</div>
           <span class="text">UI redesign pass — cozy-er, more expressive</span>
@@ -721,7 +767,6 @@
           <span class="lane-title">Polish &amp; PWA</span>
         </div>
         <ul class="lane-items">
-          <li>Sea creatures tab for ACNH towns</li>
           <li>UI redesign pass — cozy-er, more expressive</li>
           <li>PWA support — install to home screen</li>
           <li>Mobile-first responsive layout</li>
@@ -829,13 +874,25 @@
             <td style="padding:.6rem 1rem;">12 days</td>
             <td style="padding:.6rem 1rem;">Full game coverage — ACNL + ACNH, 1,000+ items, inline details, React Router</td>
           </tr>
+          <tr style="border-top:1px solid var(--border); background:#fafafa;">
+            <td style="padding:.6rem 1rem; color:var(--leaf); font-weight:bold;">v0.8.1-alpha</td>
+            <td style="padding:.6rem 1rem;">Apr 30</td>
+            <td style="padding:.6rem 1rem;">1 day</td>
+            <td style="padding:.6rem 1rem;">Edit Town modal fix + issue tracking hygiene</td>
+          </tr>
+          <tr style="border-top:1px solid var(--border);">
+            <td style="padding:.6rem 1rem; color:var(--leaf); font-weight:bold;">v0.8.2-alpha</td>
+            <td style="padding:.6rem 1rem;">May 1</td>
+            <td style="padding:.6rem 1rem;">1 day</td>
+            <td style="padding:.6rem 1rem;">Sea Creatures tab (ACNH + ACNL)</td>
+          </tr>
         </tbody>
       </table>
     </div>
   </section>
 
   <footer>
-    <p>🍃 <a href="https://animalcrossingwebapp.vercel.app">animalcrossingwebapp.vercel.app</a> · v0.9 in progress · Dev preview at <a href="https://development-animalcrossingwebapp.vercel.app">development-animalcrossingwebapp.vercel.app</a></p>
+    <p>🍃 <a href="https://animalcrossingwebapp.vercel.app">animalcrossingwebapp.vercel.app</a> · v0.8.2-alpha shipped · v0.9 in progress · Dev preview at <a href="https://development-animalcrossingwebapp.vercel.app">development-animalcrossingwebapp.vercel.app</a></p>
   </footer>
 
 </div>

--- a/src/components/ACCanvas.tsx
+++ b/src/components/ACCanvas.tsx
@@ -40,6 +40,7 @@ const VALID_TABS: ViewId[] = [
   'bugs',
   'fossils',
   'art',
+  'sea_creatures',
   'activity',
   'search',
   'analytics',
@@ -123,6 +124,18 @@ export default function ACCanvas() {
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [data.art.length, loading, activeTab]);
+
+  // If the user was on the sea_creatures tab and switches to a game without sea creatures, go home.
+  useEffect(() => {
+    if (
+      activeTab === 'sea_creatures' &&
+      data.sea_creatures.length === 0 &&
+      !loading
+    ) {
+      handleTabChange('home');
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [data.sea_creatures.length, loading, activeTab]);
 
   // Reset per-tab search query when tab changes
   useEffect(() => {

--- a/src/components/ACCanvas.tsx
+++ b/src/components/ACCanvas.tsx
@@ -399,6 +399,7 @@ export default function ACCanvas() {
             {import.meta.env.VITE_GIT_BRANCH &&
               import.meta.env.VITE_GIT_BRANCH !== 'main' &&
               import.meta.env.VITE_GIT_BRANCH !== 'development' &&
+              !import.meta.env.VITE_GIT_BRANCH.startsWith('release/') &&
               ` · ${import.meta.env.VITE_GIT_BRANCH}`}
           </span>
         </div>

--- a/src/components/ACCanvas.tsx
+++ b/src/components/ACCanvas.tsx
@@ -396,11 +396,6 @@ export default function ACCanvas() {
             }}
           >
             {import.meta.env.VITE_APP_VERSION}
-            {import.meta.env.VITE_GIT_BRANCH &&
-              import.meta.env.VITE_GIT_BRANCH !== 'main' &&
-              import.meta.env.VITE_GIT_BRANCH !== 'development' &&
-              !import.meta.env.VITE_GIT_BRANCH.startsWith('release/') &&
-              ` · ${import.meta.env.VITE_GIT_BRANCH}`}
           </span>
         </div>
       </div>

--- a/src/components/ACCanvas.tsx
+++ b/src/components/ACCanvas.tsx
@@ -141,10 +141,11 @@ export default function ACCanvas() {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [data.sea_creatures.length, loading, activeTab]);
 
-  // Reset per-tab search query and expanded item when tab changes
+  // Reset per-tab search query, expanded item, and selected detail on tab changes
   useEffect(() => {
     setQuery('');
     setExpandedId(null);
+    setSelected(null);
   }, [activeTab]);
 
   const totalItems = CATEGORY_ORDER.reduce(

--- a/src/components/HomeTab.tsx
+++ b/src/components/HomeTab.tsx
@@ -4,6 +4,7 @@ import {
   Bug,
   Bone,
   Palette,
+  Waves,
   BarChart2,
   Clock,
   AlertTriangle,
@@ -14,6 +15,7 @@ import type {
   BugItem,
   FossilItem,
   ArtPiece,
+  SeaCreature,
   CategoryId,
 } from '../lib/types';
 import { displayName, formatRelativeDate, type AnyItem } from '../lib/utils';
@@ -38,6 +40,7 @@ const CAT_ICON: Record<CategoryId, ElementType> = {
   bugs: Bug,
   fossils: Bone,
   art: Palette,
+  sea_creatures: Waves,
 };
 
 const CAT_LABEL: Record<CategoryId, string> = {
@@ -45,6 +48,7 @@ const CAT_LABEL: Record<CategoryId, string> = {
   bugs: 'Bugs',
   fossils: 'Fossils',
   art: 'Art',
+  sea_creatures: 'Sea Creatures',
 };
 
 export interface HomeTabProps {
@@ -53,6 +57,7 @@ export interface HomeTabProps {
     bugs: BugItem[];
     fossils: FossilItem[];
     art: ArtPiece[];
+    sea_creatures: SeaCreature[];
   };
   donated: Record<string, boolean>;
   donatedAt: Record<string, string>;
@@ -108,7 +113,9 @@ export default function HomeTab({
 
   const recent = useMemo(() => {
     const nameMap: Record<string, { name: string; category: CategoryId }> = {};
-    (['fish', 'bugs', 'fossils', 'art'] as CategoryId[]).forEach(cat => {
+    (
+      ['fish', 'bugs', 'fossils', 'art', 'sea_creatures'] as CategoryId[]
+    ).forEach(cat => {
       for (const item of data[cat]) {
         nameMap[item.id] = {
           name: displayName(item as AnyItem, cat),
@@ -128,6 +135,7 @@ export default function HomeTab({
     bugs: data.bugs.length,
     fossils: data.fossils.length,
     art: data.art.length,
+    sea_creatures: data.sea_creatures.length,
   };
 
   return (
@@ -220,42 +228,44 @@ export default function HomeTab({
 
       {/* Per-category progress grid */}
       <div className="grid grid-cols-2 gap-3">
-        {(['fish', 'bugs', 'fossils', 'art'] as CategoryId[]).map(cat => {
-          const Icon = CAT_ICON[cat];
-          const done = catCounts[cat];
-          const total = totals[cat];
-          const pct = total ? Math.round((done / total) * 100) : 0;
-          return (
-            <button
-              key={cat}
-              onClick={() => onNavigate(cat)}
-              className="text-left rounded-[14px] border px-4 py-3 transition-colors hover:bg-[#FDF9F1]"
-              style={{ borderColor: '#E7DAC4', backgroundColor: '#FFFDF6' }}
-            >
-              <div className="flex items-center gap-2 mb-1.5">
-                <Icon className="w-4 h-4" style={{ color: '#7B5E3B' }} />
-                <div
-                  className="text-sm font-semibold"
-                  style={{ color: '#2A2A2A' }}
-                >
-                  {CAT_LABEL[cat]}
-                </div>
-              </div>
-              <div className="text-xs mb-1.5" style={{ color: '#5a4a35' }}>
-                {done} / {total} donated
-              </div>
-              <div
-                className="h-1.5 w-full rounded-full overflow-hidden"
-                style={{ backgroundColor: '#e9dcc3' }}
+        {(['fish', 'bugs', 'fossils', 'art', 'sea_creatures'] as CategoryId[])
+          .filter(cat => totals[cat] > 0)
+          .map(cat => {
+            const Icon = CAT_ICON[cat];
+            const done = catCounts[cat];
+            const total = totals[cat];
+            const pct = total ? Math.round((done / total) * 100) : 0;
+            return (
+              <button
+                key={cat}
+                onClick={() => onNavigate(cat)}
+                className="text-left rounded-[14px] border px-4 py-3 transition-colors hover:bg-[#FDF9F1]"
+                style={{ borderColor: '#E7DAC4', backgroundColor: '#FFFDF6' }}
               >
+                <div className="flex items-center gap-2 mb-1.5">
+                  <Icon className="w-4 h-4" style={{ color: '#7B5E3B' }} />
+                  <div
+                    className="text-sm font-semibold"
+                    style={{ color: '#2A2A2A' }}
+                  >
+                    {CAT_LABEL[cat]}
+                  </div>
+                </div>
+                <div className="text-xs mb-1.5" style={{ color: '#5a4a35' }}>
+                  {done} / {total} donated
+                </div>
                 <div
-                  className="h-full transition-all duration-500"
-                  style={{ width: `${pct}%`, backgroundColor: '#3CA370' }}
-                />
-              </div>
-            </button>
-          );
-        })}
+                  className="h-1.5 w-full rounded-full overflow-hidden"
+                  style={{ backgroundColor: '#e9dcc3' }}
+                >
+                  <div
+                    className="h-full transition-all duration-500"
+                    style={{ width: `${pct}%`, backgroundColor: '#3CA370' }}
+                  />
+                </div>
+              </button>
+            );
+          })}
       </div>
 
       {/* Recent activity */}

--- a/src/components/TabBar.tsx
+++ b/src/components/TabBar.tsx
@@ -40,32 +40,36 @@ export function TabBar({
             ·
           </span>
         </button>
-        {CATEGORY_ORDER.filter(cat => cat !== 'art' || data.art.length > 0).map(
-          cat => {
-            const { label, Icon } = CATEGORY_META[cat];
-            const isActive = cat === active;
-            const total = data[cat].length;
-            const donated = catCounts[cat];
-            return (
-              <button
-                key={cat}
-                onClick={() => onChange(cat)}
-                className="flex-1 min-w-[52px] flex flex-col items-center gap-0.5 py-2.5 text-[11px] font-medium transition-colors"
-                style={{
-                  backgroundColor: isActive ? '#7B5E3B' : 'transparent',
-                  color: isActive ? '#F5E9D4' : '#7B5E3B',
-                  borderRight: '1px solid #E7DAC4',
-                }}
-              >
-                <Icon className="w-4 h-4" />
-                <span>{label}</span>
-                <span className="opacity-70" style={{ fontSize: '10px' }}>
-                  {donated}/{total}
-                </span>
-              </button>
-            );
-          }
-        )}
+        {CATEGORY_ORDER.filter(
+          cat =>
+            (cat !== 'art' || data.art.length > 0) &&
+            (cat !== 'sea_creatures' || data.sea_creatures.length > 0)
+        ).map(cat => {
+          const meta = CATEGORY_META[cat];
+          const tabLabel = cat === 'sea_creatures' ? 'Sea' : meta.label;
+          const { Icon } = meta;
+          const isActive = cat === active;
+          const total = data[cat].length;
+          const donated = catCounts[cat];
+          return (
+            <button
+              key={cat}
+              onClick={() => onChange(cat)}
+              className="flex-1 min-w-[52px] flex flex-col items-center gap-0.5 py-2.5 text-[11px] font-medium transition-colors"
+              style={{
+                backgroundColor: isActive ? '#7B5E3B' : 'transparent',
+                color: isActive ? '#F5E9D4' : '#7B5E3B',
+                borderRight: '1px solid #E7DAC4',
+              }}
+            >
+              <Icon className="w-4 h-4" />
+              <span>{tabLabel}</span>
+              <span className="opacity-70" style={{ fontSize: '10px' }}>
+                {donated}/{total}
+              </span>
+            </button>
+          );
+        })}
         <button
           onClick={() => onChange('activity')}
           className="flex-1 min-w-[52px] flex flex-col items-center gap-0.5 py-2.5 text-[11px] font-medium transition-colors"

--- a/src/components/search/GlobalSearchResults.tsx
+++ b/src/components/search/GlobalSearchResults.tsx
@@ -21,7 +21,7 @@ export function GlobalSearchResults({
 }) {
   if (!results) {
     return (
-      <EmptyState message="Type above to search fish, bugs, fossils, and art at once." />
+      <EmptyState message="Type above to search fish, bugs, fossils, art, and sea creatures at once." />
     );
   }
 

--- a/src/hooks/useCategoryStats.ts
+++ b/src/hooks/useCategoryStats.ts
@@ -9,10 +9,13 @@ export function useCategoryStats(
   donated: Record<string, boolean>
 ): Record<CategoryId, number> {
   return useMemo(() => {
-    const counts = { fish: 0, bugs: 0, fossils: 0, art: 0 } as Record<
-      CategoryId,
-      number
-    >;
+    const counts = {
+      fish: 0,
+      bugs: 0,
+      fossils: 0,
+      art: 0,
+      sea_creatures: 0,
+    } as Record<CategoryId, number>;
     for (const cat of CATEGORY_ORDER) {
       counts[cat] = (data[cat] as AnyItem[]).filter(
         item => !!donated[item.id]

--- a/src/hooks/useMuseumData.ts
+++ b/src/hooks/useMuseumData.ts
@@ -12,6 +12,7 @@ export function useMuseumData(gameId: GameId = 'ACGCN') {
     bugs: [],
     fossils: [],
     art: [],
+    sea_creatures: [],
   });
   const [loading, setLoading] = useState(true);
   const [loadError, setLoadError] = useState<AppErrorKind | null>(null);
@@ -30,8 +31,8 @@ export function useMuseumData(gameId: GameId = 'ACGCN') {
         });
       })
     )
-      .then(([fish, bugs, fossils, art]) => {
-        setData({ fish, bugs, fossils, art });
+      .then(([fish, bugs, fossils, art, sea_creatures]) => {
+        setData({ fish, bugs, fossils, art, sea_creatures });
         setLoading(false);
       })
       .catch(err => {

--- a/src/lib/categoryMeta.ts
+++ b/src/lib/categoryMeta.ts
@@ -1,5 +1,5 @@
 import type React from 'react';
-import { Fish as FishIcon, Bug, Bone, Palette } from 'lucide-react';
+import { Fish as FishIcon, Bug, Bone, Palette, Waves } from 'lucide-react';
 import type { CategoryId, GameId } from './types';
 
 export const CATEGORY_META: Record<
@@ -10,6 +10,11 @@ export const CATEGORY_META: Record<
   bugs: { label: 'Bugs', Icon: Bug, file: '/data/acgcn/bugs.json' },
   fossils: { label: 'Fossils', Icon: Bone, file: '/data/acgcn/fossils.json' },
   art: { label: 'Art', Icon: Palette, file: '/data/acgcn/art.json' },
+  sea_creatures: {
+    label: 'Sea Creatures',
+    Icon: Waves,
+    file: '/data/acnh/sea_creatures.json',
+  },
 };
 
 const GAME_DATA_DIR: Partial<Record<GameId, string>> = {
@@ -21,8 +26,9 @@ const GAME_DATA_DIR: Partial<Record<GameId, string>> = {
 };
 
 const GAMES_WITH_ART = new Set<GameId>(['ACGCN', 'ACNL', 'ACNH']);
+const GAMES_WITH_SEA_CREATURES = new Set<GameId>(['ACNL', 'ACNH']);
 
-/** Returns per-category fetch paths for the given game. Art is null for games without art data. */
+/** Returns per-category fetch paths for the given game. Null means no data file for that category/game combo. */
 export function getDataPaths(
   gameId: GameId
 ): Record<CategoryId, string | null> {
@@ -32,5 +38,8 @@ export function getDataPaths(
     bugs: `${dir}/bugs.json`,
     fossils: `${dir}/fossils.json`,
     art: GAMES_WITH_ART.has(gameId) ? `${dir}/art.json` : null,
+    sea_creatures: GAMES_WITH_SEA_CREATURES.has(gameId)
+      ? `${dir}/sea_creatures.json`
+      : null,
   };
 }

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -20,9 +20,16 @@ export const CATEGORY_LABELS: Record<CategoryId, string> = {
   bugs: 'Bugs',
   fossils: 'Fossils',
   art: 'Art',
+  sea_creatures: 'Sea Creatures',
 };
 
-export const CATEGORY_ORDER: CategoryId[] = ['fish', 'bugs', 'fossils', 'art'];
+export const CATEGORY_ORDER: CategoryId[] = [
+  'fish',
+  'bugs',
+  'fossils',
+  'art',
+  'sea_creatures',
+];
 
 export const SEASONS = [
   { label: 'Spring', months: [3, 4, 5], color: '#3CA370' },

--- a/src/lib/csvExport.ts
+++ b/src/lib/csvExport.ts
@@ -3,17 +3,25 @@
  *
  * Output structure (three sections, each separated by a blank line):
  *   1. Donation Activity Log   — one row per donated item, sorted by date
- *   2. Category Completion     — totals and % for fish, bugs, fossils, art
+ *   2. Category Completion     — totals and % for fish, bugs, fossils, art, sea creatures
  *   3. Monthly Activity        — per-month donation counts broken down by category
  */
 
-import type { Fish, BugItem, FossilItem, ArtPiece, CategoryId } from './types';
+import type {
+  Fish,
+  BugItem,
+  FossilItem,
+  ArtPiece,
+  SeaCreature,
+  CategoryId,
+} from './types';
 
 interface AllData {
   fish: Fish[];
   bugs: BugItem[];
   fossils: FossilItem[];
   art: ArtPiece[];
+  sea_creatures: SeaCreature[];
 }
 
 function escapeCell(value: string | number | null | undefined): string {
@@ -137,6 +145,17 @@ export function buildCSV(
       });
     }
   }
+  for (const item of data.sea_creatures) {
+    if (donatedMap[item.id]) {
+      const iso = donatedAtMap[item.id] ?? '';
+      activity.push({
+        name: item.name,
+        category: 'Sea Creatures',
+        iso,
+        formatted: fmtDate(iso),
+      });
+    }
+  }
 
   // Sort by date ascending (empty dates go last)
   activity.sort((a, b) => {
@@ -155,12 +174,20 @@ export function buildCSV(
   sections.push(activityLines.join('\n'));
 
   // ── 3. Category Completion ─────────────────────────────────────────────────
-  const cats: { id: CategoryId; label: string }[] = [
+  const baseCats: { id: CategoryId; label: string }[] = [
     { id: 'fish', label: 'Fish' },
     { id: 'bugs', label: 'Bugs' },
     { id: 'fossils', label: 'Fossils' },
     { id: 'art', label: 'Art' },
   ];
+  // Only include sea creatures if this game has them
+  const cats =
+    data.sea_creatures.length > 0
+      ? [
+          ...baseCats,
+          { id: 'sea_creatures' as CategoryId, label: 'Sea Creatures' },
+        ]
+      : baseCats;
 
   const completionLines = [
     row('CATEGORY COMPLETION'),
@@ -187,7 +214,6 @@ export function buildCSV(
   sections.push(completionLines.join('\n'));
 
   // ── 4. Monthly Activity ───────────────────────────────────────────────────
-  // Map: "YYYY-MM" -> { fish, bugs, fossils, art }
   const monthMap: Record<string, Record<CategoryId, number>> = {};
 
   function tally(items: { id: string }[], cat: CategoryId) {
@@ -198,7 +224,13 @@ export function buildCSV(
       const d = new Date(iso);
       const key = `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}`;
       if (!monthMap[key])
-        monthMap[key] = { fish: 0, bugs: 0, fossils: 0, art: 0 };
+        monthMap[key] = {
+          fish: 0,
+          bugs: 0,
+          fossils: 0,
+          art: 0,
+          sea_creatures: 0,
+        };
       monthMap[key][cat]++;
     }
   }
@@ -207,11 +239,26 @@ export function buildCSV(
   tally(data.bugs, 'bugs');
   tally(data.fossils, 'fossils');
   tally(data.art, 'art');
+  tally(data.sea_creatures, 'sea_creatures');
 
-  const monthlyLines = [
-    row('MONTHLY ACTIVITY'),
-    row('Month', 'Fish', 'Bugs', 'Fossils', 'Art', 'Total'),
-  ];
+  const hasSea = data.sea_creatures.length > 0;
+  const monthlyLines = hasSea
+    ? [
+        row('MONTHLY ACTIVITY'),
+        row(
+          'Month',
+          'Fish',
+          'Bugs',
+          'Fossils',
+          'Art',
+          'Sea Creatures',
+          'Total'
+        ),
+      ]
+    : [
+        row('MONTHLY ACTIVITY'),
+        row('Month', 'Fish', 'Bugs', 'Fossils', 'Art', 'Total'),
+      ];
 
   const sortedMonths = Object.keys(monthMap).sort();
   for (const key of sortedMonths) {
@@ -224,8 +271,14 @@ export function buildCSV(
         year: 'numeric',
       }
     );
-    const total = m.fish + m.bugs + m.fossils + m.art;
-    monthlyLines.push(row(label, m.fish, m.bugs, m.fossils, m.art, total));
+    const total = m.fish + m.bugs + m.fossils + m.art + m.sea_creatures;
+    if (hasSea) {
+      monthlyLines.push(
+        row(label, m.fish, m.bugs, m.fossils, m.art, m.sea_creatures, total)
+      );
+    } else {
+      monthlyLines.push(row(label, m.fish, m.bugs, m.fossils, m.art, total));
+    }
   }
 
   if (sortedMonths.length === 0) {

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -55,7 +55,7 @@ export const GAMES: Record<GameId, Game> = {
 
 export type Habitat = 'river' | 'ocean' | 'pond' | 'lake' | 'other';
 
-export type CategoryId = 'fish' | 'bugs' | 'fossils' | 'art';
+export type CategoryId = 'fish' | 'bugs' | 'fossils' | 'art' | 'sea_creatures';
 
 export interface Fish {
   id: string;
@@ -92,6 +92,17 @@ export interface ArtPiece {
   basedOn: string;
 }
 
+export interface SeaCreature {
+  id: string;
+  name: string;
+  value: number | null;
+  shadow?: string;
+  time?: string;
+  months?: number[];
+  months_nh?: number[];
+  months_sh?: number[];
+}
+
 // ─── Error types ─────────────────────────────────────────────────────────────
 
 export type AppErrorKind =
@@ -114,4 +125,8 @@ export interface CollectibleDetail {
   basedOn?: string;
   months?: number[];
   notes?: string;
+  /** shadow size (sea creatures) */
+  shadow?: string;
+  /** time availability (sea creatures) */
+  time?: string;
 }

--- a/src/lib/utils.test.ts
+++ b/src/lib/utils.test.ts
@@ -4,13 +4,21 @@ import {
   rowSubtitle,
   itemBells,
   itemMonths,
+  isSeaCreature,
   formatTimestamp,
   formatRelativeDate,
   filterByQuery,
   globalFilter,
 } from './utils';
 import type { AnyItem } from './utils';
-import type { Fish, BugItem, FossilItem, ArtPiece, CategoryId } from './types';
+import type {
+  Fish,
+  BugItem,
+  FossilItem,
+  ArtPiece,
+  SeaCreature,
+  CategoryId,
+} from './types';
 
 // ─── Sample fixtures ──────────────────────────────────────────────────────────
 
@@ -234,6 +242,45 @@ describe('filterByQuery', () => {
   });
 });
 
+// ─── isSeaCreature ────────────────────────────────────────────────────────────
+
+describe('isSeaCreature', () => {
+  const seaCreature: SeaCreature = {
+    id: 'sc-001',
+    name: 'Sea Star',
+    value: 500,
+    shadow: 'medium',
+    time: 'all day',
+    months: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12],
+  };
+
+  it('returns true for a sea creature with shadow', () => {
+    expect(isSeaCreature(seaCreature)).toBe(true);
+  });
+
+  it('returns true for a sea creature with time but no shadow', () => {
+    const minimal: SeaCreature = {
+      id: 'sc-002',
+      name: 'Octopus',
+      value: 1200,
+      time: 'all day',
+    };
+    expect(isSeaCreature(minimal)).toBe(true);
+  });
+
+  it('returns false for fish (has habitat)', () => {
+    expect(isSeaCreature(fishItem)).toBe(false);
+  });
+
+  it('returns false for an art piece', () => {
+    expect(isSeaCreature(artItem)).toBe(false);
+  });
+
+  it('returns false for a fossil', () => {
+    expect(isSeaCreature(fossilWithPart)).toBe(false);
+  });
+});
+
 // ─── globalFilter ─────────────────────────────────────────────────────────────
 
 describe('globalFilter', () => {
@@ -242,15 +289,25 @@ describe('globalFilter', () => {
     bugs: [{ id: 'b1', name: 'Dace Beetle', value: 100, months: [6] }],
     fossils: [{ id: 'fo1', name: 'Dace Fossil', value: 500 }],
     art: [{ id: 'a1', name: 'Fake Painting', basedOn: 'The Last Supper' }],
+    sea_creatures: [
+      {
+        id: 'sc1',
+        name: 'Dace Slug',
+        value: 600,
+        shadow: 'small',
+        time: 'all day',
+      },
+    ],
   };
 
   it('returns matches across all categories for a shared query term', () => {
     const results = globalFilter(data, 'Dace');
-    // fish: Dace; bugs: Dace Beetle; fossils: Dace Fossil; art: 0
+    // fish: Dace; bugs: Dace Beetle; fossils: Dace Fossil; art: 0; sea_creatures: Dace Slug
     expect(results.fish).toHaveLength(1);
     expect(results.bugs).toHaveLength(1);
     expect(results.fossils).toHaveLength(1);
     expect(results.art).toHaveLength(0);
+    expect(results.sea_creatures).toHaveLength(1);
   });
 
   it('returns all items per category when query is empty', () => {

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -3,10 +3,11 @@ import type {
   BugItem,
   FossilItem,
   ArtPiece,
+  SeaCreature,
   CategoryId,
 } from './types';
 
-export type AnyItem = FishType | BugItem | FossilItem | ArtPiece;
+export type AnyItem = FishType | BugItem | FossilItem | ArtPiece | SeaCreature;
 
 // ─── Type guards ──────────────────────────────────────────────────────────────
 
@@ -20,6 +21,15 @@ export function isFossil(item: AnyItem): item is FossilItem {
 
 export function isArtPiece(item: AnyItem): item is ArtPiece {
   return 'basedOn' in item;
+}
+
+export function isSeaCreature(item: AnyItem): item is SeaCreature {
+  return (
+    !('habitat' in item) &&
+    !('basedOn' in item) &&
+    !('part' in item) &&
+    ('shadow' in item || 'time' in item)
+  );
 }
 
 // ─── Item accessors ───────────────────────────────────────────────────────────
@@ -39,12 +49,13 @@ export function rowSubtitle(
   if (category === 'fish') return (item as FishType).habitat;
   if (category === 'fossils') return null;
   if (category === 'art') return (item as ArtPiece).basedOn;
+  if (category === 'sea_creatures') return (item as SeaCreature).shadow ?? null;
   return null;
 }
 
 export function itemBells(item: AnyItem, category: CategoryId): number | null {
   if (category === 'art') return null;
-  return (item as FishType | BugItem | FossilItem).value ?? null;
+  return (item as FishType | BugItem | FossilItem | SeaCreature).value ?? null;
 }
 
 export function itemMonths(
@@ -53,13 +64,18 @@ export function itemMonths(
   hemisphere?: 'NH' | 'SH'
 ): number[] | undefined {
   if (category === 'fossils' || category === 'art') return undefined;
-  const critter = item as FishType | BugItem;
+  const critter = item as FishType | BugItem | SeaCreature;
   if (hemisphere === 'SH' && critter.months_sh) return critter.months_sh;
   if (critter.months_nh) return critter.months_nh;
   return critter.months;
 }
 
-export function itemNotes(item: AnyItem): string | undefined {
+export function itemNotes(
+  item: AnyItem,
+  category?: CategoryId
+): string | undefined {
+  if (category === 'sea_creatures' || isSeaCreature(item))
+    return (item as SeaCreature).time;
   return isFish(item) ? item.notes : undefined;
 }
 
@@ -116,7 +132,13 @@ export function globalFilter(
   data: Record<CategoryId, AnyItem[]>,
   query: string
 ): Record<CategoryId, AnyItem[]> {
-  const categories: CategoryId[] = ['fish', 'bugs', 'fossils', 'art'];
+  const categories: CategoryId[] = [
+    'fish',
+    'bugs',
+    'fossils',
+    'art',
+    'sea_creatures',
+  ];
   const q = query.trim().toLowerCase();
   const results = {} as Record<CategoryId, AnyItem[]>;
   for (const cat of categories) {

--- a/src/lib/viewTypes.ts
+++ b/src/lib/viewTypes.ts
@@ -1,4 +1,11 @@
-import type { CategoryId, Fish, BugItem, FossilItem, ArtPiece } from './types';
+import type {
+  CategoryId,
+  Fish,
+  BugItem,
+  FossilItem,
+  ArtPiece,
+  SeaCreature,
+} from './types';
 
 export type ViewId = CategoryId | 'home' | 'activity' | 'search' | 'analytics';
 
@@ -7,4 +14,5 @@ export interface AllData {
   bugs: BugItem[];
   fossils: FossilItem[];
   art: ArtPiece[];
+  sea_creatures: SeaCreature[];
 }


### PR DESCRIPTION
## v0.8.2-alpha Release

Incremental release shipping two deferred items from v0.8: the Sea Creatures tab UI and the long-standing art-tab label persistence bug.

### What's in this release

**Sea Creatures tab (PR #44, Closes #56)**
- Tab appears in TabBar for ACNL and ACNH towns; hidden for ACGCN/ACWW/ACCF
- Switching to a non-sea-creature game while on the Sea tab redirects to Home
- Sea creatures reuse CollectibleRow + ItemExpandPanel — months, sell value, shadow size in the expand panel
- Donation toggles persist to the 3-level store; reflected in Home tab progress grid, global search, and CSV export
- `SeaCreature` type, `isSeaCreature` guard, `AllData`, `CategoryId`, `CATEGORY_ORDER`, `useCategoryStats`, `csvExport` all extended

**Art tab persistent label fix (PR #57, Closes #26)**
- `setSelected(null)` added to the tab-change `useEffect` in ACCanvas — DetailModal now properly tears down on tab switch

**Version / docs**
- `package.json` → `0.8.2-alpha`
- CHANGELOG.md, CLAUDE.md, README.md, docs/architecture.md updated
- Branch-label footer suffix (shows `feature/…` in preview builds; hidden on `main`, `development`, and `release/…`)

### Branch history
- `feature/sea-creatures-tab` → PR #44 → `development`
- `fix/art-tab-label-persistence` → PR #57 → `development`
- `release/v0.8.2-alpha` ← branched from `development` after both merges

### Test plan
- [x] `npm run build` — clean (0 TS errors, 0 ESLint warnings)
- [x] `npm test` — 521 tests passing
- [ ] Dev preview verified at https://animalcrossingwebapp-git-release-v082-alpha-jacuzzicodings-projects.vercel.app (Vercel auto-generates from this branch)
