### PR TITLE
chore(docs): v0.9 doc sweep through Phase 9

### DIFF
--- a/.claude/rules/architecture.md
+++ b/.claude/rules/architecture.md
@@ -1,49 +1,74 @@
-# Architecture Reference (v0.8)
+# Architecture Reference (v0.9.0-beta)
 
 ## Stack
-Vite + React 19 + TypeScript + Tailwind CSS v4 + Zustand (persist middleware) + React Router v6
+Vite + React 19 + TypeScript + Tailwind CSS v4 + Zustand (persist + non-persisted UI store) + React Router v6. Meadow design tokens (CSS custom properties in `src/index.css` `@theme`); Fraunces (display) + Inter (UI).
 
 ## Key Files
-- `src/lib/store.ts` — Zustand store, persist v3, 3-level donation schema
-- `src/lib/types.ts` — GameId union, Town, Game interface, GAMES registry
-- `src/lib/constants.ts` — MONTH_NAMES, CATEGORY_LABELS, SEASONS (single source of truth)
-- `src/lib/colors.ts` — design token hex constants
-- `src/lib/categoryMeta.ts` — CATEGORY_META constant (label/Icon/file per category)
-- `src/lib/viewTypes.ts` — ViewId and AllData types
-- `src/lib/storeMigrations.ts` — Zustand migrate callback (v1→v2→v3; backfills gameId, then hemisphere)
-- `src/lib/bootstrapMigration.ts` — one-time localStorage key rename, called in main.tsx before createRoot
-- `src/hooks/useHydration.ts` — onFinishHydration guard, prevents flash of empty state
-- `src/hooks/useMuseumData.ts` — fetches and caches all category JSONs for the active town's game (including sea creatures for ACNH); accepts `gameId` and fetches from `/data/<game>/`; re-fetches when active town's game changes
-- `src/hooks/useSearch.ts` — search history, click-outside, debounce
-- `src/hooks/useCategoryStats.ts` — memoized donated counts per category
-- `src/components/ErrorBoundary.tsx` — wraps app root, crashes show ErrorState not blank page
-- `src/components/ACCanvas.tsx` — ~298-line orchestration shell; decomposition complete (v0.7 PR #25); wires ItemExpandPanel inline-expand and DetailModal bottom-sheet
-- `src/components/ItemExpandPanel.tsx` — inline accordion panel for Fish/Bugs/Fossils rows (month grid, bells, habitat, donate toggle)
-- `src/components/shared/` — HabitatChip, DonateToggle, CategoryProgress, SearchBar, EmptyState, MonthGrid
-- `src/components/modals/` — CreateTownModal (game selector, new town form), EditTownModal, DetailModal (bottom-sheet for Art + Search results)
-- `src/components/views/` — AnalyticsView, ActivityFeed, SectionCard
-- `src/components/search/` — GlobalSearchBar, GlobalSearchResults, SearchHistoryPopover
-- `src/components/CollectibleRow.tsx`, `TownSwitcher.tsx`, `MuseumHeader.tsx`, `TabBar.tsx`
-- `public/data/<gameId>/` — item data files for all 5 games: acgcn/, acww/, accf/, acnl/, acnh/ all present
+
+### State + data
+- `src/lib/store.ts` — Zustand app store, persist key `ac-web` schema v3, 3-level donation schema. `createTown(name, gameId, hemisphere?)`, `updateTown(id, patch: { name?, hemisphere? })` — `gameId` is intentionally not patchable post-create (Decision 1). Includes `resetActiveTownDonations()` + `resetAll()` for the Phase 3 Settings danger zone.
+- `src/lib/uiStore.ts` — non-persisted Zustand store for transient UI state (`townManagerOpen`, `townManagerForceCreate`).
+- `src/lib/types.ts` — GameId union, `Town` (no longer has `playerName` — removed in Phase 4 / Decision 5), Game interface, GAMES registry, GAME_LIST.
+- `src/lib/constants.ts` — MONTH_NAMES, CATEGORY_LABELS, CATEGORY_ORDER, SEASONS.
+- `src/lib/colors.ts` — `meadow` token export (mirrors CSS custom properties), `fontStacks` for Fraunces/Inter, legacy `colors` retained until consumers retire.
+- `src/lib/categoryMeta.ts` — CATEGORY_META (label / Icon / file / data presence per game).
+- `src/lib/viewTypes.ts` — ViewId union and AllData shape. Phase 8 removed the `'search'` route.
+- `src/lib/storeMigrations.ts` — Zustand migrate callback v1→v2 (gameId backfill) and v2→v3 (hemisphere backfill).
+- `src/lib/bootstrapMigration.ts` — one-time localStorage key rename, called in main.tsx before createRoot.
+
+### Hooks
+- `src/hooks/useHydration.ts` — onFinishHydration guard.
+- `src/hooks/useMuseumData.ts` — fetches all category JSONs for the active town's game (sea creatures included for ACNL/ACNH); re-fetches when active town's game changes.
+- `src/hooks/useCategoryStats.ts` — memoized donated counts per category.
+- `src/hooks/useJumpToRow.ts` — Phase 6 navigation helper. Pushes `/town/:townId/:tab` and sets `highlightId` on the next animation frame; ACCanvas's effect picks up the change and scrolls + pulses the matching row.
+- (`useSearch` retired in Phase 8 — search state lives inside GlobalSearchDropdown.)
+
+### Components — shell
+- `src/components/Sidebar.tsx` — 280px sticky left sidebar (Phase 2). Brand, active-town card, NavLink nav with per-category counts, Export CSV / Settings footer. "Switch town ›" opens TownManager via useUIStore.
+- `src/components/TownManager.tsx` — right-side drawer (bottom sheet ≤720px) mounted at App layout level (Phase 4). Switch / inline-edit / create / delete towns. Edit form is name + (ACNH-only) hemisphere; game is read-only post-create.
+- `src/components/SettingsPage.tsx` + `SettingsRoute.tsx` — `/settings` route (Phase 3). About + Danger zone only (no Appearance, Decision 3).
+- `src/components/ACCanvas.tsx` — orchestration shell. Owns `highlightId` state. Mounts active tab; wires GlobalSearchDropdown topbar (Home only) and DetailModal (art).
+- `src/components/ErrorBoundary.tsx` / `ErrorBanner.tsx` / `ErrorState.tsx`.
+
+### Components — tabs
+- `src/components/HomeTab.tsx` — Phase 6 rebuild. Hero stat + ProgressMeter, month strip, "Leaving end of {month}" shelf, "Just arrived" shelf, latest donations. Cards fire `jumpTo`.
+- `src/components/CategoryTab.tsx` — Phase 7. Sections: Leaving this month / Available now / Out of season / Already donated. Owns expandedId; reacts to `highlightId`. Hosts per-tab `SearchBar`. Routes art clicks to DetailModal instead of inline expand.
+- `src/components/StatsTab.tsx` — Phase 9. Per-category cards (3/4/5 by game) + 12-column yearly rhythm chart. Replaces AnalyticsView.
+- `src/components/ProgressMeter.tsx` (+ `progressMeterUtils.ts`, `ProgressMeter.test.ts`) — Phase 6. 4 segments (fish/bugs/fossils/art) for ACGCN/ACWW/ACCF; 5 segments (+ sea) for ACNL/ACNH. `.ac-meter-5` modifier handles responsive wrapping.
+
+### Components — rows + panels
+- `src/components/CollectibleRow.tsx` — Phase 5 restyle. Monogram glyph, meta line with `·` separators, leaving/new pills, animated chevron. Stamps `data-row-id`. Donate UI lives in the expand panel only.
+- `src/components/ItemExpandPanel.tsx` — Phase 5 rebuild. Two-column grid: MonthGrid + stats stack (bells / shadow / hours / notes) + donate button.
+- `src/components/shared/` — DonateToggle, EmptyState, HabitatChip, MonthGrid (Phase 5 re-skin, accepts `current` prop), SearchBar (per-tab, used by CategoryTab). `CategoryProgress.tsx` is dead — file remains pending cleanup.
+- `src/components/modals/DetailModal.tsx` — bottom-sheet detail. Used by Art and as a fallback in some paths.
+- `src/components/views/ActivityFeed.tsx` — recent donations list (consumed by HomeTab). `AnalyticsView` and `SectionCard` retired in Phase 9.
+- `src/components/search/GlobalSearchDropdown.tsx` — Phase 8 unified search dropdown (anchored under Home topbar). Grouped category results (5 groups for ACNL/ACNH, 4 elsewhere), keyboard nav (↑↓↵esc), search history at localStorage key `ac-curator-search-history` (max 8). Replaces GlobalSearchBar / GlobalSearchResults / SearchHistoryPopover.
+
+### Data
+- `public/data/<gameId>/` — `acgcn/`, `acww/`, `accf/`, `acnl/`, `acnh/` all present. Sea creatures for ACNL + ACNH. Art for ACGCN + ACNH today; ACWW + ACCF art incoming via PR #78 (closes Issue #74).
 
 ## Store Schema (v3)
 ```
 donated: Record<townId, Record<gameId, Record<itemId, boolean>>>
 donatedAt: Record<townId, Record<gameId, Record<itemId, string>>>
-towns: Town[]  // each Town has id, name, playerName, gameId, hemisphere ('NH'|'SH'), createdAt
+towns: Town[]  // Town: id, name, gameId, hemisphere ('NH'|'SH'), createdAt
 ```
-CRITICAL: callers use getActiveTown().gameId to scope donations — store handles the 3rd level.
-`hemisphere` defaults to 'NH'; only used for ACNH month display (months_nh / months_sh).
+CRITICAL: callers use `getActiveTown().gameId` to scope donations — store handles the 3rd level. `hemisphere` defaults to `'NH'`; only meaningful for ACNH (drives months_nh / months_sh).
 
 ## Multi-Game Support
 - GameId = 'ACGCN' | 'ACWW' | 'ACCF' | 'ACNL' | 'ACNH'
-- Data files use game-local IDs (sea-bass in ACGCN == sea-bass in ACWW — schema handles scoping)
-- Only show games with data files present in CreateTownModal
+- Data files use game-local IDs; the schema scopes by gameId.
+- Game is **immutable post-create** (Decision 1). Only display games with data files in TownManager's create form.
+
+## Scroll-to + highlight (Decision 10)
+`ACCanvas` owns `highlightId`. Setters: HomeTab (via `useJumpToRow`) and `GlobalSearchDropdown.onJump` both `setTab + setHighlightId`. `CategoryTab` opens the matching row, scrolls (`block: 'center'`, smooth) on the next animation frame, and adds `.ac-row-pulse` (1.4s `@keyframes ac-row-pulse`). Rows stamp `data-row-id={item.id}`. The state clears after the pulse so re-jumping the same id retriggers.
 
 ## Dev Preview
-https://development-animalcrossingwebapp.vercel.app/ — auto-deploys from `development` branch via Vercel GitHub integration. Never run `vercel` CLI manually.
+https://development-animalcrossingwebapp.vercel.app/ — auto-deploys from `development` via Vercel GitHub integration. Never run `vercel` CLI manually.
 
 ## Reference Docs
-- docs/v0.7-audit.md — full ranked audit (P0/P1/P2)
-- docs/v0.7-architecture-proposal.md — approved design decisions
-- docs/dev-process.md — full dev process (this is the .claude/rules/ version)
+- `docs/v0.9-plan.md` — canonical v0.9 implementation plan + locked decisions
+- `docs/decisions.md` — reverse-chronological decision log
+- `docs/design-handoffs/` — v0.9 / v0.9.1 / v0.9.2 design specs
+- `docs/v0.7-audit.md` / `docs/v0.7-architecture-proposal.md` — multi-game foundation history
+- `docs/dev-process.md` — full dev process

--- a/.claude/rules/dev-process.md
+++ b/.claude/rules/dev-process.md
@@ -7,7 +7,7 @@ Every feature, fix, or change must follow this checklist before the PR is comple
 3. CHANGELOG.md updated with entry under the current version section
 4. CLAUDE.md updated if any of these changed: file structure, new components/hooks/utils, architecture, commands, known issues, version number
 5. Tests pass — run `npm run build` and `npm test` before pushing
-6. Dev preview tested at https://animalcrossingwebapp-git-development-jacuzzicodings-projects.vercel.app for any user-visible changes
+6. Dev preview tested at https://development-animalcrossingwebapp.vercel.app for any user-visible changes
 7. Version references kept current (CLAUDE.md, README.md)
 
 ## PR Description Requirements

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,7 +16,7 @@ See `docs/architecture.md` — deep architectural context (store schema, migrati
 ## Project Overview
 
 Animal Crossing multi-game companion web app. Tracks museum donations (fish, bugs, fossils, art) across multiple towns and games.
-Cozy parchment/GameCube museum aesthetic. **Last stable: v0.8.2-alpha (shipped 2026-05-01). Active development: v0.9.0-beta — Phase 2 (sidebar shell) shipped; see `docs/v0.9-plan.md` for canonical plan.**
+Meadow design language (Fraunces + Inter, moss-green accent) as of v0.9. **Last stable: v0.8.2-alpha (shipped 2026-05-01). Active development: v0.9.0-beta — Phases 1–9 shipped to `development`; Phase 10 (mobile responsive verification) pending. See `docs/v0.9-plan.md` for canonical plan.**
 Live at: https://animalcrossingwebapp.vercel.app | Dev preview: https://development-animalcrossingwebapp.vercel.app
 
 ## Commands
@@ -33,14 +33,16 @@ npm install       # Install dependencies
 ## Architecture
 
 **Framework:** Vite + React 19 + TypeScript  
-**Styling:** Tailwind CSS v4 (utility classes only; design tokens via `src/lib/colors.ts` — inline hex)  
-**State:** Zustand ^5 with `persist` middleware (localStorage key: `ac-web`, schema v3)  
+**Styling:** Tailwind CSS v4 + Meadow CSS custom properties (`@theme` block in `src/index.css`); design tokens mirrored as the `meadow` export in `src/lib/colors.ts`. Fraunces (display) + Inter (UI) loaded via Google Fonts. Varela Round retired in v0.9 Phase 1. Legacy `colors` export retained until all consumers are removed.  
+**State:** Zustand ^5 with `persist` middleware (localStorage key: `ac-web`, schema v3) for app data; non-persisted `useUIStore` (`src/lib/uiStore.ts`) for transient UI state (TownManager open/forceCreate flags).  
 **Routing:** React Router v6 (`BrowserRouter`); URL structure: `/` → redirect, `/town/:townId` → home tab, `/town/:townId/:tab` → specific tab; `vercel.json` has catch-all SPA rewrite for preview/branch deploys  
 **Tests:** Vitest  
 **Store schema:** 3-level `donated[townId][gameId][itemId]` (as of v0.7); `Town` includes `hemisphere: 'NH' | 'SH'` (as of v0.8)  
 **Migration:** Zustand persist v3 + `bootstrapMigration.ts` — zero data loss for existing users  
 **Town CRUD (v0.9 Phase 4):** `TownManager` drawer mounts at the App layout level (above the router), opened via `useUIStore.openTownManager()`. Replaces `CreateTownModal`, `EditTownModal`, and the `TownSwitcher` dropdown. When `towns.length === 0`, App.tsx auto-opens it in `forceCreate` mode (no close/Esc/scrim dismissal). Per Decision 1, edit form has no game `<select>` — game is read-only post-create.  
-**Shell layout (v0.9 Phase 2):** `Sidebar` (280px left, sticky) + `<main className="ac-main">` in CSS grid `280px 1fr`, max-width 1440px centered. Below 980px sidebar stacks above main. `MuseumHeader`, `TabBar`, `TownSwitcher` retired — nav lives in the sidebar.
+**Shell layout (v0.9 Phase 2):** `Sidebar` (280px left, sticky) + `<main className="ac-main">` in CSS grid `280px 1fr`, max-width 1440px centered. Below 980px sidebar stacks above main. `MuseumHeader`, `TabBar`, `TownSwitcher` retired — nav lives in the sidebar.  
+**Scroll-to + highlight (v0.9 Phase 5/6/8):** `ACCanvas` owns `highlightId` state. `HomeTab` shelves and `GlobalSearchDropdown` results call `jumpTo(category, id)` (via `useJumpToRow`); `CategoryTab` opens the matching row, scrolls it into view (`block: 'center'`, smooth) on the next animation frame, and adds `.ac-row-pulse` (1.4s `@keyframes ac-row-pulse`). Rows stamp `data-row-id={item.id}` so the effect can locate them. See locked decision #10 in `docs/v0.9-plan.md`.  
+**Search (v0.9 Phase 8):** `GlobalSearchDropdown` is mounted only on the Home tab inside an `.ac-topbar`. Other tabs use `CategoryTab`'s inline per-tab `SearchBar`. Search history persists at localStorage key `ac-curator-search-history` (max 8, deduplicated).
 
 ### File Structure
 
@@ -49,17 +51,26 @@ src/
   App.tsx                   # Root component — hydration guard + ErrorBoundary + Routes (/, /town/:townId/:tab)
   main.tsx                  # Entry point — runs bootstrapMigration, wraps app in BrowserRouter
   components/
-    ACCanvas.tsx            # Orchestration shell ~298 lines. Mounts active tab view,
-                            # wires modals and global search. Decomposition complete (v0.7).
+    ACCanvas.tsx            # Orchestration shell. Mounts active tab view; owns
+                            # `highlightId` state for scroll-to + pulse; wires
+                            # GlobalSearchDropdown topbar (Home only) and DetailModal (art).
     HomeTab.tsx             # v0.9 Phase 6: rebuilt — hero stat + ProgressMeter,
                             # month strip, leaving-soon shelf, just-arrived shelf,
                             # latest donations. Cards fire jumpTo (scroll + pulse).
     ProgressMeter.tsx       # v0.9 Phase 6: segmented progress bar (4 or 5 segments
                             # gated by gameId; sea segment for ACNL/ACNH).
     progressMeterUtils.ts   # Pure helper segmentsForGame (unit-tested).
-    CategoryTab.tsx         # v0.9 Phase 7: sectioned category page (Leaving / Available / Out of season / Already donated)
-    CollectibleRow.tsx      # Single item row with donate toggle; shows chevron + rounded-top when expanded
-    ItemExpandPanel.tsx     # Inline accordion panel shown below CollectibleRow for fish/bugs/fossils
+    CategoryTab.tsx         # v0.9 Phase 7: sectioned category page (Leaving / Available
+                            # / Out of season / Already donated). Owns expandedId,
+                            # reacts to highlightId by opening the matching row
+                            # before ACCanvas's scroll-to fires. Hosts per-tab SearchBar.
+    CollectibleRow.tsx      # v0.9 Phase 5 restyle: monogram glyph tile, meta line with
+                            # `·` separators, leaving/new pills, animated chevron.
+                            # Stamps data-row-id; accepts highlighted/currentMonth/hemisphere props.
+    ItemExpandPanel.tsx     # v0.9 Phase 5 rebuild: two-column inline panel (MonthGrid
+                            # + stats stack with bells/shadow/hours/notes) with the
+                            # donate / undonate button at the bottom. Donate UI lives
+                            # in the panel only — the row no longer renders a toggle.
     Sidebar.tsx             # v0.9 Phase 2: 280px left sidebar — brand, active town card, NavLink nav with counts, footer (replaces MuseumHeader/TabBar/TownSwitcher)
     SettingsPage.tsx        # v0.9 Phase 3: full-page Settings — About + Danger zone (no Appearance per locked decision #3)
     SettingsRoute.tsx       # v0.9 Phase 3: route wrapper that mounts Sidebar + SettingsPage at /settings
@@ -67,20 +78,28 @@ src/
     ErrorBoundary.tsx       # Top-level React error boundary; crashes render ErrorState
     ErrorState.tsx          # Full-page error fallback UI
     shared/
-      CategoryProgress.tsx  # "X / Y donated" progress bar
-      DonateToggle.tsx      # Checkbox/button to mark item donated
+      DonateToggle.tsx      # Checkbox/button to mark item donated (used by sea-creature search rows; donate on category rows is panel-only as of Phase 5)
       EmptyState.tsx        # "Nothing here yet" placeholder
       HabitatChip.tsx       # Fish habitat badge
-      MonthGrid.tsx         # 12-cell month availability grid
-      SearchBar.tsx         # Per-tab inline search input
+      MonthGrid.tsx         # 12-cell month availability grid (Phase 5 re-skin; accepts `current` prop)
+      SearchBar.tsx         # Per-tab inline search input (consumed by CategoryTab)
+      # CategoryProgress.tsx — DEAD: its only consumers (ACCanvas inline category
+      # render + AnalyticsView) were retired in Phase 7 / Phase 9. File remains
+      # in tree pending a follow-up cleanup PR.
     modals/
-      DetailModal.tsx       # Item detail sheet
-    TownManager.tsx         # Right-side drawer for switch/edit/create/delete towns (v0.9 Phase 4)
+      DetailModal.tsx       # Bottom-sheet item detail. Used by Art (CategoryTab routes
+                            # art clicks here) and persistent across search jumps.
+    TownManager.tsx         # v0.9 Phase 4: right-side drawer (bottom sheet ≤720px) mounted
+                            # at App layout level via useUIStore. Switch/edit/create/delete
+                            # towns. Inline edit = name + (ACNH-only) hemisphere — game is
+                            # read-only post-create (Decision 1). Replaces CreateTownModal,
+                            # EditTownModal, TownSwitcher, TownNameFields.
     StatsTab.tsx            # v0.9 Phase 9: per-category cards (3/4/5 by game) +
                             # 12-column yearly rhythm chart (fish + bugs always,
                             # sea added for ACNL/ACNH). Replaces AnalyticsView.
     views/
-      ActivityFeed.tsx      # Recent donations list
+      ActivityFeed.tsx      # Recent donations list (consumed by HomeTab).
+                            # AnalyticsView + SectionCard retired in Phase 9.
     search/
       GlobalSearchDropdown.tsx # v0.9 Phase 8: unified search dropdown — anchored
                                # under the Home topbar input. Grouped category
@@ -90,18 +109,29 @@ src/
                                # Replaces GlobalSearchBar/Results/HistoryPopover.
   hooks/
     useHydration.ts         # Gates render on Zustand persist rehydration (onFinishHydration)
-    useMuseumData.ts        # Fetches and caches all 4 category JSONs for active town's game
+    useMuseumData.ts        # Fetches and caches all category JSONs for the active town's game
     useCategoryStats.ts     # Memoized donated counts per category
     useJumpToRow.ts         # v0.9 Phase 6: navigate to a category tab + set
-                            # highlightId so ACCanvas scrolls + pulses the target row
+                            # highlightId so ACCanvas scrolls + pulses the target row.
+                            # Wired by HomeTab shelves and GlobalSearchDropdown.
+                            # `useSearch.ts` retired in Phase 8 — search state now
+                            # lives inside GlobalSearchDropdown.
   lib/
-    store.ts                # Zustand store: towns, donations, activeTownId. persist key 'ac-web' v2.
+    store.ts                # Zustand app store: towns, donations, activeTownId. persist
+                            # key 'ac-web' schema v3. Includes resetActiveTownDonations
+                            # + resetAll (Phase 3 Settings danger zone). createTown signature
+                            # is (name, gameId, hemisphere?); updateTown takes a TownPatch
+                            # ({ name?, hemisphere? }) — gameId is intentionally not patchable
+                            # post-create (Decision 1). `playerName` removed from Town in
+                            # Phase 4 (Decision 5).
+    uiStore.ts              # v0.9 Phase 4: non-persisted Zustand store for transient UI
+                            # state (`townManagerOpen`, `townManagerForceCreate`).
     bootstrapMigration.ts   # One-time localStorage rename (ac-web:v1 → ac-web), called in main.tsx
-    storeMigrations.ts      # Zustand migrate callback: v1→v2 schema lift
+    storeMigrations.ts      # Zustand migrate callback: v1→v2 schema lift, v2→v3 hemisphere backfill
     categoryMeta.ts         # CATEGORY_META constant (label/Icon/file per category)
     viewTypes.ts            # ViewId and AllData types
     constants.ts            # MONTH_NAMES, CATEGORY_LABELS, CATEGORY_ORDER, SEASONS
-    colors.ts               # Design token hex constants
+    colors.ts               # Design tokens — `meadow` export (v0.9 Phase 1) mirrors the CSS custom properties in `src/index.css` `@theme`. Legacy `colors` export kept until all consumers are removed. Includes `fontStacks` for Fraunces/Inter.
     types.ts                # Shared TypeScript interfaces (Town, Donation, GameId, Game, etc.)
     utils.ts                # Helper functions (formatting, date math, type guards)
     csvExport.ts            # CSV export logic for donation data
@@ -131,20 +161,28 @@ public/data/acnh/
 docs/
   dev-process.md            # PR checklist and dev process rules for Claude Code sessions
   architecture.md           # Deep architectural context: store schema, migrations, multi-game types
+  decisions.md              # Reverse-chronological design decision log
+  v0.9-plan.md              # Canonical v0.9.0-beta implementation plan + locked decisions
+  design-handoffs/          # v0.9 / v0.9.1 / v0.9.2 design specs ("Curator" codename)
   v0.7-audit.md             # Codebase audit: component modularity, type safety, latent bugs
   v0.7-architecture-proposal.md  # Multi-game foundation design: store schema, decomposition plan
 ```
 
-### Design System
+### Design System (Meadow — v0.9)
 
-Inline hex constants via `src/lib/colors.ts` — **no Tailwind design tokens**:
-- `#7B5E3B` — wood (header/section backgrounds)
-- `#F5E9D4` — paper (card backgrounds)
-- `#2A2A2A` — ink (primary text)
-- `#3CA370` — leaf (progress bars, success states)
-- `#E7DAC4` — border colour
-- `#5a4a35` — secondary/muted text
-- Google Fonts: **Varela Round**
+Tokens are CSS custom properties in `src/index.css` `@theme` block, mirrored in `src/lib/colors.ts` as the `meadow` export. The legacy `colors` export (parchment/wood) is retained for backwards-compatibility but is no longer the active palette. See section 5 of `docs/v0.9-plan.md` for the full token table and typographic scale.
+
+Key tokens:
+- `--bg` `#F4EFE3` · `--surface` `#FFFDF7` · `--surface-alt` `#F8F2E2`
+- `--ink` `#23241F` · `--ink-soft` `#5C5848` · `--ink-muted` `#8A8470`
+- `--border` `#E2D9C3` · `--border-strong` `#CFC4A8`
+- `--accent` `oklch(0.55 0.09 150)` (moss green) · `--accent-soft` · `--accent-ink`
+- `--warn` `oklch(0.62 0.12 50)` (clay) — leaving-soon
+- `--chip-fish` / `--chip-bugs` / `--chip-fossils` / `--chip-art` / `--chip-sea` — category identity tokens
+
+Type stack: **Fraunces** (display, opsz 9..144, 400/500/600 + italic) and **Inter** (UI, 400/500/600/700) loaded via Google Fonts. Varela Round was retired in Phase 1.
+
+Per locked decision #2, Meadow is the **only theme** — Parchment, Midnight, and Sakura were dropped from the v0.9 scope.
 
 ## Git Workflow
 
@@ -183,10 +221,9 @@ See `.claude/rules/vercel.md` for full deployment rules. Key points:
 
 ## ACCanvas.tsx
 
-`src/components/ACCanvas.tsx` was decomposed in v0.7 and is now ~298 lines (orchestration shell only).
-It mounts the active tab view, wires modals, and handles global search. All data fetching,
-filtering, and sub-component logic lives in dedicated hooks and components.
-Do not add new top-level tabs without updating the tab switch in ACCanvas and the nav list in `Sidebar`.
+`src/components/ACCanvas.tsx` is the orchestration shell that lives below the `Sidebar`. It mounts the active tab view (HomeTab, CategoryTab, StatsTab), owns the `highlightId` state for the scroll-to + pulse effect (Phase 5/6/8), wires the GlobalSearchDropdown topbar (Home tab only), and renders the persistent DetailModal for art. All data fetching lives in `useMuseumData`; per-category filtering and sectioning lives in `CategoryTab`.
+
+Do not add new top-level tabs without updating the tab switch in ACCanvas, the nav list in `Sidebar`, and `VALID_TABS` / `ViewId` in `src/lib/viewTypes.ts`.
 
 ## Roadmap
 
@@ -228,9 +265,21 @@ Do not add new top-level tabs without updating the tab switch in ACCanvas and th
   - Art tab persistent label fix — `setSelected(null)` on tab change (PR #57, Closes #26)
   - Branch-label footer suffix for non-main/development/release builds
 
-### v0.9 — Polish, onboarding, and PWA (next)
-- Seasonal/time-based filtering
-- UI redesign pass; PWA support; mobile-first responsive pass; first-run onboarding
+### v0.9.0-beta — UI revamp (in progress on `development`)
+Phases shipped to `development`:
+- Phase 1 — Meadow tokens + Fraunces/Inter; Varela Round retired (PR #63)
+- Phase 2 — Sidebar shell; MuseumHeader/TabBar/TownSwitcher retired (PR #65)
+- Phase 3 — Settings page (About + Danger zone) (PR #66)
+- Phase 4 — TownManager drawer; CreateTownModal/EditTownModal/TownNameFields retired; `playerName` removed from Town (PR #67)
+- Phase 5 — CollectibleRow + ItemExpandPanel restyle; donate moves into expand panel (PR #70)
+- Phase 6 — HomeTab rebuild + ProgressMeter (4/5 segments); closed Issue #71 ACNH "all caught up" bug (PR #72)
+- Phase 7 — CategoryTab sectioning (Leaving / Available / Out of season / Already donated) (PR #73)
+- Phase 8 — GlobalSearchDropdown; GlobalSearchBar/Results/HistoryPopover/`useSearch` retired; a11y polish tracked in Issue #76 (PR #75)
+- Phase 9 — StatsTab rebuild; AnalyticsView + SectionCard retired (PR #77)
+
+Pending:
+- Phase 10 — Mobile responsive verification pass
+- ACWW + ACCF art data (PR #78, closes Issue #74)
 
 ### v1.0 — Launch ready
 - Branding, SEO, accessibility, performance audit

--- a/README.md
+++ b/README.md
@@ -9,16 +9,18 @@ A cozy companion web app for tracking Animal Crossing museum donations across mu
 ## Features
 
 - Track donations for all museum categories: Fish, Bugs, Fossils, Art, and Sea Creatures
-- Manage multiple towns — create, switch, and rename them at any time
+- Manage multiple towns from a single TownManager drawer — switch, rename, create, and delete (game is locked at create-time)
 - **Five games supported:** Animal Crossing (GCN), Wild World, City Folk, New Leaf, New Horizons
-- **Item inline expand** — tap a Fish, Bug, or Fossil row to expand it in-place: month availability grid, sell value, habitat, and donate/undonate button (powered by `ItemExpandPanel`)
-- **Bottom-sheet detail view** — Art rows and Search results open a full detail sheet (`DetailModal`)
-- **Hemisphere toggle** — New Horizons towns show an NH/SH toggle; month grids reflect the correct hemisphere
+- **Persistent left sidebar** with brand, active town card, per-category donation counts, and Export CSV / Settings footer
+- **Inline item expand** — tap a Fish, Bug, Fossil, or Sea Creature row to open a two-column panel with the month availability grid, bells / shadow / hours, notes, and donate/undonate button
+- **Bottom-sheet detail view** — Art opens a full detail sheet (`DetailModal`)
+- **Hemisphere toggle** — New Horizons towns expose an NH/SH toggle; month grids reflect the correct hemisphere
 - **URL-based navigation** — every town and tab has a shareable URL via React Router v6
-- Home screen with seasonal availability, leaving-soon alerts, and progress cards
-- Global search across all categories
-- Stats tab with collection analytics and monthly availability chart
-- Recent activity feed per town
+- Home screen with hero stat, current-month strip, "Leaving end of {month}" and "Just arrived" shelves, segmented progress meter, and latest donations
+- Sectioned category pages — Leaving this month / Available now / Out of season / Already donated
+- Unified global search dropdown with grouped category results, keyboard navigation, and recent-search history
+- Stats tab with per-category cards and a 12-column "Yearly rhythm" availability chart
+- Settings page — About + Danger zone (reset active town donations, reset everything)
 - CSV export of your donation records
 - Fully persistent — data saved to localStorage, no account required
 
@@ -65,6 +67,6 @@ Museum data lives in `public/data/<game>/`:
 
 ## Version
 
-Current release: **v0.8.2-alpha** (last stable). Active development: **v0.9.0-beta** — see [CHANGELOG.md](CHANGELOG.md) for history and [docs/v0.9-plan.md](docs/v0.9-plan.md) for the in-progress plan.
+Current release: **v0.8.2-alpha** (last stable on `main`). Active development: **v0.9.0-beta** — Phases 1–9 of the UI revamp shipped to `development`; Phase 10 (mobile responsive verification) pending. See [CHANGELOG.md](CHANGELOG.md) for history and [docs/v0.9-plan.md](docs/v0.9-plan.md) for the canonical plan.
 
 Significant design decisions are logged in [docs/decisions.md](docs/decisions.md).

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,94 +1,22 @@
-# Architecture Reference (v0.8.2)
+# Architecture Reference (v0.9.0-beta)
 
-Key architectural context for Claude Code sessions. See also `docs/v0.7-architecture-proposal.md`.
+This document mirrors `.claude/rules/architecture.md` — the canonical copy that Claude Code sessions auto-load. They are kept in lockstep; if they diverge, the `.claude/rules/` copy wins. Update both together.
 
-## Stack
+For the full reference (stack, key files, store schema, scroll-to + highlight wiring, multi-game support), see [`.claude/rules/architecture.md`](../.claude/rules/architecture.md).
 
-- **Framework:** Vite + React 19 + TypeScript
-- **Styling:** Tailwind CSS v4 — utility classes only; design tokens are inline hex constants in `src/lib/colors.ts`
-- **State:** Zustand ^5 with `persist` middleware (localStorage key: `ac-web`, schema version 2)
-- **Tests:** Vitest
-- **Hosting:** Vercel (auto-deploys from `main`)
+## Quick reference
 
-## Store Schema (v2, as of v0.7)
+- **Stack:** Vite + React 19 + TypeScript + Tailwind CSS v4 + Zustand + React Router v6
+- **Design:** Meadow tokens (CSS custom properties in `src/index.css` `@theme`), Fraunces + Inter (Varela Round retired in Phase 1)
+- **State:** persisted `useAppStore` (key `ac-web`, schema v3) + non-persisted `useUIStore` (TownManager open flags)
+- **Layout:** `Sidebar` (280px, sticky) + main column. `TownManager` drawer mounts at App level. `MuseumHeader` / `TabBar` / `TownSwitcher` retired in Phase 2.
+- **Highlight:** `ACCanvas` owns `highlightId`; HomeTab + `GlobalSearchDropdown` call `jumpTo(category, id)` (via `useJumpToRow`) and `CategoryTab` scrolls + pulses the matching row.
+- **Settings:** `/settings` route — About + Danger zone only (no Appearance per Decision 3).
 
-Donation data uses a **3-level schema**:
+## Reference docs
 
-```
-donated[townId][gameId][itemId] = boolean
-donatedAt[townId][gameId][itemId] = ISO timestamp
-```
-
-- `gameId` is a `GameId` union: `'ACGCN' | 'ACWW' | 'ACCF' | 'ACNL' | 'ACNH'`
-- `Town` has a `gameId` field (backfilled to `'ACGCN'` for pre-v0.7 towns)
-- Zustand `persist` is at `version: 2`; migrations in `src/lib/storeMigrations.ts`
-
-## Migration Path
-
-- `src/lib/bootstrapMigration.ts` — runs in `main.tsx` before React mounts; one-time localStorage key rename (`ac-web:v1` → `ac-web`)
-- `src/lib/storeMigrations.ts` — Zustand `migrate()` callback: v1→v2 lifts flat schema to 3-level, backfills `gameId`
-- Zero data loss for existing users
-
-## Hydration Guard
-
-- `src/hooks/useHydration.ts` — custom hook that resolves after `onFinishHydration`
-- `App.tsx` renders a loading state until the store is rehydrated — eliminates empty-state flash for returning users
-
-## ACCanvas.tsx
-
-- Orchestration shell; mounts the active tab view, wires modals, and handles global search
-- Do not add new top-level tabs without updating `VALID_TABS`, the tab-switch render, and `TabBar` props
-
-## Categories
-
-`CategoryId = 'fish' | 'bugs' | 'fossils' | 'art' | 'sea_creatures'` (added v0.8.2)
-
-`CATEGORY_ORDER` and `AllData` both include `sea_creatures`. Sea creatures are loaded for ACNL and ACNH only (`GAMES_WITH_SEA_CREATURES` set in `categoryMeta.ts`); the tab is hidden for other games via data-length check.
-
-## Data Files
-
-Museum data lives in `public/data/<gameId>/`:
-- `public/data/acgcn/` — Animal Crossing GCN (40 fish, 40 bugs, 25 fossils, 13 art)
-- `public/data/acww/` — Animal Crossing Wild World (56 fish, 56 bugs, 52 fossils) — added v0.7
-- `public/data/accf/` — City Folk (40 fish, 40 bugs, 52 fossils) — added v0.7
-- `public/data/acnl/` — New Leaf (fish, bugs, fossils, art, sea creatures) — added v0.8
-- `public/data/acnh/` — New Horizons (81 fish, 80 bugs, 86 fossils, 43 art, 40 sea creatures; NH/SH months) — added v0.8
-
-Item IDs are shared across games where species overlap. The store scopes by `gameId`, so this is safe.
-
-## Multi-Game Types
-
-```ts
-type GameId = 'ACGCN' | 'ACWW' | 'ACCF' | 'ACNL' | 'ACNH';
-
-interface Game {
-  id: GameId;
-  name: string;
-  shortName: string;
-  year: number;
-}
-
-const GAMES: Record<GameId, Game> = { ... }; // in src/lib/types.ts
-```
-
-## Error Handling
-
-- `src/components/ErrorBoundary.tsx` — top-level React error boundary in `App.tsx`; unhandled crashes render `ErrorState`
-- `src/components/ErrorBanner.tsx` — dismissible inline error for soft failures
-- `src/components/ErrorState.tsx` — full-page fallback for hard failures
-- `AppErrorKind` discriminated union in `src/lib/types.ts`
-
-## Design Tokens
-
-Inline hex values via `src/lib/colors.ts` — **no Tailwind design tokens**:
-- `#7B5E3B` — wood (header/section backgrounds)
-- `#F5E9D4` — paper (card backgrounds)
-- `#2A2A2A` — ink (primary text)
-- `#3CA370` — leaf (progress bars, success states)
-- `#E7DAC4` — border colour
-- `#5a4a35` — secondary/muted text
-- Google Fonts: **Varela Round**
-
-## Constants
-
-Shared constants in `src/lib/constants.ts`: `MONTH_NAMES`, `CATEGORY_LABELS`, `CATEGORY_ORDER`, `SEASONS`.
+- `docs/v0.9-plan.md` — canonical v0.9.0-beta plan + 10 locked decisions
+- `docs/decisions.md` — reverse-chronological decision log
+- `docs/design-handoffs/` — v0.9 / v0.9.1 / v0.9.2 design specs
+- `docs/dev-process.md` — full dev process
+- `docs/v0.7-audit.md` / `v0.7-architecture-proposal.md` — multi-game foundation history

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -4,6 +4,16 @@ Reverse-chronological record of significant design and scope decisions. Newest f
 
 ---
 
+## 2026-05-03 — v0.9.0-beta locked decisions live in `docs/v0.9-plan.md`
+
+**Decision:** The 10 locked design decisions for the v0.9 UI revamp (game immutability, Meadow-only theme, Settings = About + Danger only, sea creatures in StatsTab, `playerName` deprecation, ACNH-only hemisphere, native `confirm()`, `basedOn` art search, sea in GlobalSearchDropdown, scroll-to + highlight wiring) are recorded in `docs/v0.9-plan.md` section 4 rather than duplicated here.
+
+**Why:** The plan doc is the canonical reference for v0.9 scope and is read alongside the design handoffs in `docs/design-handoffs/`. Splitting the decisions across two files would create two sources of truth. This log continues to capture decisions that don't sit inside an active plan doc (incident-driven, post-ship, scope tradeoffs).
+
+**Pointer:** See `docs/v0.9-plan.md` § 4 "Locked Design Decisions" for the binding list.
+
+---
+
 ## 2026-05-01 — Shadow size not surfaced in any UI — defer to v0.9 (Issue #59)
 
 **Decision:** Defer adding shadow size display to v0.9. Do not add it to v0.8.2.

--- a/docs/v0.9-plan.md
+++ b/docs/v0.9-plan.md
@@ -1,6 +1,6 @@
 # v0.9.0-beta — Implementation Plan
 
-**Status:** In design / Pre-implementation  
+**Status:** In implementation — Phases 1–9 shipped to `development`; Phase 10 (mobile responsive) pending  
 **Target tag:** `v0.9.0-beta`  
 **Planned milestone:** Following v0.8.2-alpha (shipped 2026-05-01)  
 **Document date:** 2026-05-03  
@@ -337,7 +337,7 @@ Parallel work is allowed within a phase where components are independent. The ph
 
 ---
 
-### Phase 3 — Settings Page
+### Phase 3 — Settings Page ✅ shipped (PR #66)
 
 **Branch:** `feature/v09-phase-3-settings`  
 **Goal:** Full-page settings route. Two sections: About + Danger zone.
@@ -361,7 +361,7 @@ Parallel work is allowed within a phase where components are independent. The ph
 
 ---
 
-### Phase 4 — TownManager Drawer
+### Phase 4 — TownManager Drawer ✅ shipped (PR #67)
 
 **Branch:** `feature/v09-phase-4-townmanager`  
 **Goal:** Replace `CreateTownModal`, `EditTownModal`, and the stub "Switch town" link from Phase 2 with a single right-side TownManager drawer.
@@ -388,7 +388,7 @@ Parallel work is allowed within a phase where components are independent. The ph
 
 ---
 
-### Phase 5 — CollectibleRow + ItemExpandPanel Restyle
+### Phase 5 — CollectibleRow + ItemExpandPanel Restyle ✅ shipped (PR #70)
 
 **Branch:** `feature/v09-phase-5-rows`  
 **Goal:** Restyle item rows and inline expand panels to match v0.9 design. Wire `data-row-id` and `highlightId` for scroll-to (Decision 10).
@@ -433,7 +433,7 @@ Parallel work is allowed within a phase where components are independent. The ph
 
 ---
 
-### Phase 6 — HomeTab + ProgressMeter ✅
+### Phase 6 — HomeTab + ProgressMeter ✅ shipped (PR #72; closes #71 — ACNH "all caught up" bug)
 
 **Branch:** `feature/v09-phase-6-home`  
 **Goal:** Rebuild HomeTab with hero + month strip + leaving/new shelves. Ship ProgressMeter with 5-segment support for ACNL/ACNH.
@@ -467,7 +467,7 @@ Parallel work is allowed within a phase where components are independent. The ph
 
 ---
 
-### Phase 7 — CategoryTab Sectioning ✅
+### Phase 7 — CategoryTab Sectioning ✅ shipped (PR #73)
 
 **Branch:** `feature/v09-phase-7-sections`  
 **Goal:** Group category items into 4 sections instead of a flat A–Z list.
@@ -494,7 +494,7 @@ Parallel work is allowed within a phase where components are independent. The ph
 
 ---
 
-### Phase 8 — GlobalSearchDropdown ✅
+### Phase 8 — GlobalSearchDropdown ✅ shipped (PR #75; a11y polish tracked in Issue #76)
 
 **Branch:** `feature/v09-phase-8-search`  
 **Goal:** Replace `GlobalSearchBar`, `GlobalSearchResults`, `SearchHistoryPopover` with `GlobalSearchDropdown`.
@@ -522,7 +522,7 @@ Parallel work is allowed within a phase where components are independent. The ph
 
 ---
 
-### Phase 9 — StatsTab ✅
+### Phase 9 — StatsTab ✅ shipped (PR #77)
 
 **Branch:** `feature/v09-phase-9-stats`  
 **Goal:** Rebuild StatsTab with per-category cards and updated yearly rhythm chart.
@@ -543,7 +543,7 @@ Parallel work is allowed within a phase where components are independent. The ph
 
 ---
 
-### Phase 10 — Mobile Responsive Verification
+### Phase 10 — Mobile Responsive Verification ⏳ pending
 
 **Branch:** `feature/v09-phase-10-mobile`  
 **Goal:** Audit and fix any mobile regressions; verify all 980px breakpoint behaviors.


### PR DESCRIPTION
## Summary

Doc-only hygiene pass to bring repo documentation in sync with v0.9.0-beta as Phases 1–9 have all merged to `development`. No code changes — verified `npm run build` and `npm test` (63 passed) still clean.

Diffs the docs against current code state and updates references to retired components, missing additions (Phase 9 StatsTab, useUIStore, useJumpToRow, etc.), and stale phase status markers.

## Files touched

- **CLAUDE.md** — Rewrote version banner, file tree, design system, ACCanvas section, and roadmap. Updated sidebar/TownManager/scroll-to architecture notes. Added new entries (Sidebar, TownManager, CategoryTab, StatsTab, ProgressMeter, SettingsPage/Route, useJumpToRow, useUIStore). Flagged retired components (MuseumHeader, TabBar, TownSwitcher, CreateTownModal, EditTownModal, TownNameFields, GlobalSearchBar/Results/HistoryPopover, useSearch, AnalyticsView, SectionCard) and noted CategoryProgress.tsx is dead pending follow-up cleanup.
- **docs/v0.9-plan.md** — Marked Phases 3, 4, 5, 7, 8, 9 ✅ with PR refs. Expanded Phase 6 ✅ to call out Issue #71 (ACNH "all caught up"). Marked Phase 10 ⏳ pending. Updated doc-level status header to "In implementation."
- **docs/architecture.md** — Rewrote as a thin pointer to `.claude/rules/architecture.md` (which Claude Code auto-loads) to prevent drift. Was stale at v0.8.2.
- **.claude/rules/architecture.md** — Full rewrite for v0.9. Captures new shell, store reset actions, `useUIStore`, Decision 1 (game immutable), Decision 5 (no `playerName`), Decision 10 highlight wiring, Phase 8 search routing.
- **.claude/rules/dev-process.md** — Fixed stale dev preview URL (was pointing at the long-form `animalcrossingwebapp-git-development-...` host).
- **README.md** — Refreshed feature list to describe sidebar, TownManager, CategoryTab sectioning, GlobalSearchDropdown, StatsTab "Yearly rhythm" chart, and Settings page. Reworded version reference to make Phases 1–9 status visible.
- **docs/decisions.md** — Added 2026-05-03 pointer entry directing readers to `docs/v0.9-plan.md` § 4 for the v0.9 locked decisions, rather than duplicating them. Older entries left untouched.

## Notes

- Did **not** touch CHANGELOG.md — verified all Phase 1–9 entries are present and accurate.
- `public/version-history.html` dev-preview link is correct as-is; the memory-flagged staleness wasn't reproducible. Left untouched.
- `src/components/shared/CategoryProgress.tsx` is dead (no importers) but was left in tree — flagged in CLAUDE.md for a follow-up cleanup PR rather than scope-creeping this doc sweep.
- Phase 10 language kept as "pending" per request — no speculative content.

## Test plan
- [x] `npm run build` clean
- [x] `npm test` — 63/63 passed
- [ ] Bea visual review of CLAUDE.md / v0.9-plan.md / architecture refs