### PR TITLE
v0.9 Phase 1: tokens + fonts (Meadow + Fraunces/Inter)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 All notable changes to this project are documented here.
 
+## [Unreleased] — v0.9.0-beta (in progress)
+
+### Added — Phase 1: tokens + fonts
+- **Meadow design tokens** — full palette added to `src/index.css` `@theme` block as CSS custom properties (`--bg`, `--surface`, `--surface-alt`, `--ink`, `--ink-soft`, `--ink-muted`, `--border`, `--border-strong`, `--accent`, `--accent-soft`, `--accent-ink`, `--warn`, `--warn-soft`, `--chip-fish`, `--chip-bugs`, `--chip-fossils`, `--chip-art`, `--chip-sea`). Mirrored in `src/lib/colors.ts` as the new `meadow` export.
+- **Fraunces** (variable, opsz 9..144, weights 400/500/600 + italic 400/500) and **Inter** (400/500/600/700) loaded via Google Fonts in `index.html` and `src/index.css`. Registered as `--font-display` and `--font-sans` in `@theme`. New `fontStacks` export in `src/lib/colors.ts`.
+
+### Removed — Phase 1
+- **Varela Round** — fully retired. `@import` removed from `src/index.css`, `index.html`, and `public/version-history.html`. Inline `fontFamily: 'Varela Round, ...'` reference in `src/App.tsx` loading state replaced with Inter. Per locked decision #2 in `docs/v0.9-plan.md`, Fraunces + Inter is the sole type stack.
+
+### Notes
+- This phase is plumbing only. No components consume the new tokens yet; visual output is intentionally near-identical to v0.8.2-alpha. Component restyles begin in Phase 5.
+- **Parchment, Midnight, and Sakura themes are intentionally excluded** per locked decision #2 in `docs/v0.9-plan.md` ("ship Meadow only"). The legacy `colors` export in `src/lib/colors.ts` is kept untouched until later phases retire its consumers.
+
 ## [v0.8.2-alpha] — 2026-05-01
 
 ### Added

--- a/index.html
+++ b/index.html
@@ -8,7 +8,7 @@
     <title>Animal Crossing Museum Tracker</title>
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=Varela+Round:wght@400&display=swap" rel="stylesheet">
+    <link href="https://fonts.googleapis.com/css2?family=Fraunces:ital,opsz,wght@0,9..144,400;0,9..144,500;0,9..144,600;1,9..144,400;1,9..144,500&family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
   </head>
   <body>
     <div id="root"></div>

--- a/public/version-history.html
+++ b/public/version-history.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Animal Crossing Web App — Version History & Roadmap</title>
-  <link href="https://fonts.googleapis.com/css2?family=Varela+Round&display=swap" rel="stylesheet" />
+  <link href="https://fonts.googleapis.com/css2?family=Fraunces:opsz,wght@9..144,400;9..144,500;9..144,600&family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet" />
   <style>
     *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
 
