### PR TITLE
v0.9 Phase 3: Settings page (About + Danger zone)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,19 @@ All notable changes to this project are documented here.
 - Hemisphere toggle relocated to the sidebar town card to avoid regressing the v0.8 functionality that lived in `MuseumHeader`. Phase 4 moves it into `TownManager`.
 - Brand wordmark uses **"Museum Tracker"** (matching the prior MuseumHeader) — not "Curator", per the codename note in `docs/v0.9-plan.md` (no user-facing copy says "Curator").
 
+### Added — Phase 3: settings page
+- **`SettingsPage` component** (`src/components/SettingsPage.tsx`) — full-page settings route with two sections: **About** (version, source link, live storage summary, credits) and **Danger zone** (reset donations for active town, reset everything). No Appearance section per locked decision #3.
+- **`SettingsRoute` wrapper** (`src/components/SettingsRoute.tsx`) — renders the Sidebar + SettingsPage in the same shell layout as `ACCanvas`, so the sidebar (active town, nav, footer) stays in place when at `/settings`.
+- **`/settings` route** added to `App.tsx`. Sidebar Settings link now navigates to it; Esc and the close button navigate back to `/town/:id/home` (or `/` if there's no active town).
+- **Store reset actions** in `src/lib/store.ts`: `resetActiveTownDonations()` clears `donated` and `donatedAt` for the active town only; `resetAll()` empties towns + donations + clears `ac-curator-search-history` from localStorage. Both are gated behind native `confirm()` per locked decision #7.
+- **Settings page styles** in `src/index.css` (`.ac-settings`, `.ac-settings-head`, `.ac-settings-eyebrow`, `.ac-settings-title`, `.ac-settings-close`, `.ac-settings-section`, `.ac-settings-card`, `.ac-about-list`, `.ac-settings-danger`, `.ac-danger-row`, `.ac-danger-btn`, `.ac-danger-btn-strong`, `ac-fade-up` keyframe). Responsive collapse at ≤700px (title 56→40px, About list single-column, Danger rows stack with full-width buttons).
+
+### Decisions — Phase 3
+- **No Appearance section** — locked decision #3. Meadow is the only theme in v0.9, so a one-card theme switcher would feel hollow. Brought back when there are real alternatives.
+- **Eyebrow text on Settings header** is "Museum Tracker" rather than "Curator" — matches the brand-wordmark decision from Phase 2 (the codename note in `docs/v0.9-plan.md`).
+- **Reset donations is disabled** when there's no active town, instead of being hidden — keeps the Danger zone shape stable across states.
+- **Settings is a top-level route** (`/settings`) rather than nested under `/town/:townId/settings`. The settings page is a property of the app, not the town — and a user mid-reset-everything wouldn't have an active town to nest under.
+
 ## [v0.8.2-alpha] — 2026-05-01
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -56,6 +56,8 @@ src/
     CollectibleRow.tsx      # Single item row with donate toggle; shows chevron + rounded-top when expanded
     ItemExpandPanel.tsx     # Inline accordion panel shown below CollectibleRow for fish/bugs/fossils
     Sidebar.tsx             # v0.9 Phase 2: 280px left sidebar — brand, active town card, NavLink nav with counts, footer (replaces MuseumHeader/TabBar/TownSwitcher)
+    SettingsPage.tsx        # v0.9 Phase 3: full-page Settings — About + Danger zone (no Appearance per locked decision #3)
+    SettingsRoute.tsx       # v0.9 Phase 3: route wrapper that mounts Sidebar + SettingsPage at /settings
     ErrorBanner.tsx         # Dismissible inline error notification
     ErrorBoundary.tsx       # Top-level React error boundary; crashes render ErrorState
     ErrorState.tsx          # Full-page error fallback UI

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,7 @@
 import { Navigate, Route, Routes } from 'react-router-dom';
 import { Analytics } from '@vercel/analytics/react';
 import ACCanvas from './components/ACCanvas';
+import SettingsRoute from './components/SettingsRoute';
 import { useHydration } from './hooks/useHydration';
 import ErrorBoundary from './components/ErrorBoundary';
 import { useAppStore } from './lib/store';
@@ -48,6 +49,7 @@ function App() {
     <ErrorBoundary>
       <Routes>
         <Route path="/" element={<RootRedirect />} />
+        <Route path="/settings" element={<SettingsRoute />} />
         <Route path="/town/:townId" element={<ACCanvas />} />
         <Route path="/town/:townId/:tab" element={<ACCanvas />} />
         <Route path="*" element={<Navigate to="/" replace />} />

--- a/src/components/SettingsPage.tsx
+++ b/src/components/SettingsPage.tsx
@@ -1,0 +1,173 @@
+import { useEffect, useMemo } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { useAppStore } from '../lib/store';
+
+export function SettingsPage() {
+  const navigate = useNavigate();
+  const towns = useAppStore(s => s.towns);
+  const donated = useAppStore(s => s.donated);
+  const activeTownId = useAppStore(s => s.activeTownId);
+  const resetActiveTownDonations = useAppStore(s => s.resetActiveTownDonations);
+  const resetAll = useAppStore(s => s.resetAll);
+
+  const totalDonations = useMemo(() => {
+    let n = 0;
+    for (const byGame of Object.values(donated)) {
+      for (const byItem of Object.values(byGame)) {
+        n += Object.keys(byItem).length;
+      }
+    }
+    return n;
+  }, [donated]);
+
+  const townCount = towns.length;
+  const version = import.meta.env.VITE_APP_VERSION ?? '0.9.0-beta';
+
+  function handleClose() {
+    if (activeTownId) {
+      navigate(`/town/${activeTownId}/home`);
+    } else {
+      navigate('/');
+    }
+  }
+
+  useEffect(() => {
+    function onKey(e: KeyboardEvent) {
+      if (e.key === 'Escape') handleClose();
+    }
+    window.addEventListener('keydown', onKey);
+    return () => window.removeEventListener('keydown', onKey);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [activeTownId]);
+
+  function handleResetDonations() {
+    if (!activeTownId) return;
+    const town = towns.find(t => t.id === activeTownId);
+    const name = town?.name ?? 'this town';
+    if (
+      window.confirm(
+        `Reset all donations for "${name}"? This cannot be undone.`
+      )
+    ) {
+      resetActiveTownDonations();
+    }
+  }
+
+  function handleResetAll() {
+    if (
+      window.confirm(
+        'Reset everything? This deletes all towns, donations, and search history. This cannot be undone.'
+      )
+    ) {
+      resetAll();
+      navigate('/');
+    }
+  }
+
+  const canResetActive = !!activeTownId;
+
+  return (
+    <div className="ac-settings">
+      <header className="ac-settings-head">
+        <div>
+          <div className="ac-settings-eyebrow">Museum Tracker</div>
+          <h1 className="ac-settings-title">
+            <em>Settings</em>
+          </h1>
+        </div>
+        <button
+          className="ac-settings-close"
+          onClick={handleClose}
+          aria-label="Close settings"
+        >
+          ✕
+        </button>
+      </header>
+
+      <section className="ac-settings-section">
+        <div className="ac-settings-section-head">
+          <h2 className="ac-settings-section-title">About</h2>
+        </div>
+        <div className="ac-settings-card">
+          <dl className="ac-about-list">
+            <div>
+              <dt>Version</dt>
+              <dd>v{version}</dd>
+            </div>
+            <div>
+              <dt>Source</dt>
+              <dd>
+                <a
+                  href="https://github.com/jacuzzicoding/animalcrossingwebapp"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
+                  jacuzzicoding/animalcrossingwebapp
+                </a>
+              </dd>
+            </div>
+            <div>
+              <dt>Storage</dt>
+              <dd>
+                localStorage · {townCount} {townCount === 1 ? 'town' : 'towns'}{' '}
+                · {totalDonations}{' '}
+                {totalDonations === 1 ? 'donation' : 'donations'}
+              </dd>
+            </div>
+            <div>
+              <dt>Credits</dt>
+              <dd>
+                Companion app for the Animal Crossing series. Not affiliated
+                with Nintendo.
+              </dd>
+            </div>
+          </dl>
+        </div>
+      </section>
+
+      <section className="ac-settings-section">
+        <div className="ac-settings-section-head">
+          <h2 className="ac-settings-section-title">Danger zone</h2>
+          <p className="ac-settings-section-sub">
+            These actions cannot be undone.
+          </p>
+        </div>
+        <div className="ac-settings-card ac-settings-danger">
+          <div className="ac-danger-row">
+            <div>
+              <div className="ac-danger-name">
+                Reset donations for active town
+              </div>
+              <div className="ac-danger-sub">
+                Clears all donation marks. Towns themselves are kept.
+              </div>
+            </div>
+            <button
+              className="ac-danger-btn"
+              onClick={handleResetDonations}
+              disabled={!canResetActive}
+            >
+              Reset donations
+            </button>
+          </div>
+          <div className="ac-danger-row">
+            <div>
+              <div className="ac-danger-name">Reset everything</div>
+              <div className="ac-danger-sub">
+                Deletes all towns, donations, and search history.
+              </div>
+            </div>
+            <button
+              className="ac-danger-btn ac-danger-btn-strong"
+              onClick={handleResetAll}
+            >
+              Reset all data
+            </button>
+          </div>
+        </div>
+      </section>
+    </div>
+  );
+}
+
+export default SettingsPage;

--- a/src/components/SettingsRoute.tsx
+++ b/src/components/SettingsRoute.tsx
@@ -1,0 +1,78 @@
+import { useState } from 'react';
+import { useAppStore } from '../lib/store';
+import { Sidebar } from './Sidebar';
+import { SettingsPage } from './SettingsPage';
+import { CreateTownModal } from './modals/CreateTownModal';
+import { EditTownModal } from './modals/EditTownModal';
+import { useMuseumData } from '../hooks/useMuseumData';
+import { useCategoryStats } from '../hooks/useCategoryStats';
+import { downloadCSV } from '../lib/csvExport';
+
+// Stable empty fallbacks
+const EMPTY_DONATED: Record<string, boolean> = {};
+const EMPTY_DONATED_AT: Record<string, string> = {};
+
+export default function SettingsRoute() {
+  const towns = useAppStore(s => s.towns);
+  const activeTownId = useAppStore(s => s.activeTownId);
+  const activeTown = towns.find(t => t.id === activeTownId);
+
+  const activeTownDonated = useAppStore(s => {
+    if (!s.activeTownId) return EMPTY_DONATED;
+    const town = s.towns.find(t => t.id === s.activeTownId);
+    if (!town) return EMPTY_DONATED;
+    return s.donated[s.activeTownId]?.[town.gameId] ?? EMPTY_DONATED;
+  });
+  const activeTownDonatedAt = useAppStore(s => {
+    if (!s.activeTownId) return EMPTY_DONATED_AT;
+    const town = s.towns.find(t => t.id === s.activeTownId);
+    if (!town) return EMPTY_DONATED_AT;
+    return s.donatedAt[s.activeTownId]?.[town.gameId] ?? EMPTY_DONATED_AT;
+  });
+
+  const [showCreateTown, setShowCreateTown] = useState(false);
+  const [showEditTown, setShowEditTown] = useState(false);
+
+  const { data } = useMuseumData(activeTown?.gameId ?? 'ACGCN');
+  const catCounts = useCategoryStats(data, activeTownDonated);
+
+  function handleExport() {
+    if (!activeTown) return;
+    downloadCSV(
+      data,
+      activeTownDonated,
+      activeTownDonatedAt,
+      activeTown.name,
+      activeTown.playerName
+    );
+  }
+
+  return (
+    <div className="ac-app">
+      {activeTownId && (
+        <Sidebar
+          townId={activeTownId}
+          data={data}
+          catCounts={catCounts}
+          onOpenCreateTown={() => setShowCreateTown(true)}
+          onOpenEditTown={() => setShowEditTown(true)}
+          onExport={handleExport}
+        />
+      )}
+      <main className="ac-main">
+        <SettingsPage />
+      </main>
+
+      <CreateTownModal
+        isOpen={showCreateTown}
+        required={false}
+        onClose={() => setShowCreateTown(false)}
+      />
+      <EditTownModal
+        isOpen={showEditTown}
+        town={activeTown ?? null}
+        onClose={() => setShowEditTown(false)}
+      />
+    </div>
+  );
+}

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -223,7 +223,7 @@ export function Sidebar({
         <button
           className="ac-foot-link"
           onClick={() => navigate('/settings')}
-          title="Settings (coming in Phase 3)"
+          title="Settings"
         >
           Settings
         </button>

--- a/src/index.css
+++ b/src/index.css
@@ -233,3 +233,172 @@
   }
   .ac-main { padding: 24px 20px 60px; }
 }
+
+/* ── Settings page ── */
+.ac-settings {
+  max-width: 920px;
+  margin: 0 auto;
+  padding: 8px 0 80px;
+  animation: ac-fade-up 0.28s ease;
+}
+@keyframes ac-fade-up {
+  from { opacity: 0; transform: translateY(6px); }
+  to { opacity: 1; transform: translateY(0); }
+}
+
+.ac-settings-head {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  padding-bottom: 28px;
+  border-bottom: 1px solid var(--border);
+  margin-bottom: 36px;
+}
+.ac-settings-eyebrow {
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.16em;
+  color: var(--ink-muted);
+  margin-bottom: 8px;
+}
+.ac-settings-title {
+  font-family: var(--font-display, 'Fraunces', Georgia, serif);
+  font-size: 56px;
+  font-weight: 400;
+  line-height: 1;
+  letter-spacing: -0.02em;
+  margin: 0;
+  color: var(--ink);
+}
+.ac-settings-title em {
+  font-style: italic;
+  color: var(--accent-ink);
+  font-variation-settings: 'opsz' 36;
+}
+.ac-settings-close {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  color: var(--ink-soft);
+  width: 36px;
+  height: 36px;
+  border-radius: 50%;
+  font-size: 14px;
+  cursor: pointer;
+  transition: all 0.15s;
+}
+.ac-settings-close:hover {
+  background: var(--surface-alt);
+  color: var(--ink);
+  border-color: var(--border-strong);
+}
+
+.ac-settings-section { margin-bottom: 44px; }
+.ac-settings-section-head { margin-bottom: 18px; }
+.ac-settings-section-title {
+  font-family: var(--font-display, 'Fraunces', Georgia, serif);
+  font-size: 22px;
+  font-weight: 500;
+  margin: 0;
+  color: var(--ink);
+  letter-spacing: -0.01em;
+}
+.ac-settings-section-sub {
+  font-size: 13px;
+  color: var(--ink-muted);
+  margin: 4px 0 0;
+}
+
+.ac-settings-card {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 14px;
+  padding: 18px 22px;
+}
+.ac-about-list {
+  display: grid;
+  gap: 14px;
+  margin: 0;
+}
+.ac-about-list > div {
+  display: grid;
+  grid-template-columns: 120px 1fr;
+  gap: 18px;
+  font-size: 14px;
+  align-items: baseline;
+}
+.ac-about-list dt {
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  color: var(--ink-muted);
+  margin: 0;
+}
+.ac-about-list dd { margin: 0; color: var(--ink); }
+.ac-about-list a {
+  color: var(--accent-ink);
+  text-decoration: underline;
+  text-decoration-color: var(--accent-soft, var(--border-strong));
+  text-underline-offset: 3px;
+}
+
+.ac-settings-danger {
+  border-color: oklch(0.62 0.12 25 / 0.35);
+  background: color-mix(in oklch, oklch(0.62 0.12 25) 4%, var(--surface));
+}
+.ac-danger-row {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 24px;
+  padding: 10px 0;
+}
+.ac-danger-row + .ac-danger-row {
+  border-top: 1px solid var(--border);
+  padding-top: 16px;
+  margin-top: 6px;
+}
+.ac-danger-name {
+  font-weight: 500;
+  color: var(--ink);
+  font-size: 14px;
+}
+.ac-danger-sub {
+  font-size: 12px;
+  color: var(--ink-muted);
+  margin-top: 2px;
+}
+.ac-danger-btn {
+  background: var(--surface);
+  border: 1px solid oklch(0.62 0.12 25 / 0.4);
+  color: oklch(0.5 0.14 25);
+  padding: 8px 16px;
+  border-radius: 999px;
+  font-size: 13px;
+  font-weight: 500;
+  cursor: pointer;
+  font-family: inherit;
+  flex: none;
+  min-height: 44px;
+  transition: all 0.15s;
+}
+.ac-danger-btn:hover:not(:disabled) {
+  background: oklch(0.62 0.12 25 / 0.08);
+  border-color: oklch(0.62 0.12 25 / 0.6);
+}
+.ac-danger-btn:disabled {
+  opacity: 0.45;
+  cursor: not-allowed;
+}
+.ac-danger-btn-strong {
+  background: oklch(0.5 0.14 25);
+  color: white;
+  border-color: transparent;
+}
+.ac-danger-btn-strong:hover { background: oklch(0.45 0.16 25); }
+
+@media (max-width: 700px) {
+  .ac-settings-title { font-size: 40px; }
+  .ac-about-list > div { grid-template-columns: 1fr; gap: 2px; }
+  .ac-danger-row { flex-direction: column; align-items: stretch; }
+  .ac-danger-btn { width: 100%; }
+}

--- a/src/lib/store.ts
+++ b/src/lib/store.ts
@@ -31,6 +31,8 @@ interface AppState {
   isDonated: (itemId: string) => boolean;
   getDonatedAt: (itemId: string) => string | undefined;
   getActiveTown: () => Town | undefined;
+  resetActiveTownDonations: () => void;
+  resetAll: () => void;
 }
 
 function generateId(): string {
@@ -142,6 +144,31 @@ export const useAppStore = create<AppState>()(
       getActiveTown: () => {
         const { towns, activeTownId } = get();
         return towns.find(t => t.id === activeTownId);
+      },
+
+      resetActiveTownDonations: () =>
+        set(state => {
+          const { activeTownId } = state;
+          if (!activeTownId) return state;
+          const donated = { ...state.donated };
+          const donatedAt = { ...state.donatedAt };
+          delete donated[activeTownId];
+          delete donatedAt[activeTownId];
+          return { donated, donatedAt };
+        }),
+
+      resetAll: () => {
+        try {
+          localStorage.removeItem('ac-curator-search-history');
+        } catch {
+          // ignore — localStorage may be unavailable (SSR / privacy mode)
+        }
+        set({
+          towns: [],
+          activeTownId: null,
+          donated: {},
+          donatedAt: {},
+        });
       },
     }),
     {


### PR DESCRIPTION
## Summary

Phase 3 of v0.9.0-beta per [`docs/v0.9-plan.md` § Phase 3](../blob/development/docs/v0.9-plan.md#phase-3--settings-page). Adds the `/settings` route with **About** and **Danger zone** sections. **No Appearance section** per locked decision #3 — Meadow is the only theme in v0.9.

## What changed

- **`src/components/SettingsPage.tsx`** — full-page Settings UI: About (version from `VITE_APP_VERSION`, GitHub source link, live storage summary derived from store, credits) + Danger zone with two `confirm()`-guarded actions ("Reset donations for active town" ghost, "Reset everything" solid red). Esc + close button navigate back to active town home (or `/` if no town).
- **`src/components/SettingsRoute.tsx`** — route wrapper that mounts `Sidebar` + `SettingsPage` so the sidebar (active town card, nav, footer) stays in place at `/settings`.
- **`src/App.tsx`** — adds `<Route path="/settings" element={<SettingsRoute />} />`.
- **`src/lib/store.ts`** — adds `resetActiveTownDonations()` and `resetAll()`. `resetAll()` also clears `ac-curator-search-history` from localStorage (forward-compatible with the Phase 8 search history key).
- **`src/index.css`** — Settings page styles ported from `docs/design-handoffs/v0.9.2_curator/addons-styles.css` (`.ac-settings*`, `.ac-about-list`, `.ac-settings-danger`, `.ac-danger-*`, `ac-fade-up` keyframe). Responsive collapse at ≤700px (title 56→40px, About list single-column, Danger rows stack with full-width buttons).
- **`src/components/Sidebar.tsx`** — drops the Phase 2 "coming in Phase 3" tooltip on the Settings link.
- **CHANGELOG.md, CLAUDE.md** — Phase 3 entries.

## Decisions

- **Settings is a top-level route (`/settings`)** rather than nested under `/town/:townId/settings`. Settings is an app property, not a town property — and a user mid-`Reset everything` wouldn't have an active town to nest under.
- **"Reset donations for active town" is disabled (not hidden)** when there's no active town — keeps Danger zone shape stable.
- **Eyebrow header text is "Museum Tracker"**, not "Curator". Matches the brand-wordmark choice from Phase 2 (codename note in the plan: no user-facing copy says "Curator").
- **`Reset everything` clears `ac-curator-search-history` defensively** even though that key isn't written until Phase 8. Safer than coming back later. The legacy in-memory `recentSearches` from `useSearch` is naturally cleared by component unmount; nothing to wipe.
- **Used `window.confirm()` for both danger actions** per locked decision #7 — a styled confirm dialog is a v1.0 polish item.

## Status

- ✅ `npm run build` — pass (tsc + vite, no TS errors)
- ✅ `npm test` — 59 tests pass
- ✅ `npm run lint` — pass (no `typecheck` script in this repo; `tsc --noEmit` runs as part of `build`)

## Test plan

- [x] Visit `/settings` from sidebar footer link — page renders with sidebar intact
- [x] About section reflects live `townCount` and `totalDonations`
- [x] GitHub source link opens in new tab
- [x] "Reset donations for active town" → confirm → only that town's donations clear
- [x] "Reset everything" → confirm → all towns + donations gone, redirected to `/`, search-history key removed from localStorage
- [x] Esc closes settings (navigates back to `/town/:id/home`)
- [x] Close ✕ button does the same
- [x] Mobile ≤700px: title shrinks, About rows stack, Danger buttons full-width

## Out of scope (per plan)

- No Appearance / theme switcher (decision #3)
- No styled confirm dialog (decision #7)
- No retiring of the Phase 2 sidebar bridge stubs (Edit/+New/Switch town buttons, hemisphere toggle) — those retire in Phase 4 with `TownManager`.
