### PR TITLE
docs: v0.9.0-beta plan

### DIFF
--- a/docs/v0.9-plan.md
+++ b/docs/v0.9-plan.md
@@ -1,0 +1,660 @@
+# v0.9.0-beta — Implementation Plan
+
+**Status:** In design / Pre-implementation  
+**Target tag:** `v0.9.0-beta`  
+**Planned milestone:** Following v0.8.2-alpha (shipped 2026-05-01)  
+**Document date:** 2026-05-03  
+**Author:** Bea + Claude Code, session 2026-05-03
+
+## Design Handoff References
+
+| Pass | Folder | Covers |
+|---|---|---|
+| v0.9 (first pass) | `design_handoff_v0.9_curator/` | Design language, palette, type scale, all screens incl. CategoryTab sectioning |
+| v0.9.1 (second pass) | `design_handoff_v0.9.1_curator/` | TownManager drawer, GlobalSearchDropdown, Sea Creatures nav integration, `chip-sea` token |
+| v0.9.2 (third pass, most current) | `design_handoff_v0.9.2_curator/` | ProgressMeter 5-segment responsive, scroll-to + highlight, Settings page |
+
+**Read the handoffs in order.** Where a topic is covered by multiple passes, the later pass takes precedence. Treat the v0.9 README as the canonical base spec for anything not overridden by v0.9.1 or v0.9.2.
+
+> **Codename note:** The design exercise is codenamed "Curator" internally — this appears in folder names and prototype files. "Curator" is **not** a rename of the app. No user-facing copy should say "Curator."
+
+---
+
+## 1. Goals
+
+### User-facing
+
+- Replace the horizontal tab bar + header bar with a persistent left sidebar that shows the active town, per-category donation counts, and nav links. Users always know where they are and how complete each category is.
+- Surface seasonal urgency on the Home tab (leaving-soon shelf, new-this-month shelf, hero stat) so players don't miss catches.
+- Unify town switching, creating, and editing into a single right-side TownManager drawer — no more disjointed modal + dropdown combo.
+- Replace the flat A–Z item list with a sectioned view: Leaving this month → Available now → Out of season → Already donated. Players see what matters first.
+- Make the app fast and clear on mobile (≥390px) with a single breakpoint at 980px.
+- Provide a Settings page with app info and data reset actions.
+
+### Architectural
+
+- Retire `MuseumHeader`, `TabBar`, `TownSwitcher`, `CreateTownModal`, `EditTownModal` — replace with `Sidebar` and `TownManager`.
+- Retire `GlobalSearchBar`, `GlobalSearchResults`, `SearchHistoryPopover` — replace with `GlobalSearchDropdown`.
+- Retire `CategoryProgress` component — progress display moves into the sidebar nav counts and ProgressMeter.
+- Introduce Meadow design tokens as CSS custom properties in `index.css`; retire Varela Round; adopt Fraunces + Inter.
+- Deprecate `playerName` field from the `Town` type.
+- Add a `Settings` route (`/settings`) inside the main column.
+- Add `highlightId` app-level state for scroll-to + expand behavior.
+
+### Version bump rationale
+
+v0.9 shifts the version suffix from `-alpha` to `-beta`. Alpha denoted pre-feature-complete internal builds. Beta denotes feature-complete, publicly accessible builds undergoing broader testing. v0.9.0-beta is the first release with the full redesigned UI — it warrants the milestone bump.
+
+---
+
+## 2. In-Scope Summary
+
+- Meadow design tokens + font swap (Fraunces + Inter replacing Varela Round)
+- Sidebar shell layout (280px fixed left, 980px breakpoint collapses above main)
+- Settings page (About + Danger zone only — see locked decision #3)
+- TownManager drawer (replaces three existing components — see locked decision #1)
+- CollectibleRow + ItemExpandPanel restyle (glyph tile, meta line, sectioning, pills, pulse animation)
+- HomeTab rebuild (hero + month strip + shelves + ProgressMeter)
+- CategoryTab sectioning (4 groups: Leaving / Available / Out of season / Already donated)
+- GlobalSearchDropdown (5 groups for ACNL/ACNH, keyboard nav, search history in localStorage)
+- StatsTab rebuild (4-up or 5-up cards gated by game, updated chart)
+- Mobile responsive verification pass (single 980px breakpoint, touch targets ≥44px)
+- Scroll-to + highlight wiring across Home shelves and GlobalSearchDropdown
+- Sea creatures in ProgressMeter (5th segment, ACNL/ACNH only)
+- Sea creatures in StatsTab (5th card, ACNL/ACNH only — see locked decision #4)
+- Open issues #59, #60, PR #45 housekeeping
+
+---
+
+## 3. Out of Scope for v0.9.0-beta
+
+| Item | Reason |
+|---|---|
+| First-run onboarding flow | Design not yet started; separate parallel workstream |
+| PWA service worker / offline support | Bea explicitly deferred — v0.9 ships manifest + icons + add-to-home only ("PWA-lite") |
+| ACGCN custom Procreate icons | Bea is painting them on her own timeline; monogram glyphs are the v0.9 fallback per the design |
+| Themes beyond Meadow (Parchment, Midnight, Sakura) | Locked decision #2 — see below |
+| Styled confirm dialog in danger zone | v1.0 polish item; native `confirm()` is acceptable for v0.9 |
+| Migration UX for changing a town's game | Game is immutable post-creation (locked decision #1); no migration UI needed |
+| Shadow size display surface (issue #59) | Data + type exist; roll in if cheap during ItemExpandPanel restyle, otherwise carry to v0.9.x |
+| Component renames beyond what's listed | No broader rename pass; only the specific retirements listed in the Glossary |
+
+---
+
+## 4. Locked Design Decisions
+
+These decisions were made explicitly in conversation with Bea on 2026-05-03 and are binding for v0.9.0-beta. Future sessions must not reverse these without a new explicit conversation.
+
+### Decision 1 — Game is immutable post-creation
+
+**Rule:** The TownManager edit form must NOT include a game `<select>`. Only `name` and (for ACNH only) `hemisphere` are editable fields.
+
+**Why:** Changing a town's game would orphan all existing donation data — the 3-level store schema (`donated[townId][gameId][itemId]`) scopes donations under the original `gameId`. A game change would leave ghost data under the old `gameId` with no migration UX. Building migration UX is out of scope for v0.9.
+
+**Implementation note:** The v0.9.2 design (`design_handoff_v0.9.2_curator/addons.jsx` `TownRow` editing state, line 104) still includes the game `<select>`:
+```jsx
+<label className="ac-tm-field">
+  <span className="ac-tm-field-label">Game</span>
+  <select className="ac-tm-input" value={gameId} onChange={e=>setGameId(e.target.value)}>
+    {GAMES.map(g => <option key={g.id} value={g.id}>{g.label}</option>)}
+  </select>
+</label>
+```
+**Drop this field entirely.** Display game as a read-only badge (same as the view state: `<span className="ac-tm-badge">{game?.short}</span>`). Do not carry `gameId` in the `onSave` patch object.
+
+---
+
+### Decision 2 — Ship Meadow theme only
+
+**Rule:** Parchment, Midnight, and Sakura themes are dropped for v0.9. Meadow is the only theme.
+
+**Why:** Bea's words: *"parchment looks a little poorly baked and it is more work to maintain. We can add themes later on."*
+
+**Implications:**
+- No `[data-theme="..."]` attribute branching in CSS or JS
+- No theme selector in Settings (the Appearance section is omitted entirely — see Decision 3)
+- No Zustand persistence for `theme`
+- Varela Round is fully retired — Fraunces + Inter become the sole type stack
+- The v0.9.2 design's Settings → Appearance section (swatch cards) is not built for v0.9
+
+Themes may return in a future v0.9.x or v1.x when there are real alternatives to choose from.
+
+---
+
+### Decision 3 — Settings page = About + Danger zone only
+
+**Rule:** The Settings page ships with two sections: About and Danger zone. The Appearance section (theme switcher) is not built.
+
+**Why:** With only one theme (Meadow), there is no choice to present. An Appearance section with a single card would feel hollow and could mislead users into expecting more options.
+
+**Sections in order:**
+1. **About** — version, source link, live storage summary (town count + total donations), credits/disclaimer
+2. **Danger zone** — "Reset donations for active town" (ghost button, `confirm()`) + "Reset everything" (solid red, `confirm()`)
+
+Appearance returns when there are multiple themes to offer (v0.9.x or v1.x).
+
+---
+
+### Decision 4 — Sea creatures in StatsTab as a 5th card
+
+**Rule:** StatsTab shows 4 category cards for ACGCN/ACWW/ACCF, and 5 category cards (adding sea) for ACNL/ACNH. Gating is identical to home shelves, sidebar nav, and ProgressMeter.
+
+**Why:** Sea is already a first-class category in sidebar nav, ProgressMeter, global search, and home shelves. Excluding it from Stats would be an inconsistency — players would see sea progress everywhere except the Stats view. The v0.9.2 spec doesn't explicitly include this; implementation extends it for consistency.
+
+---
+
+### Decision 5 — `playerName` deprecated from Town type
+
+**Rule:** Remove `playerName` from the `Town` interface in `src/lib/types.ts`. Do not display it or collect it in any form.
+
+**Why:** Bea's words: *"really not important tbh."* It was never surfaced in the v0.9 design. Re-addable later if a user need surfaces.
+
+**Migration:** Zustand's `persist` middleware will simply ignore the field on existing stored data — no migration step required. Any existing `playerName` values in localStorage will be silently dropped on next write.
+
+---
+
+### Decision 6 — Hemisphere exposed only for ACNH
+
+**Rule:** In TownManager (both the create form and the edit form), the hemisphere toggle is only shown when `gameId === "acnh"`.
+
+**Why:** The ACNL sea creature and fish/bug data we shipped is NH-only — no SH month variant exists in our published JSON. Exposing a hemisphere toggle for ACNL would produce incorrect month availability display. This matches the guard condition in the v0.9.2 design.
+
+---
+
+### Decision 7 — Native `confirm()` for danger zone
+
+**Rule:** Both danger zone actions use native browser `confirm()` dialogs for v0.9.
+
+**Why:** A styled confirmation dialog is a v1.0 polish item. The v0.9.2 spec explicitly calls this out: *"Both actions in the demo go through `confirm()` placeholders; production should wire a proper styled confirm dialog (out of scope for this design pass)."*
+
+---
+
+### Decision 8 — Search includes `basedOn` field for art
+
+**Rule:** Art search matches against both `name` and `basedOn` (the real-world painting name). Searching "Leonardo" must surface Famous Painting.
+
+**Why:** This is the current behavior and is explicitly confirmed in the v0.9.2 README: *"`basedOn` matching confirmed in the existing search filter (`it.basedOn.toLowerCase().includes(q)`) — 'Leonardo' surfaces Famous Painting. No change needed."*
+
+Do not break this during GlobalSearchDropdown replacement.
+
+---
+
+### Decision 9 — Sea creatures in GlobalSearchDropdown
+
+**Rule:** For ACNL/ACNH towns, GlobalSearchDropdown shows a 5th result group for sea creatures. Empty groups are hidden, same as other categories. Row treatment matches fish/bugs/fossils.
+
+**Why:** Sea is a first-class category. Excluding it from search while it appears in nav, ProgressMeter, and HomeTab shelves would be a confusing inconsistency. Explicitly confirmed in the v0.9.2 README.
+
+---
+
+### Decision 10 — Scroll-to + highlight behavior
+
+**Rule:** When a Home shelf card or GlobalSearchDropdown result is clicked, the target row is:
+1. Scrolled into view (`scrollIntoView({ behavior: 'smooth', block: 'center' })`)
+2. Auto-expanded (inline detail panel opens)
+3. Highlighted with a 1.4s `accent-soft` background pulse
+
+Behavior is identical on mobile. No separate codepath for small screens.
+
+**CSS (verbatim from v0.9.2 README):**
+```css
+.ac-row-pulse > .ac-row-main { animation: ac-row-pulse 1.4s ease-out; }
+@keyframes ac-row-pulse {
+  0%   { background: var(--accent-soft); }
+  60%  { background: color-mix(in oklch, var(--accent) 16%, transparent); }
+  100% { background: var(--surface-alt); }
+}
+```
+
+**Wiring (verbatim from v0.9.2 README):**
+> `App` owns `highlightId` state. Setters: `jumpTo(cat, id)` (Home cards) and `onJump` in `GlobalSearchDropdown` both `setTab(cat) + setHighlightId(id)`. `CategoryTab` receives `highlightId` + `onHighlightConsumed`. On change, it sets `expanded = highlightId`, waits a frame for the row to render, then queries `[data-row-id="…"]`, scrolls + adds `.ac-row-pulse`, and clears the parent state via `onHighlightConsumed` so re-clicking the same item triggers the effect again. `ItemRow` stamps `data-row-id={item.id}` on its outer div.
+
+---
+
+## 5. Visual Direction
+
+### Palette — Meadow (only theme for v0.9)
+
+All values must be defined as CSS custom properties in `src/index.css` `@theme` block and mirrored in `src/lib/colors.ts`.
+
+| Token | Value | Usage |
+|---|---|---|
+| `--bg` | `#F4EFE3` | Page background |
+| `--surface` | `#FFFDF7` | Card backgrounds |
+| `--surface-alt` | `#F8F2E2` | Hover, expand panel, secondary surfaces |
+| `--ink` | `#23241F` | Primary text |
+| `--ink-soft` | `#5C5848` | Secondary text |
+| `--ink-muted` | `#8A8470` | Tertiary text, eyebrows |
+| `--border` | `#E2D9C3` | Subtle borders, dividers |
+| `--border-strong` | `#CFC4A8` | Hover borders, separator dots, strikethrough |
+| `--accent` | `oklch(0.55 0.09 150)` | Primary moss green — buttons, progress bars |
+| `--accent-soft` | `oklch(0.55 0.09 150 / 0.12)` | Nav active bg, accent pill bg, current-month bg |
+| `--accent-ink` | `oklch(0.32 0.06 150)` | Accent text on light bg |
+| `--warn` | `oklch(0.62 0.12 50)` | Clay — leaving-soon |
+| `--warn-soft` | `oklch(0.62 0.12 50 / 0.14)` | Warn pill bg |
+| `--chip-fish` | `oklch(0.62 0.08 230)` | Fish category tint |
+| `--chip-bugs` | `oklch(0.6 0.1 130)` | Bugs category tint |
+| `--chip-fossils` | `oklch(0.55 0.06 60)` | Fossils category tint |
+| `--chip-art` | `oklch(0.58 0.08 320)` | Art category tint |
+| `--chip-sea` | `oklch(0.58 0.09 200)` | Sea creatures category tint (v0.9.1) |
+
+Category chip colors are **identity tokens** — per v0.9.1 README: *"Category chip colors are identity tokens — they should remain consistent across all themes. Only `accent`, `bg`, `surface`, and `ink` shift between themes."*
+
+### Typography
+
+- **Display:** `'Fraunces', Georgia, serif` — 9..144 opsz axis. Weights 400/500/600. Italic 400/500 for accents.
+- **UI:** `'Inter', system-ui, sans-serif` — weights 400/500/600/700.
+- Load both via Google Fonts. Remove the Varela Round `@import` from `src/index.css`.
+
+| Usage | Spec |
+|---|---|
+| Hero headline | Fraunces 38 / 400 / lh 1.15 / tracking -0.02em |
+| Category h1 | Fraunces 44 / 400 / lh 1.0 / tracking -0.02em |
+| Card / shelf title | Fraunces 24 / 500 / lh 1.2 / tracking -0.01em |
+| Section eyebrow | Inter 11 / 600 / lh 1.4 / tracking 0.12em / UPPERCASE |
+| Body | Inter 14 / 400 / lh 1.5 / tracking -0.005em |
+| Row name | Inter 14 / 500 |
+| Row meta | Inter 12 / 400 |
+| Stat value | Fraunces 22 / 500 / tracking -0.01em |
+| Tabular numbers | `font-variant-numeric: tabular-nums` everywhere counts/values appear |
+
+### Spacing and Radii
+
+- Card radius: 12px (lists, stat cards), 14px (hero cards, town card)
+- Pill radius: 999px
+- Button radius: 8px; glyph tile: 8–10px
+- Section gaps: 36px between hero/shelves/groups; 28px between groups
+- Sidebar padding: 28×22px; main column padding: 32×48px (24×20px mobile)
+- No box shadows. Hover lift is `transform: translateY(-1px)` + border color change only.
+
+### Motion
+
+- Row background + card border + donate button opacity hover transitions: 0.12s
+- Chevron rotation: 0.18s
+- Scroll-to + highlight: `scrollIntoView({ behavior: 'smooth', block: 'center' })` + 1.4s ease-out pulse (see Decision 10 CSS)
+
+### Mobile breakpoint
+
+Single breakpoint at **980px**. Below 980px:
+- Sidebar stacks above main column (not hidden)
+- ProgressMeter 5-segment wraps to 2 rows (`.ac-meter-5` modifier — see Phase 6)
+- Main column padding reduces to 24×20px
+
+TownManager collapses to bottom sheet at ≤**720px**.  
+Settings page sections collapse at ≤**700px**.
+
+---
+
+## 6. Implementation Phasing
+
+Phases are ordered by dependency. Each phase targets the `development` branch via PR on its own feature branch. Each PR must include: CHANGELOG entry, CLAUDE.md updates, passing `npm run build` + `npm test`.
+
+Parallel work is allowed within a phase where components are independent. The phase order itself is locked.
+
+---
+
+### Phase 1 — Tokens + Fonts
+
+**Branch:** `feature/v09-phase-1-tokens`  
+**Goal:** Pre-work only. No visible UI changes.
+
+**Work:**
+- Add Meadow CSS custom properties to `src/index.css` `@theme` block (all tokens from section 5)
+- Add `@import` for Fraunces (variable, weights 400/500/600) + Inter (400/500/600/700) via Google Fonts
+- Remove Varela Round `@import` and any `font-family: 'Varela Round'` declarations
+- Update `src/lib/colors.ts`: add a `meadow` export alongside the existing `colors` export; keep `colors` intact as it may still be referenced elsewhere until later phases clean it up
+- Add `--chip-sea` to the token set
+
+**Files likely affected:** `src/index.css`, `src/lib/colors.ts`
+
+**Definition of done:** Build passes; no font flash; grep confirms zero remaining `Varela Round` references.
+
+---
+
+### Phase 2 — Sidebar + Shell Layout
+
+**Branch:** `feature/v09-phase-2-sidebar`  
+**Goal:** Replace `MuseumHeader` + `TabBar` + `TownSwitcher` with a 280px left sidebar. React Router routes and URL structure are fully preserved.
+
+**Work:**
+- Create `src/components/Sidebar.tsx` — CSS grid `280px 1fr`, sticky full-height sidebar, max-width 1440px centered
+- Sidebar contents (top → bottom per v0.9 README):
+  - Brand: museum-roof SVG monogram (38×38) + app wordmark (Fraunces 20/600) + italic sub
+  - Active town card: eyebrow "ACTIVE TOWN", town name (Fraunces 22/500), meta line with game + hemisphere, "Switch town ›" link that opens TownManager (stub for Phase 4)
+  - Nav: vertical list, `<NavLink>` per tab. Each shows label left + `donated/total` count right (tabular-nums, dimmed slash). Active: `accent-soft` bg + `accent-ink` text + 500 weight + 9px radius. Hover: `surface-alt` bg.
+  - Sea entry gated on `gameId in {acnl, acnh}`
+  - Footer: Export CSV link + Settings link (routes to `/settings`, Phase 3), 1px top border
+- Below 980px: sidebar stacks above main (CSS grid row change, not a hidden/toggle)
+- Remove `MuseumHeader.tsx`, `TabBar.tsx`, `TownSwitcher.tsx` (or mark as dead — clean delete if no other consumers)
+- Update `App.tsx` + `ACCanvas.tsx` to mount `Sidebar` instead of the old header/tab pattern
+- Wire existing `useCategoryStats` hook into sidebar nav counts
+
+**Files likely affected:** `src/App.tsx`, `src/components/ACCanvas.tsx`, `src/components/MuseumHeader.tsx` (delete), `src/components/TabBar.tsx` (delete), `src/components/TownSwitcher.tsx` (delete), new `src/components/Sidebar.tsx`
+
+**Dependencies:** Phase 1 (tokens must exist)
+
+**Definition of done:** All 5 tab routes load correctly; counts display; nav active state tracks URL; sea nav entry appears/disappears by game; 980px sidebar stacks above main.
+
+---
+
+### Phase 3 — Settings Page
+
+**Branch:** `feature/v09-phase-3-settings`  
+**Goal:** Full-page settings route. Two sections: About + Danger zone.
+
+**Work:**
+- Create `src/components/SettingsPage.tsx` — full-page route inside main column; when mounted, main column renders `<SettingsPage>` instead of the active tab
+- Add `/settings` route in `App.tsx` router; sidebar Settings link navigates to it; any tab click or Esc closes it (navigate back to active town/tab)
+- **About section:** `dl/dt/dd` list in a single card — version label (`v0.9.0-beta`), source (GitHub link, `target="_blank"`), live storage summary (derive from store: town count, total donations), credits disclaimer ("Companion app for the Animal Crossing series. Not affiliated with Nintendo.")
+- **Danger zone section:** Red-tinted card (`oklch(0.62 0.12 25)` family per v0.9.2). Two actions:
+  - "Reset donations for active town" — ghost button, `confirm()` guard, calls store action
+  - "Reset everything" — solid red button, `confirm()` guard, clears towns + donations + search history
+- Responsive: sections collapse at ≤700px; title shrinks 56→40px; danger buttons full-width at ≤700px
+- Esc key closes settings (navigate back)
+- **No Appearance section** — locked decision #3
+
+**Files likely affected:** `src/App.tsx` (new route), new `src/components/SettingsPage.tsx`, `src/lib/store.ts` (confirm reset actions exist)
+
+**Dependencies:** Phase 2 (sidebar footer link must exist to wire)
+
+**Definition of done:** Settings route loads; About data is live (not hardcoded); both danger zone actions work with `confirm()`; Esc navigates back; responsive at 700px.
+
+---
+
+### Phase 4 — TownManager Drawer
+
+**Branch:** `feature/v09-phase-4-townmanager`  
+**Goal:** Replace `CreateTownModal`, `EditTownModal`, and the stub "Switch town" link from Phase 2 with a single right-side TownManager drawer.
+
+**Work:**
+- Create `src/components/TownManager.tsx` — right-side drawer, 420px wide, scrim overlay, mounts at **layout level** (in `App.tsx`, above the router outlet), so it renders on all routes including category tabs. This resolves the v0.8.1 stopgap (greyed-out buttons).
+- View state: list of towns. Each row shows radio mark, town name, game badge (short label, e.g. "NL"), game full name, hemisphere (if ACNH), donated count.
+- Active town: `--accent` border, filled `●` mark
+- Edit state (row-level inline): **`name` field only** + hemisphere toggle (ACNH only). **No game `<select>`.** Game displayed as read-only badge. (Locked decision #1)
+- Save patch: `{ name, hemisphere: gameId === "acnh" ? hemisphere : null }` — never includes `gameId`
+- Create form ("+ New town" sticky CTA in footer): `name` field + game selector (new towns may choose any game) + hemisphere toggle (ACNH only). Game is set at creation and becomes immutable.
+- Delete: allowed if `towns.length > 1`; uses native `confirm()`. Not allowed for last remaining town.
+- Mobile: bottom sheet at ≤720px
+- Esc closes drawer
+- Remove `CreateTownModal.tsx`, `EditTownModal.tsx`, `src/components/shared/TownNameFields.tsx` (if no other consumers)
+- Remove the v0.8.1 greyed-out button stopgap from whichever component holds it
+- Deprecate `playerName` from `Town` type in `src/lib/types.ts` (remove field, remove from any form that collected it)
+
+**Files likely affected:** `src/App.tsx`, new `src/components/TownManager.tsx`, `src/components/modals/CreateTownModal.tsx` (delete), `src/components/modals/EditTownModal.tsx` (delete), `src/components/shared/TownNameFields.tsx` (delete), `src/lib/types.ts`, `src/lib/store.ts`
+
+**Dependencies:** Phase 2 (sidebar "Switch town" stub wires to this)
+
+**Definition of done:** All town CRUD works; game cannot be changed for existing towns; new towns can set any game; hemisphere toggle ACNH-only; drawer renders on category tabs without z-index or overflow issues; `playerName` absent from type and all forms; mobile bottom sheet at 720px.
+
+---
+
+### Phase 5 — CollectibleRow + ItemExpandPanel Restyle
+
+**Branch:** `feature/v09-phase-5-rows`  
+**Goal:** Restyle item rows and inline expand panels to match v0.9 design. Wire `data-row-id` and `highlightId` for scroll-to (Decision 10).
+
+**Work:**
+
+**CollectibleRow:**
+- Left: Glyph tile (32×32 rounded square, 1.5px category-tinted border, Fraunces monogram — first two letters of name). Donated state: fills glyph bg with category tint, inverts text to `--surface`.
+- Name (Inter 14/500). Donated: add `●` checkmark in `--accent`; strike through name with 1px `--border-strong` decoration.
+- Meta line (Inter 12/400): `habitat · value ✦` for fish; `location · value` for bugs; `part · value` for fossils; italic `basedOn` for art. Separators use `·` glyph in `--border-strong`, 8px each side.
+- Right: `Leaving soon` warn pill (if leaving this month and not donated) OR `New this month` accent pill (if new this month and not donated). Time pill ("4pm–9am") if not "all day". Animated chevron (0.18s rotation on expand).
+- Hover: `--surface-alt` bg (0.12s).
+- Stamp `data-row-id={item.id}` on outer div.
+- Accept `highlightId` prop; add `.ac-row-pulse` class when `item.id === highlightId`.
+
+**ItemExpandPanel:**
+- Two-column grid: `1fr 240px`, padding `4px 18px 22px 64px` (left-pad aligns with row text after glyph)
+- `--surface-alt` bg, 1px top border
+- Left column: "Available in" eyebrow + 12-cell MonthGrid. Available months: `--accent-soft` bg + `--accent` border. Current month: 1.5px inset accent ring + 600 weight label.
+- Right column: stats stack — bells value (Fraunces 22/500), shadow size (if present), active hours. Optional `notes` quote-block (`--accent`-bordered left). Donate button at bottom: `--accent` bg / `--surface` text; flips to outlined "Donated ✓ — undonate" when donated.
+- Chevron rotates 90° on expand.
+
+**Highlight/scroll wiring (Decision 10):**
+- `CategoryTab` receives `highlightId: string | null` + `onHighlightConsumed: () => void`
+- On `highlightId` change: `setExpanded(highlightId)`, wait one frame, query `[data-row-id="${highlightId}"]`, call `scrollIntoView({ behavior: 'smooth', block: 'center' })`, add `.ac-row-pulse` class, call `onHighlightConsumed()`
+
+**CSS additions:**
+```css
+.ac-row-pulse > .ac-row-main { animation: ac-row-pulse 1.4s ease-out; }
+@keyframes ac-row-pulse {
+  0%   { background: var(--accent-soft); }
+  60%  { background: color-mix(in oklch, var(--accent) 16%, transparent); }
+  100% { background: var(--surface-alt); }
+}
+```
+
+**Files likely affected:** `src/components/CollectibleRow.tsx`, `src/components/ItemExpandPanel.tsx`, `src/components/shared/MonthGrid.tsx`, `src/components/shared/DonateToggle.tsx`, `src/index.css`
+
+**Dependencies:** Phases 1 (tokens), 2 (sidebar exists so layout context is correct)
+
+**Definition of done:** All categories render with new row style; expand panel is two-column; `data-row-id` stamps present; pulse animation fires on highlight; donated state strikes through and fills glyph.
+
+---
+
+### Phase 6 — HomeTab + ProgressMeter
+
+**Branch:** `feature/v09-phase-6-home`  
+**Goal:** Rebuild HomeTab with hero + month strip + leaving/new shelves. Ship ProgressMeter with 5-segment support for ACNL/ACNH.
+
+**Work:**
+
+**ProgressMeter (in Sidebar or HomeTab header):**
+- Derives segment list from `gameId`: 4 segments (fish/bugs/fossils/art) for ACGCN/ACWW/ACCF; 5 segments (+ sea, `--chip-sea`) for ACNL/ACNH
+- Each segment: colored fill proportional to `donated/total`, dot + name label + `n/total` fraction
+- 5-segment responsive behavior (`.ac-meter-5` modifier class):
+  - ≥1180px: full labels with fraction. 8px gap.
+  - 980–1180px: drop fractions, keep dot + name, tighter padding (7px 8px).
+  - ≤980px: wrap to 2 rows, `flex-basis: calc(50% - 3px)`, fractions return.
+- 4-segment: unchanged from the design's default behavior
+
+**HomeTab:**
+- **Hero:** Eyebrow "AVAILABLE IN [MONTH]". Headline (Fraunces 38/400/lh 1.15/tracking -0.02em): `<em>{stillNeeded}</em> creatures still to donate this month.<br><span class="aside">{leavingSoon} are leaving soon.</span>` — italic accent number in `--accent-ink`, warn aside in `--warn` italic.
+- **Month strip:** 12-cell grid in a `--surface` rounded card. Current month: `--accent-soft` bg + `--accent-ink` + 500 weight.
+- **"Leaving end of month" shelf:** `--warn`-colored eyebrow, Fraunces shelf title, count. Cards: 3-column grid, each card shows tinted glyph tile (44×44), name + meta + month dots + warn ⚠ icon.
+- **"Just arrived" shelf:** same card pattern, no warn icon, `--accent`-toned eyebrow.
+- **Latest donations:** `--surface` card, list rows with category dot + item name + category eyebrow + relative time.
+- Sea creatures included in shelves for ACNL/ACNH towns.
+- Cards are clickable: call `jumpTo(cat, id)` which sets `tab` + `highlightId` at App level.
+- `jumpTo` wires to `setTab(cat) + setHighlightId(id)` in App state.
+
+**Files likely affected:** `src/components/HomeTab.tsx`, new or updated `src/components/shared/ProgressMeter.tsx`, `src/index.css` (`.ac-meter-5` rules)
+
+**Dependencies:** Phases 1, 2, 5 (rows must be wired for `highlightId` before `jumpTo` flows end-to-end)
+
+**Definition of done:** Hero stat is accurate for current month; leaving/new shelves show correct items; month strip highlights current month; ProgressMeter shows 4 vs 5 segments by game; shelf card click fires scroll-to + highlight in category tab; sea appears in shelves + ProgressMeter for ACNL/ACNH.
+
+---
+
+### Phase 7 — CategoryTab Sectioning
+
+**Branch:** `feature/v09-phase-7-sections`  
+**Goal:** Group category items into 4 sections instead of a flat A–Z list.
+
+**Section order (groups appear only when non-empty):**
+1. **Leaving this month** — warn-toned eyebrow
+2. **Available now** — accent-toned eyebrow
+3. **Out of season** — muted eyebrow
+4. **Already donated** — muted eyebrow
+
+**Work:**
+- Section header: Inter 11/600/0.12em tracking/UPPERCASE, count right-aligned 12px tabular
+- Section card: `--surface` bg, 1px `--border`, 12px radius, divider lines between rows
+- Month-wrapping logic for "leaving" and "new": an item is "leaving this month" if it's available in the current month but not next month. An item is "new this month" if it's available in the current month but not last month. Handle December→January wrap correctly (month index modulo 12).
+- Items in multiple states: "leaving" takes precedence over "new"; donated items always go to the "Already donated" section regardless of availability.
+- Per v0.9 README: *"Row click: toggles inline expand. Only one row open at a time per category (state lives in CategoryTab)."*
+- Apply `--accent-soft` bg + `--accent` border to "Leaving soon" and "New this month" pill labels (not row bg) as appropriate.
+
+**Files likely affected:** `src/components/ACCanvas.tsx` or a new `src/components/CategoryTab.tsx`, `src/components/CollectibleRow.tsx`
+
+**Dependencies:** Phase 5 (rows restyled), Phase 1 (tokens)
+
+**Definition of done:** All 4 section groups appear in correct order; empty groups hidden; leaving/new month-wrap logic handles December/January correctly; single-expand-at-a-time enforced per tab; donated items always in "Already donated" section.
+
+---
+
+### Phase 8 — GlobalSearchDropdown
+
+**Branch:** `feature/v09-phase-8-search`  
+**Goal:** Replace `GlobalSearchBar`, `GlobalSearchResults`, `SearchHistoryPopover` with `GlobalSearchDropdown`.
+
+**Work:**
+- Create `src/components/search/GlobalSearchDropdown.tsx`
+- Anchored under the search input in the main column topbar. Only active on home tab (`tab === "home"`); other tabs keep per-tab inline search filtering.
+- Three states:
+  1. **Empty / focused with no query:** shows recent searches from localStorage (key: `ac-curator-search-history`, max 8 entries)
+  2. **No results for query:** "No results" empty state
+  3. **Results:** grouped by category (colored dot + count header). Each row: monogram glyph (category-tinted), name, meta line, donated badge
+- 5 groups for ACNL/ACNH towns (fish, bugs, fossils, art, sea). 4 groups for others. Empty groups hidden.
+- **`basedOn` matching preserved** (Decision 8): art matches against both `name` and `basedOn` fields.
+- Keyboard nav: `↑↓` moves between results, `↵` selects (fires `jumpTo` + closes dropdown), `Esc` closes.
+- Selecting a result: calls `jumpTo(cat, id)` which sets tab + highlightId, then closes dropdown.
+- Search history: on result selection, add query to `ac-curator-search-history` in localStorage (trim to 8 entries, deduplicate).
+- Debounce: 150ms (wire through existing `useSearch` hook for debounce logic; replace `SearchHistoryPopover` entirely).
+- Delete `src/components/search/GlobalSearchBar.tsx`, `src/components/search/GlobalSearchResults.tsx`, `src/components/search/SearchHistoryPopover.tsx`
+
+**Files likely affected:** `src/components/search/GlobalSearchDropdown.tsx` (new), `src/hooks/useSearch.ts`, `src/components/ACCanvas.tsx`, deletions of old search components
+
+**Dependencies:** Phases 2 (topbar location), 5 (row/glyph treatment for result rows)
+
+**Definition of done:** Search works for all categories; `basedOn` art search confirmed ("Leonardo" → Famous Painting); keyboard nav ↑↓↵esc functional; history persisted to correct localStorage key; max 8 entries; sea group appears for ACNL/ACNH; selecting result jumps to correct tab + row with pulse.
+
+---
+
+### Phase 9 — StatsTab
+
+**Branch:** `feature/v09-phase-9-stats`  
+**Goal:** Rebuild StatsTab with per-category cards and updated yearly rhythm chart.
+
+**Work:**
+- **Category cards:** 4-up grid for ACGCN/ACWW/ACCF, 5-up for ACNL/ACNH (sea card gated same as nav/ProgressMeter)
+- Each card: eyebrow in category chip color, donated/total in Fraunces big, thin progress bar tinted with chip color, "X% complete" caption
+- **Yearly rhythm chart:** 12 columns, each with stacked bar. BG height = % of max availability across all months. Inner fill (50% accent opacity) = donated fraction within available. Current month column has `--accent` border. Number above each column = items available that month.
+- Sea creatures included in chart calculation for ACNL/ACNH towns (Decision 4).
+- Legend: "Available" / "Already donated"
+- Retire `src/components/views/AnalyticsView.tsx` if it holds the old stats view (or refactor in place).
+
+**Files likely affected:** `src/components/views/AnalyticsView.tsx` (restyle/replace), `src/hooks/useCategoryStats.ts` (extend if sea not already counted for ACNL/ACNH)
+
+**Dependencies:** Phase 1 (tokens), Phase 2 (layout context)
+
+**Definition of done:** 4 vs 5 cards display correctly by game; chart uses correct current month; sea included in chart for ACNL/ACNH; percentage captions accurate; category chip colors correct.
+
+---
+
+### Phase 10 — Mobile Responsive Verification
+
+**Branch:** `feature/v09-phase-10-mobile`  
+**Goal:** Audit and fix any mobile regressions; verify all 980px breakpoint behaviors.
+
+**Checklist:**
+- [ ] Sidebar stacks above main at 980px (not hidden)
+- [ ] TownManager renders as bottom sheet at ≤720px
+- [ ] ProgressMeter 5-segment wraps to 2 rows at ≤980px; 4-segment unchanged
+- [ ] Settings sections collapse at ≤700px; danger buttons full-width
+- [ ] All touch targets ≥44px (nav items, donate toggle, glyph tile, drawer close, row chevron)
+- [ ] Hero headline wraps without overflow at 390px
+- [ ] Scroll-to + highlight works on mobile (identical behavior per Decision 10 spec)
+- [ ] Category section headers + row meta readable at 390px
+- [ ] GlobalSearchDropdown keyboard nav inaccessible without hardware keyboard on mobile — ensure tap-to-select works
+
+**Files likely affected:** `src/index.css`, any component with hardcoded pixel widths
+
+**Dependencies:** All prior phases
+
+**Definition of done:** All checklist items pass at 390px (iPhone SE) and 768px (iPad portrait) viewport simulation.
+
+---
+
+## 7. Open Issues
+
+### Issue #59 — Shadow size not displayed
+
+Shadow size data exists in the JSON and is typed correctly, but has no render surface in `ItemExpandPanel` or elsewhere. The v0.9 ItemExpandPanel spec includes it in the right-column stat stack ("shadow size"). Roll in during Phase 5 if it's trivial (it's just another stat line in the expand panel). If it adds meaningful scope, carry to v0.9.x and leave the issue open.
+
+### Issue #60 — Version footer branch suffix
+
+`App.tsx` version footer always shows `· release/...` suffix on non-prod hostnames. Should hide for branches whose name `startsWith('release/')`. Address during Phase 2 or 10 (the new shell may move or replace the footer entirely). If the footer is retired during the shell rebuild, close #60 as "resolved by design change."
+
+### PR #45 — Stale roadmap docs draft
+
+PR #45 ("docs: v0.8.0-alpha roadmap audit") has been open since 2026-04-29, is never-merged, and is mostly superseded by `docs/decisions.md` and this document. Close it during v0.9 housekeeping with a comment: "Superseded by docs/v0.9-plan.md and docs/decisions.md."
+
+---
+
+## 8. Success Criteria for Tagging v0.9.0-beta
+
+All 10 phases merged to `development`. All of the following must be true:
+
+- [ ] `npm run build` passes with zero TypeScript errors
+- [ ] `npm test` passes
+- [ ] Meadow tokens are the only active theme; no Varela Round font loads
+- [ ] Sidebar renders on all routes; nav counts are accurate; sea entry gated correctly
+- [ ] TownManager creates, edits (name only), activates, and deletes towns correctly; game immutable on edit; hemisphere ACNH-only; `playerName` absent from all forms and types
+- [ ] Settings page has About + Danger zone sections only; reset actions work; Esc closes
+- [ ] Item rows match v0.9 design: glyph, meta line, pills, strikethrough, chevron
+- [ ] CategoryTab sections: Leaving / Available / Out of season / Already donated; month-wrap logic correct
+- [ ] HomeTab: hero stat accurate; shelves correct; month strip; ProgressMeter 4/5 segments; jumpTo works
+- [ ] GlobalSearchDropdown: 5 groups for ACNL/ACNH; `basedOn` art search; keyboard nav; history max 8; jump fires scroll+highlight
+- [ ] StatsTab: 4/5 cards by game; chart includes sea for ACNL/ACNH
+- [ ] Scroll-to + highlight: smooth scroll, auto-expand, 1.4s pulse, works from both Home shelves and search
+- [ ] Mobile: 980px breakpoint; touch targets ≥44px; bottom sheet at 720px; 5-seg ProgressMeter wraps
+- [ ] Dev preview at https://development-animalcrossingwebapp.vercel.app verified manually before tag
+- [ ] CHANGELOG.md has v0.9.0-beta entry; CLAUDE.md updated with new component names and retired names
+- [ ] PR #45 closed with a comment
+- [ ] Issues #59 and #60 assessed: either fixed or explicitly carried with updated labels
+
+---
+
+## 9. Glossary / Vocabulary
+
+### New names (v0.9+)
+
+| New name | Type | Description |
+|---|---|---|
+| `Sidebar` | Component | Left 280px navigation column with brand, active town card, nav links, footer |
+| `TownManager` | Component | Right-side drawer (bottom sheet on mobile) for switch/create/edit/delete towns |
+| `ProgressMeter` | Component | Multi-segment donation progress bar; 4-seg for older games, 5-seg for ACNL/ACNH |
+| `GlobalSearchDropdown` | Component | Unified search dropdown with category groups, keyboard nav, history |
+| `SettingsPage` | Component | Full-page settings route: About + Danger zone |
+| `ac-row-pulse` | CSS class | Keyframe animation class for scroll-to + highlight effect |
+| `ac-meter-5` | CSS class | Modifier for 5-segment ProgressMeter responsive rules |
+| `highlightId` | App state | String or null — the item ID to scroll to and pulse when set |
+| `jumpTo(cat, id)` | Function | Sets active tab to `cat` + sets `highlightId` to `id` |
+| `ac-curator-search-history` | localStorage key | Persists last 8 search queries (max 8, deduplicated) |
+
+### Retired names (deprecated in v0.9)
+
+| Retired name | Replaced by |
+|---|---|
+| `MuseumHeader` | `Sidebar` |
+| `TabBar` | `Sidebar` nav section |
+| `TownSwitcher` | `TownManager` drawer |
+| `CreateTownModal` | `TownManager` create form |
+| `EditTownModal` | `TownManager` row edit |
+| `TownNameFields` | Inline fields in `TownManager` |
+| `GlobalSearchBar` | `GlobalSearchDropdown` |
+| `GlobalSearchResults` | `GlobalSearchDropdown` |
+| `SearchHistoryPopover` | `GlobalSearchDropdown` empty state |
+| `CategoryProgress` | Sidebar nav counts + `ProgressMeter` |
+| `AnalyticsView` | `StatsTab` (refactored in place or replaced) |
+| `playerName` (Town field) | Deprecated — not replaced |
+
+---
+
+## 10. References
+
+| Resource | Path / URL |
+|---|---|
+| Design handoff v0.9 | `design_handoff_v0.9_curator/README.md` |
+| Design handoff v0.9.1 | `design_handoff_v0.9.1_curator/README.md` |
+| Design handoff v0.9.2 (most current) | `design_handoff_v0.9.2_curator/README.md` |
+| Architecture reference | `.claude/rules/architecture.md` |
+| Dev process checklist | `.claude/rules/dev-process.md` |
+| Vercel deployment rules | `.claude/rules/vercel.md` |
+| Project context | `CLAUDE.md` |
+| Decisions log | `docs/decisions.md` |
+| Changelog | `CHANGELOG.md` |
+| Dev preview | https://development-animalcrossingwebapp.vercel.app |
+| Production | https://animalcrossingwebapp.vercel.app |


### PR DESCRIPTION
## Summary

Adds `docs/v0.9-plan.md` — the canonical scope, phasing, and decision record for v0.9.0-beta.

- Covers all 10 implementation phases (tokens → sidebar → settings → TownManager → rows → home → category sections → search → stats → mobile)
- Documents all 10 locked design decisions from the 2026-05-03 session with Bea, including the WHY for each
- References all three design handoff passes: `design_handoff_v0.9_curator/`, `design_handoff_v0.9.1_curator/`, `design_handoff_v0.9.2_curator/`
- **Calls out explicitly** the conflict between the v0.9.2 handoff (which still has a game `<select>` in TownRow's edit form) and locked decision #1 (game is immutable post-creation) — implementation must drop that field, and the plan says so verbatim
- Includes success criteria checklist, glossary of new/retired component names, open issues (#59, #60, PR #45), and a references table

Written now so that future sessions and Bea both have a single source of truth before any implementation work begins. Bea's explicit instruction: "there is a lot of room for error so we can't risk leaving information up to interpretation in the future."

No code changes. Docs only.