@@ -25,7 +25,7 @@
     }
 
     body {
-      font-family: 'Varela Round', sans-serif;
+      font-family: 'Inter', system-ui, sans-serif;
       background: #eef7ee;
       color: var(--ink);
       min-height: 100vh;

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -34,7 +34,7 @@ function App() {
         <span
           style={{
             color: '#7B5E3B',
-            fontFamily: 'Varela Round, sans-serif',
+            fontFamily: "'Inter', system-ui, sans-serif",
             fontSize: 18,
           }}
         >

--- a/src/index.css
+++ b/src/index.css
@@ -1,7 +1,54 @@
+@import url('https://fonts.googleapis.com/css2?family=Fraunces:ital,opsz,wght@0,9..144,400;0,9..144,500;0,9..144,600;1,9..144,400;1,9..144,500&family=Inter:wght@400;500;600;700&display=swap');
+
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
 
+@theme {
+  --color-bg: #F4EFE3;
+  --color-surface: #FFFDF7;
+  --color-surface-alt: #F8F2E2;
+  --color-ink: #23241F;
+  --color-ink-soft: #5C5848;
+  --color-ink-muted: #8A8470;
+  --color-border: #E2D9C3;
+  --color-border-strong: #CFC4A8;
+  --color-accent: oklch(0.55 0.09 150);
+  --color-accent-soft: oklch(0.55 0.09 150 / 0.12);
+  --color-accent-ink: oklch(0.32 0.06 150);
+  --color-warn: oklch(0.62 0.12 50);
+  --color-warn-soft: oklch(0.62 0.12 50 / 0.14);
+  --color-chip-fish: oklch(0.62 0.08 230);
+  --color-chip-bugs: oklch(0.6 0.1 130);
+  --color-chip-fossils: oklch(0.55 0.06 60);
+  --color-chip-art: oklch(0.58 0.08 320);
+  --color-chip-sea: oklch(0.58 0.09 200);
+
+  --font-display: 'Fraunces', Georgia, serif;
+  --font-sans: 'Inter', system-ui, sans-serif;
+}
+
+:root {
+  --bg: #F4EFE3;
+  --surface: #FFFDF7;
+  --surface-alt: #F8F2E2;
+  --ink: #23241F;
+  --ink-soft: #5C5848;
+  --ink-muted: #8A8470;
+  --border: #E2D9C3;
+  --border-strong: #CFC4A8;
+  --accent: oklch(0.55 0.09 150);
+  --accent-soft: oklch(0.55 0.09 150 / 0.12);
+  --accent-ink: oklch(0.32 0.06 150);
+  --warn: oklch(0.62 0.12 50);
+  --warn-soft: oklch(0.62 0.12 50 / 0.14);
+  --chip-fish: oklch(0.62 0.08 230);
+  --chip-bugs: oklch(0.6 0.1 130);
+  --chip-fossils: oklch(0.55 0.06 60);
+  --chip-art: oklch(0.58 0.08 320);
+  --chip-sea: oklch(0.58 0.09 200);
+}
+
 * {
-  font-family: 'Varela Round', sans-serif;
+  font-family: 'Inter', system-ui, sans-serif;
 }

--- a/src/lib/colors.ts
+++ b/src/lib/colors.ts
@@ -7,3 +7,36 @@ export const colors = {
   border: '#E7DAC4', // borders
   muted: '#5a4a35', // secondary/muted text
 } as const;
+
+/**
+ * Meadow theme tokens (v0.9). Mirrors the CSS custom properties defined in
+ * `src/index.css` `@theme` block. Use the CSS vars (`var(--accent)`) for
+ * styling; this export exists for cases where a JS literal is required.
+ *
+ * Color values match the locked palette in docs/v0.9-plan.md §5.
+ */
+export const meadow = {
+  bg: '#F4EFE3',
+  surface: '#FFFDF7',
+  surfaceAlt: '#F8F2E2',
+  ink: '#23241F',
+  inkSoft: '#5C5848',
+  inkMuted: '#8A8470',
+  border: '#E2D9C3',
+  borderStrong: '#CFC4A8',
+  accent: 'oklch(0.55 0.09 150)',
+  accentSoft: 'oklch(0.55 0.09 150 / 0.12)',
+  accentInk: 'oklch(0.32 0.06 150)',
+  warn: 'oklch(0.62 0.12 50)',
+  warnSoft: 'oklch(0.62 0.12 50 / 0.14)',
+  chipFish: 'oklch(0.62 0.08 230)',
+  chipBugs: 'oklch(0.6 0.1 130)',
+  chipFossils: 'oklch(0.55 0.06 60)',
+  chipArt: 'oklch(0.58 0.08 320)',
+  chipSea: 'oklch(0.58 0.09 200)',
+} as const;
+
+export const fontStacks = {
+  display: "'Fraunces', Georgia, serif",
+  sans: "'Inter', system-ui, sans-serif",
+} as const;


### PR DESCRIPTION
## Summary

Phase 1 of the v0.9.0-beta implementation plan ([`docs/v0.9-plan.md` §6 — Phase 1](https://github.com/jacuzzicoding/animalcrossingwebapp/blob/development/docs/v0.9-plan.md#phase-1--tokens--fonts), merged in #62). **Plumbing only** — adds the Meadow design tokens and the new type stack, but does not yet wire them into any component. Visual output should be near-identical to v0.8.2-alpha. Component restyles consuming these tokens begin in Phase 5; the Sidebar and TownManager rebuilds (Phases 2–4) come first.

## Added

- **Meadow palette** — full token set added to `src/index.css` `@theme` block as CSS custom properties:
  - Surfaces: `--bg`, `--surface`, `--surface-alt`
  - Text: `--ink`, `--ink-soft`, `--ink-muted`
  - Borders: `--border`, `--border-strong`
  - Accent: `--accent`, `--accent-soft`, `--accent-ink` (oklch moss green)
  - Warn: `--warn`, `--warn-soft` (oklch clay)
  - Category chip identity tokens: `--chip-fish`, `--chip-bugs`, `--chip-fossils`, `--chip-art`, `--chip-sea`
- **Mirror in `src/lib/colors.ts`** — new `meadow` export (JS literals for any spot a CSS var can't be used) plus a `fontStacks` export. The legacy `colors` export is kept untouched per the plan ("keep `colors` intact as it may still be referenced elsewhere until later phases clean it up").
- **Fraunces** — variable, opsz axis 9..144, weights 400/500/600 + italic 400/500. Loaded in `src/index.css` and `index.html`. Registered as `--font-display`.
- **Inter** — weights 400/500/600/700. Loaded alongside Fraunces. Registered as `--font-sans`. Set as the global default `font-family` (replacing the previous Varela Round default).

## Removed

- **Varela Round** — fully retired:
  - `@import` removed from `src/index.css`
  - `<link>` removed from `index.html`
  - `<link>` and `font-family` removed from `public/version-history.html`
  - Inline `fontFamily: 'Varela Round, ...'` in `src/App.tsx` loading state replaced with Inter
- `grep -i "varela"` returns zero matches across `src/`, `public/`, and the repo root HTML.

## Intentional exclusions (per locked decisions in the plan doc)

- **Parchment, Midnight, Sakura themes** are explicitly **not** included — locked decision #2 in `docs/v0.9-plan.md` ("ship Meadow only"). No `[data-theme="..."]` branching, no theme-switcher state, no alternate token sets.
- No theme-switcher UI, no Settings → Appearance section.

## Visual impact

Components don't consume the new tokens yet, so most of the app looks the same. The one user-facing change is the body font: Varela Round is gone, so text now renders in Inter. Fraunces will start appearing in Phase 5+ when display headings, row names, and stat values get restyled.

## Test plan

- [x] `npm run build` — passes (tsc + vite build, 0 errors)
- [x] `npm test` — 59/59 passing
- [x] `grep -i "varela"` across `src/`, `public/`, `index.html` returns zero matches
- [x] Lint + prettier hooks pass on commit
- [ ] Manual: load dev preview, confirm Inter is in use site-wide and Fraunces loaded (DevTools → Network → fonts)
- [ ] Manual: confirm no font-flash / FOUC on cold load

## Decisions made on ambiguous points

- **`@theme` syntax with v3-style `@tailwind` directives:** The repo uses Tailwind v4 (`tailwindcss@^4.1.12` + `@tailwindcss/postcss`) but with the legacy `@tailwind base/components/utilities` directives. Tailwind v4's `@theme` block works alongside this setup, so I added `@theme { ... }` without migrating to `@import "tailwindcss"`. A future phase can do that migration if needed.
- **Token mirroring strategy:** The plan says tokens "must be defined as CSS custom properties in `src/index.css` `@theme` block and mirrored in `src/lib/colors.ts`." I added both the `@theme` registrations (Tailwind-aware) and a plain `:root` block (so anything reading `var(--accent)` outside Tailwind context still works), plus the `meadow` JS export. Belt-and-braces; consolidate later if redundant.
- **Global font default:** With Varela Round removed, the `* { font-family: ... }` rule in `src/index.css` had to point somewhere. I set it to Inter (the new UI stack). This is technically a small visual change (text now renders in Inter), but the alternative was to leave a dangling Varela Round reference, which the plan explicitly forbids.
- **`public/version-history.html`:** This is a standalone static HTML page, not part of the React app, but it loaded Varela Round directly. Updated it to load Fraunces + Inter for consistency since the plan says "any `Varela Round` references."

## Design handoff note

`design_handoff_v0.9.2_curator/` is referenced in the plan but is not present in this worktree (likely lives outside the repo / in a sibling directory I don't have access to from the worktree). All Phase 1 specs were taken directly from `docs/v0.9-plan.md` §5 ("Visual Direction") which has the full token table verbatim — so handoff CSS wasn't needed for this phase. Will need access to the handoff folder for Phase 5+.
