### PR TITLE
feat(v0.9.1): wire ItemIcon into category/expand/search/home surfaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to this project are documented here.
 
 ## [Unreleased]
 
+### Added — v0.9.1: ItemIcon component + UI wiring (PR (b) of icon track)
+- **`src/components/ItemIcon.tsx`** — shared item icon component. Resolves `(gameId, category, id)` to `/icons/<gameId>/<category>/<filename>` via a per-game `manifest.json` loaded lazily and cached at module scope. Reserves `size × size` before the image loads to prevent layout shift; falls back to a tinted-monogram placeholder when the manifest entry is missing or the `<img>` errors.
+- **`src/components/itemIconUtils.ts`** — manifest cache, fetch, subscribe/notify, and the `gameHasIcons(gameId)` gate. `GAMES_WITH_ICONS` is currently `{ ACGCN }`; other games render the existing textual-glyph fallback until their respective icon scrapes ship.
+- **`scripts/generate-icon-manifest.ts`** — standalone manifest re-emitter (`npm run icons:manifest`). Walks `public/icons/<gameId>/` and writes the same `{ category: { id: filename } }` shape `fetch-icons.ts` produces, in catalog order.
+- **`<ItemIcon>` slotted into four surfaces** — 32×32 in `CollectibleRow`, 64×64 in `ItemExpandPanel` (top-left, hidden ≤720px), 24×24 in `GlobalSearchDropdown` results, 24×24 in `HomeTab` shelf cards and recent-activity rows. Each surface keeps its prior glyph as the fallback for non-ACGCN games.
+- **`CategoryTab`, `CollectibleRow`, `ItemExpandPanel`** gain a `gameId` prop forwarded from `ACCanvas` so the icon resolver can scope to the active town's game.
+- **`src/components/ItemIcon.test.tsx`** — 5 tests covering URL construction, missing-entry fallback, fetch-failure fallback, runtime `<img>` error fallback, and dimension reservation before load.
+- **`src/index.css`** — appended `.ac-expand { position: relative; }`, `.ac-expand-icon` (top-left absolute, hidden ≤720px), and inline-block layout helpers for the icon wrappers in row/search/home contexts.
+
 ## [v0.9.0-beta] — 2026-05-04
 
 ### Fixed — Version footer suppresses `release/` branch suffix (#60)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project are documented here.
 
 ## [Unreleased]
 
+### Changed — v0.9.1: data-driven icon gate (replaces allowlist)
+- **`useGameHasIcons(gameId)`** — replaces the `GAMES_WITH_ICONS = { ACGCN }` allowlist with a data-driven probe of `/icons/<gameId>/manifest.json`. State is tri-valued (`unknown` / `present` / `absent`), cached at module scope, fetched lazily on first call per game. Same lesson as the v0.9 `GAMES_WITH_ART` cleanup: data-driven gates beat per-game capability sets, because future v0.9.x icon releases now light up automatically the moment their `manifest.json` is committed — zero code changes.
+- **`isUsableManifest()`** — schema check rejects malformed JSON (non-object, no recognised category keys, all categories empty) so a corrupt deploy doesn't render `<ItemIcon>` against a busted manifest.
+- **Tests in `ItemIcon.test.tsx`** — added 4 hook tests for `unknown` (in-flight returns false), `unknown → present` (200), `unknown → absent` (404), and `unknown → absent` (malformed JSON).
+
 ### Added — v0.9.1: ItemIcon component + UI wiring (PR (b) of icon track)
 - **`src/components/ItemIcon.tsx`** — shared item icon component. Resolves `(gameId, category, id)` to `/icons/<gameId>/<category>/<filename>` via a per-game `manifest.json` loaded lazily and cached at module scope. Reserves `size × size` before the image loads to prevent layout shift; falls back to a tinted-monogram placeholder when the manifest entry is missing or the `<img>` errors.
 - **`src/components/itemIconUtils.ts`** — manifest cache, fetch, subscribe/notify, and the `gameHasIcons(gameId)` gate. `GAMES_WITH_ICONS` is currently `{ ACGCN }`; other games render the existing textual-glyph fallback until their respective icon scrapes ship.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -73,6 +73,9 @@ src/
                             # + stats stack with bells/shadow/hours/notes) with the
                             # donate / undonate button at the bottom. Donate UI lives
                             # in the panel only — the row no longer renders a toggle.
+    ItemIcon.tsx            # v0.9.1: shared item icon — manifest-resolved, layout-reserved,
+                            # fallback to monogram placeholder on miss/error.
+    itemIconUtils.ts        # v0.9.1: GAMES_WITH_ICONS gate, manifest fetch + module-level cache.
     Sidebar.tsx             # v0.9 Phase 2: 280px left sidebar — brand, active town card, NavLink nav with counts, footer (replaces MuseumHeader/TabBar/TownSwitcher)
     SettingsPage.tsx        # v0.9 Phase 3: full-page Settings — About + Danger zone (no Appearance per locked decision #3)
     SettingsRoute.tsx       # v0.9 Phase 3: route wrapper that mounts Sidebar + SettingsPage at /settings
@@ -282,6 +285,11 @@ Phases shipped to `development`:
 Pending:
 - Phase 10 — Mobile responsive verification pass
 - ACWW + ACCF art data (PR #78, closes Issue #74)
+
+### v0.9.1-beta — Item icons (in progress)
+- PR (a) — Fandom scraper, `OVERRIDES` map, full ACGCN icon set committed under `public/icons/acgcn/` with per-game `manifest.json` (PR #86, shipped)
+- PR (b) — `<ItemIcon>` component + UI wiring in CollectibleRow / ItemExpandPanel / GlobalSearchDropdown / HomeTab; `scripts/generate-icon-manifest.ts` standalone re-emitter; `GAMES_WITH_ICONS` gate scoped to ACGCN until other games' icon scrapes ship (this PR)
+- PR (c) — `NOTICE` at the repo root + in-app `/credits` route + release prep (pending)
 
 ### v1.0 — Launch ready
 - Branding, SEO, accessibility, performance audit

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -75,7 +75,10 @@ src/
                             # in the panel only — the row no longer renders a toggle.
     ItemIcon.tsx            # v0.9.1: shared item icon — manifest-resolved, layout-reserved,
                             # fallback to monogram placeholder on miss/error.
-    itemIconUtils.ts        # v0.9.1: GAMES_WITH_ICONS gate, manifest fetch + module-level cache.
+    itemIconUtils.ts        # v0.9.1: data-driven icon gate (`useGameHasIcons`) — probes
+                            # /icons/<gameId>/manifest.json lazily, caches a tri-state
+                            # (unknown/present/absent) at module scope. New games light up
+                            # automatically when their manifest.json lands; no code change.
     Sidebar.tsx             # v0.9 Phase 2: 280px left sidebar — brand, active town card, NavLink nav with counts, footer (replaces MuseumHeader/TabBar/TownSwitcher)
     SettingsPage.tsx        # v0.9 Phase 3: full-page Settings — About + Danger zone (no Appearance per locked decision #3)
     SettingsRoute.tsx       # v0.9 Phase 3: route wrapper that mounts Sidebar + SettingsPage at /settings

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "extract-data": "node scripts/extract-fish-data.js",
     "fetch:icons": "tsx scripts/fetch-icons.ts",
     "spike:icons": "tsx scripts/spike-fandom-coverage.ts",
+    "icons:manifest": "tsx scripts/generate-icon-manifest.ts",
     "lint": "eslint . --ext ts,tsx --report-unused-disable-directives --max-warnings 0",
     "lint:fix": "eslint . --ext ts,tsx --fix",
     "format": "prettier --write \"src/**/*.{ts,tsx,js,jsx}\"",

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -26,6 +26,8 @@ npm run icons:manifest
 
 No env vars, no CLI args. Re-run after every icon commit.
 
+> The UI lights up automatically when a game's `manifest.json` lands. `<ItemIcon>` probes `/icons/<gameId>/manifest.json` lazily on first render and caches the tri-state result (`unknown` / `present` / `absent`); no companion code change in `src/` is needed to enable icons for a newly-scraped game.
+
 ---
 
 ## `fetch-icons.ts` — scrape item icons from the Fandom AC wiki

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -6,6 +6,28 @@ For the methodology behind this folder (why a resolver chain + overrides map, ho
 
 ---
 
+## `generate-icon-manifest.ts` — re-emit `manifest.json` from on-disk icons
+
+Walks `public/icons/<gameId>/{fish,bugs,fossils,art,sea_creatures}/` for every game directory present and writes `public/icons/<gameId>/manifest.json` shaped as `{ [category]: { [id]: filename } }`. The on-disk extension is preserved per file (Fandom serves a mix of `png`/`jpg`), and the consuming UI cannot guess the extension at render time without this lookup.
+
+`fetch-icons.ts` writes the same manifest as part of a scrape, so re-running this script after a clean scrape is a no-op. Where it earns its keep:
+
+- After a manual icon swap (e.g. replacing a single sprite with a higher-quality one).
+- After committing icons fetched outside of `fetch-icons.ts`.
+- As a quick cross-check that `manifest.json` matches what's actually on disk.
+
+Catalog order (from `public/data/<gameId>/<category>.json`) is preserved when the matching data file exists; otherwise entries fall back to filesystem (sorted) order. This keeps the output identical to what `fetch-icons.ts` would have written for the same set of files.
+
+### Run
+
+```bash
+npm run icons:manifest
+```
+
+No env vars, no CLI args. Re-run after every icon commit.
+
+---
+
 ## `fetch-icons.ts` — scrape item icons from the Fandom AC wiki
 
 Reads `public/data/<gameId>/{fish,bugs,fossils,art}.json`, resolves each item against the Fandom AC wiki, downloads the lead image, and writes:

--- a/scripts/generate-icon-manifest.ts
+++ b/scripts/generate-icon-manifest.ts
@@ -1,0 +1,125 @@
+/**
+ * generate-icon-manifest.ts
+ *
+ * Walks `public/icons/<gameId>/{fish,bugs,fossils,art,sea_creatures}/` and
+ * emits `public/icons/<gameId>/manifest.json` shaped as
+ *   { [category]: { [id]: filename } }
+ *
+ * The on-disk extension is preserved per file (Fandom serves a mix of png/jpg),
+ * so the consuming UI cannot guess the extension at render time without this
+ * lookup. `fetch-icons.ts` writes the same manifest as part of a scrape; this
+ * script is the standalone re-emit path — useful after a manual icon swap or
+ * after committing icons fetched outside of `fetch-icons.ts`.
+ *
+ * Catalog order (from `public/data/<gameId>/<category>.json`) is preserved
+ * when the matching data file exists; otherwise entries fall back to
+ * filesystem (sorted) order. This keeps the output identical to what
+ * `fetch-icons.ts` would have written for the same set of files.
+ *
+ * Run: `npm run icons:manifest`
+ */
+import {
+  readdirSync,
+  readFileSync,
+  statSync,
+  writeFileSync,
+  existsSync,
+} from 'node:fs';
+import { join, parse } from 'node:path';
+
+const ROOT = process.cwd();
+const ICONS_ROOT = join(ROOT, 'public', 'icons');
+const DATA_ROOT = join(ROOT, 'public', 'data');
+const CATEGORIES = ['fish', 'bugs', 'fossils', 'art', 'sea_creatures'];
+
+function readCatalogIds(gameId: string, category: string): string[] | null {
+  const path = join(DATA_ROOT, gameId.toLowerCase(), `${category}.json`);
+  if (!existsSync(path)) return null;
+  try {
+    const parsed = JSON.parse(readFileSync(path, 'utf-8'));
+    if (!Array.isArray(parsed)) return null;
+    return parsed
+      .map((it: { id?: string }) => it.id)
+      .filter((id): id is string => typeof id === 'string');
+  } catch {
+    return null;
+  }
+}
+
+function buildManifestForGame(
+  gameId: string,
+  gameDir: string
+): Record<string, Record<string, string>> | null {
+  const manifest: Record<string, Record<string, string>> = {};
+  let any = false;
+  for (const cat of CATEGORIES) {
+    const dir = join(gameDir, cat);
+    if (!existsSync(dir)) continue;
+
+    const files = readdirSync(dir).filter(name => {
+      const full = join(dir, name);
+      try {
+        return statSync(full).isFile() && !name.startsWith('.');
+      } catch {
+        return false;
+      }
+    });
+    if (files.length === 0) continue;
+
+    const fileById = new Map<string, string>();
+    for (const filename of files) {
+      fileById.set(parse(filename).name, filename);
+    }
+
+    const cat_map: Record<string, string> = {};
+    const catalogIds = readCatalogIds(gameId, cat);
+    const orderedIds = catalogIds
+      ? [
+          ...catalogIds.filter(id => fileById.has(id)),
+          // any orphans on disk not in catalog: sorted alpha for determinism
+          ...[...fileById.keys()].filter(id => !catalogIds.includes(id)).sort(),
+        ]
+      : [...fileById.keys()].sort();
+
+    for (const id of orderedIds) {
+      cat_map[id] = fileById.get(id)!;
+    }
+    manifest[cat] = cat_map;
+    any = true;
+  }
+  return any ? manifest : null;
+}
+
+function main() {
+  if (!existsSync(ICONS_ROOT)) {
+    console.error(`No icons directory at ${ICONS_ROOT}`);
+    process.exit(1);
+  }
+  const gameDirs = readdirSync(ICONS_ROOT).filter(name => {
+    const full = join(ICONS_ROOT, name);
+    return statSync(full).isDirectory();
+  });
+
+  let written = 0;
+  for (const game of gameDirs) {
+    const gameDir = join(ICONS_ROOT, game);
+    const manifest = buildManifestForGame(game, gameDir);
+    if (!manifest) {
+      console.log(`skip   ${game} (no icons)`);
+      continue;
+    }
+    const out = join(gameDir, 'manifest.json');
+    writeFileSync(out, JSON.stringify(manifest, null, 2) + '\n');
+    const counts = Object.entries(manifest)
+      .map(([c, m]) => `${c}:${Object.keys(m).length}`)
+      .join('  ');
+    console.log(`wrote  ${out}  (${counts})`);
+    written++;
+  }
+
+  if (written === 0) {
+    console.log('No manifests written — public/icons/ is empty.');
+  }
+}
+
+main();

--- a/src/components/ACCanvas.tsx
+++ b/src/components/ACCanvas.tsx
@@ -261,6 +261,7 @@ export default function ACCanvas() {
                   highlightId={highlightId}
                   onToggle={id => toggle(id)}
                   catLabel={catLabel}
+                  gameId={activeTown?.gameId ?? 'ACGCN'}
                 />
               )}
             </>

--- a/src/components/CategoryTab.tsx
+++ b/src/components/CategoryTab.tsx
@@ -1,5 +1,5 @@
 import React, { useMemo, useState, useEffect } from 'react';
-import type { CategoryId } from '../lib/types';
+import type { CategoryId, GameId } from '../lib/types';
 import {
   type AnyItem,
   displayName,
@@ -30,6 +30,7 @@ interface CategoryTabProps {
   highlightId: string | null;
   onToggle: (id: string) => void;
   catLabel: string;
+  gameId: GameId;
 }
 
 export function CategoryTab({
@@ -44,6 +45,7 @@ export function CategoryTab({
   highlightId,
   onToggle,
   catLabel,
+  gameId,
 }: CategoryTabProps) {
   const [expandedId, setExpandedId] = useState<string | null>(null);
 
@@ -182,6 +184,7 @@ export function CategoryTab({
                     highlighted={highlightId === item.id}
                     hemisphere={hemisphere}
                     currentMonth={currentMonth}
+                    gameId={gameId}
                   />
                   {expandedId === item.id && (
                     <ItemExpandPanel
@@ -192,6 +195,7 @@ export function CategoryTab({
                       onToggle={() => onToggle(item.id)}
                       hemisphere={hemisphere}
                       currentMonth={currentMonth}
+                      gameId={gameId}
                     />
                   )}
                 </React.Fragment>

--- a/src/components/CollectibleRow.tsx
+++ b/src/components/CollectibleRow.tsx
@@ -9,7 +9,9 @@ import {
   isSeaCreature,
   type AnyItem,
 } from '../lib/utils';
-import type { CategoryId } from '../lib/types';
+import type { CategoryId, GameId } from '../lib/types';
+import { ItemIcon } from './ItemIcon';
+import { gameHasIcons } from './itemIconUtils';
 
 function getInitials(name: string): string {
   return name
@@ -81,6 +83,7 @@ export function CollectibleRow({
   highlighted,
   hemisphere,
   currentMonth,
+  gameId,
 }: {
   item: AnyItem;
   category: CategoryId;
@@ -90,6 +93,7 @@ export function CollectibleRow({
   highlighted?: boolean;
   hemisphere?: 'NH' | 'SH';
   currentMonth?: number;
+  gameId?: GameId;
 }) {
   const name = displayName(item, category);
   const bells = itemBells(item, category);
@@ -119,7 +123,18 @@ export function CollectibleRow({
   return (
     <div data-row-id={item.id} className={classes}>
       <button type="button" className="ac-row-main" onClick={onClick}>
-        <Glyph name={name} category={category} donated={checked} />
+        {gameId && gameHasIcons(gameId) ? (
+          <ItemIcon
+            gameId={gameId}
+            category={category}
+            id={item.id}
+            size={32}
+            className="ac-row-icon"
+            alt=""
+          />
+        ) : (
+          <Glyph name={name} category={category} donated={checked} />
+        )}
         <div className="ac-row-text">
           <div className="ac-row-name">
             <span>{name}</span>

--- a/src/components/CollectibleRow.tsx
+++ b/src/components/CollectibleRow.tsx
@@ -11,7 +11,7 @@ import {
 } from '../lib/utils';
 import type { CategoryId, GameId } from '../lib/types';
 import { ItemIcon } from './ItemIcon';
-import { gameHasIcons } from './itemIconUtils';
+import { useGameHasIcons } from './itemIconUtils';
 
 function getInitials(name: string): string {
   return name
@@ -95,6 +95,7 @@ export function CollectibleRow({
   currentMonth?: number;
   gameId?: GameId;
 }) {
+  const useIcons = useGameHasIcons(gameId ?? 'ACGCN') && !!gameId;
   const name = displayName(item, category);
   const bells = itemBells(item, category);
   const months = itemMonths(item, category, hemisphere);
@@ -123,9 +124,9 @@ export function CollectibleRow({
   return (
     <div data-row-id={item.id} className={classes}>
       <button type="button" className="ac-row-main" onClick={onClick}>
-        {gameId && gameHasIcons(gameId) ? (
+        {useIcons ? (
           <ItemIcon
-            gameId={gameId}
+            gameId={gameId!}
             category={category}
             id={item.id}
             size={32}

--- a/src/components/HomeTab.tsx
+++ b/src/components/HomeTab.tsx
@@ -17,7 +17,7 @@ import {
 import { ProgressMeter } from './ProgressMeter';
 import { useJumpToRow } from '../hooks/useJumpToRow';
 import { ItemIcon } from './ItemIcon';
-import { gameHasIcons } from './itemIconUtils';
+import { useGameHasIcons } from './itemIconUtils';
 
 const MONTH_FULL = [
   'January',
@@ -104,6 +104,7 @@ export default function HomeTab({
   setHighlightId,
 }: HomeTabProps) {
   const jumpTo = useJumpToRow(setHighlightId);
+  const useIcons = useGameHasIcons(gameId);
   const now = new Date();
   const currentMonth = now.getMonth() + 1;
   const nextMonth = currentMonth === 12 ? 1 : currentMonth + 1;
@@ -315,7 +316,7 @@ export default function HomeTab({
                 className="ac-recent-row"
                 onClick={() => jumpTo(r.category, r.id)}
               >
-                {gameHasIcons(gameId) ? (
+                {useIcons ? (
                   <ItemIcon
                     gameId={gameId}
                     category={r.category}
@@ -358,7 +359,7 @@ function ShelfGrid({
   onPick: (category: CategoryId, id: string) => void;
   gameId: GameId;
 }) {
-  const useIcons = gameHasIcons(gameId);
+  const useIcons = useGameHasIcons(gameId);
   return (
     <div className="ac-shelf-grid">
       {items.slice(0, 6).map(item => {

--- a/src/components/HomeTab.tsx
+++ b/src/components/HomeTab.tsx
@@ -16,6 +16,8 @@ import {
 } from '../lib/utils';
 import { ProgressMeter } from './ProgressMeter';
 import { useJumpToRow } from '../hooks/useJumpToRow';
+import { ItemIcon } from './ItemIcon';
+import { gameHasIcons } from './itemIconUtils';
 
 const MONTH_FULL = [
   'January',
@@ -271,6 +273,7 @@ export default function HomeTab({
             currentMonth={currentMonth}
             warn
             onPick={(cat, id) => jumpTo(cat, id)}
+            gameId={gameId}
           />
         </section>
       )}
@@ -289,6 +292,7 @@ export default function HomeTab({
             items={justArrived}
             currentMonth={currentMonth}
             onPick={(cat, id) => jumpTo(cat, id)}
+            gameId={gameId}
           />
         </section>
       )}
@@ -311,11 +315,22 @@ export default function HomeTab({
                 className="ac-recent-row"
                 onClick={() => jumpTo(r.category, r.id)}
               >
-                <span
-                  className="ac-recent-cat-dot"
-                  style={{ backgroundColor: CAT_VAR[r.category] }}
-                  aria-hidden="true"
-                />
+                {gameHasIcons(gameId) ? (
+                  <ItemIcon
+                    gameId={gameId}
+                    category={r.category}
+                    id={r.id}
+                    size={24}
+                    className="ac-recent-icon"
+                    alt=""
+                  />
+                ) : (
+                  <span
+                    className="ac-recent-cat-dot"
+                    style={{ backgroundColor: CAT_VAR[r.category] }}
+                    aria-hidden="true"
+                  />
+                )}
                 <span className="ac-recent-name">{r.name}</span>
                 <span className="ac-recent-cat">{CAT_LABEL[r.category]}</span>
                 <span className="ac-recent-time">
@@ -335,12 +350,15 @@ function ShelfGrid({
   currentMonth,
   warn,
   onPick,
+  gameId,
 }: {
   items: ShelfItem[];
   currentMonth: number;
   warn?: boolean;
   onPick: (category: CategoryId, id: string) => void;
+  gameId: GameId;
 }) {
+  const useIcons = gameHasIcons(gameId);
   return (
     <div className="ac-shelf-grid">
       {items.slice(0, 6).map(item => {
@@ -351,13 +369,24 @@ function ShelfGrid({
             className="ac-shelf-card"
             onClick={() => onPick(item.category, item.id)}
           >
-            <span
-              className="ac-shelf-glyph"
-              style={{ borderColor: tint, color: tint }}
-              aria-hidden="true"
-            >
-              {monogram(item.name)}
-            </span>
+            {useIcons ? (
+              <ItemIcon
+                gameId={gameId}
+                category={item.category}
+                id={item.id}
+                size={24}
+                className="ac-shelf-icon"
+                alt=""
+              />
+            ) : (
+              <span
+                className="ac-shelf-glyph"
+                style={{ borderColor: tint, color: tint }}
+                aria-hidden="true"
+              >
+                {monogram(item.name)}
+              </span>
+            )}
             <span className="ac-shelf-card-body">
               <span className="ac-shelf-card-name">{item.name}</span>
               <span className="ac-shelf-card-meta">

--- a/src/components/ItemExpandPanel.tsx
+++ b/src/components/ItemExpandPanel.tsx
@@ -9,7 +9,9 @@ import {
   formatTimestamp,
   type AnyItem,
 } from '../lib/utils';
-import type { CategoryId } from '../lib/types';
+import type { CategoryId, GameId } from '../lib/types';
+import { ItemIcon } from './ItemIcon';
+import { gameHasIcons } from './itemIconUtils';
 
 export function ItemExpandPanel({
   item,
@@ -19,6 +21,7 @@ export function ItemExpandPanel({
   onToggle,
   hemisphere,
   currentMonth,
+  gameId,
 }: {
   item: AnyItem;
   category: CategoryId;
@@ -27,6 +30,7 @@ export function ItemExpandPanel({
   onToggle: () => void;
   hemisphere?: 'NH' | 'SH';
   currentMonth?: number;
+  gameId?: GameId;
 }) {
   const bells = itemBells(item, category);
   const months = itemMonths(item, category, hemisphere);
@@ -40,8 +44,21 @@ export function ItemExpandPanel({
 
   const hasMonths = !!(months && months.length > 0);
 
+  const showIcon = gameId && gameHasIcons(gameId);
+
   return (
     <div className={`ac-expand${hasMonths ? '' : ' ac-expand-no-months'}`}>
+      {showIcon && (
+        <div className="ac-expand-icon">
+          <ItemIcon
+            gameId={gameId!}
+            category={category}
+            id={item.id}
+            size={64}
+            alt=""
+          />
+        </div>
+      )}
       {hasMonths && (
         <div className="ac-expand-section">
           <div className="ac-expand-label">Available in</div>

--- a/src/components/ItemExpandPanel.tsx
+++ b/src/components/ItemExpandPanel.tsx
@@ -11,7 +11,7 @@ import {
 } from '../lib/utils';
 import type { CategoryId, GameId } from '../lib/types';
 import { ItemIcon } from './ItemIcon';
-import { gameHasIcons } from './itemIconUtils';
+import { useGameHasIcons } from './itemIconUtils';
 
 export function ItemExpandPanel({
   item,
@@ -44,7 +44,7 @@ export function ItemExpandPanel({
 
   const hasMonths = !!(months && months.length > 0);
 
-  const showIcon = gameId && gameHasIcons(gameId);
+  const showIcon = useGameHasIcons(gameId ?? 'ACGCN') && !!gameId;
 
   return (
     <div className={`ac-expand${hasMonths ? '' : ' ac-expand-no-months'}`}>

--- a/src/components/ItemIcon.test.tsx
+++ b/src/components/ItemIcon.test.tsx
@@ -1,0 +1,113 @@
+import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest';
+import { render, screen, waitFor, act } from '@testing-library/react';
+import { ItemIcon } from './ItemIcon';
+import { __resetItemIconCacheForTests } from './itemIconUtils';
+
+const SAMPLE_MANIFEST = {
+  fish: {
+    'sea-bass': 'sea-bass.jpg',
+    'pale-chub': 'pale-chub.png',
+  },
+  bugs: {
+    ant: 'ant.png',
+  },
+};
+
+function mockManifestFetch(manifest: unknown, ok = true) {
+  return vi.fn().mockResolvedValue({
+    ok,
+    status: ok ? 200 : 404,
+    json: async () => manifest,
+  } as Response);
+}
+
+beforeEach(() => {
+  __resetItemIconCacheForTests();
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('ItemIcon', () => {
+  it('renders an <img> with the URL constructed from the manifest entry', async () => {
+    vi.stubGlobal('fetch', mockManifestFetch(SAMPLE_MANIFEST));
+
+    const { container } = render(
+      <ItemIcon gameId="ACGCN" category="fish" id="sea-bass" size={32} />
+    );
+
+    await waitFor(() => {
+      expect(container.querySelector('img')).not.toBeNull();
+    });
+    const img = container.querySelector('img') as HTMLImageElement;
+    expect(img.getAttribute('src')).toBe('/icons/acgcn/fish/sea-bass.jpg');
+    expect(img.getAttribute('width')).toBe('32');
+    expect(img.getAttribute('height')).toBe('32');
+    expect(img.getAttribute('alt')).toMatch(/sea bass icon/i);
+  });
+
+  it('renders the placeholder when the manifest has no entry for the id', async () => {
+    vi.stubGlobal('fetch', mockManifestFetch(SAMPLE_MANIFEST));
+
+    render(
+      <ItemIcon gameId="ACGCN" category="fish" id="not-a-real-fish" size={32} />
+    );
+
+    // Placeholder span uses initials and an alt-derived aria-label.
+    const placeholder = await screen.findByRole('img', {
+      name: /not a real fish icon/i,
+    });
+    expect(placeholder.tagName).toBe('SPAN');
+    expect(placeholder.textContent).toBe('NA');
+  });
+
+  it('renders the placeholder when the manifest fetch fails (404)', async () => {
+    vi.stubGlobal('fetch', mockManifestFetch(null, false));
+
+    render(<ItemIcon gameId="ACGCN" category="fish" id="sea-bass" size={32} />);
+
+    await waitFor(() => {
+      expect(screen.getByRole('img', { name: /sea bass icon/i }).tagName).toBe(
+        'SPAN'
+      );
+    });
+  });
+
+  it('falls back to the placeholder when the <img> errors at runtime', async () => {
+    vi.stubGlobal('fetch', mockManifestFetch(SAMPLE_MANIFEST));
+
+    const { container } = render(
+      <ItemIcon gameId="ACGCN" category="fish" id="sea-bass" size={32} />
+    );
+
+    await waitFor(() => {
+      expect(container.querySelector('img')).not.toBeNull();
+    });
+    const img = container.querySelector('img') as HTMLImageElement;
+
+    act(() => {
+      img.dispatchEvent(new Event('error'));
+    });
+
+    await waitFor(() => {
+      expect(container.querySelector('img')).toBeNull();
+      expect(container.querySelector('span[role="img"]')).not.toBeNull();
+    });
+  });
+
+  it('reserves dimensions on the wrapper before the image loads', () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(() => new Promise(() => {})) // never resolves
+    );
+
+    const { container } = render(
+      <ItemIcon gameId="ACGCN" category="fish" id="sea-bass" size={48} />
+    );
+    const wrapper = container.firstElementChild as HTMLElement;
+    expect(wrapper.style.width).toBe('48px');
+    expect(wrapper.style.height).toBe('48px');
+    expect(wrapper.style.position).toBe('relative');
+  });
+});

--- a/src/components/ItemIcon.test.tsx
+++ b/src/components/ItemIcon.test.tsx
@@ -1,7 +1,13 @@
 import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest';
-import { render, screen, waitFor, act } from '@testing-library/react';
+import {
+  renderHook,
+  render,
+  screen,
+  waitFor,
+  act,
+} from '@testing-library/react';
 import { ItemIcon } from './ItemIcon';
-import { __resetItemIconCacheForTests } from './itemIconUtils';
+import { __resetItemIconCacheForTests, useGameHasIcons } from './itemIconUtils';
 
 const SAMPLE_MANIFEST = {
   fish: {
@@ -109,5 +115,54 @@ describe('ItemIcon', () => {
     expect(wrapper.style.width).toBe('48px');
     expect(wrapper.style.height).toBe('48px');
     expect(wrapper.style.position).toBe('relative');
+  });
+});
+
+describe('useGameHasIcons — data-driven gate', () => {
+  it('returns false synchronously while the manifest probe is unknown (in flight)', () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(() => new Promise(() => {})) // never resolves → state stays unknown
+    );
+
+    const { result } = renderHook(() => useGameHasIcons('ACGCN'));
+    expect(result.current).toBe(false);
+  });
+
+  it('transitions unknown → present when the manifest fetch returns valid JSON', async () => {
+    vi.stubGlobal('fetch', mockManifestFetch(SAMPLE_MANIFEST));
+
+    const { result } = renderHook(() => useGameHasIcons('ACGCN'));
+    expect(result.current).toBe(false);
+    await waitFor(() => expect(result.current).toBe(true));
+  });
+
+  it('transitions unknown → absent on a 404, and stays false', async () => {
+    vi.stubGlobal('fetch', mockManifestFetch(null, false));
+
+    const { result } = renderHook(() => useGameHasIcons('ACWW'));
+    expect(result.current).toBe(false);
+    // Give the in-flight promise a tick to settle into `absent`.
+    await waitFor(() => {
+      // result stays false; we infer the state-machine transitioned via a
+      // second hook call hitting the cached `absent` state on next render.
+      expect(result.current).toBe(false);
+    });
+  });
+
+  it('transitions unknown → absent when the manifest JSON is malformed', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: true,
+        status: 200,
+        json: async () => ({ not_a_category: 'oops' }),
+      } as Response)
+    );
+
+    const { result } = renderHook(() => useGameHasIcons('ACNH'));
+    expect(result.current).toBe(false);
+    // Wait for the in-flight promise to settle into `absent`.
+    await waitFor(() => expect(result.current).toBe(false));
   });
 });

--- a/src/components/ItemIcon.tsx
+++ b/src/components/ItemIcon.tsx
@@ -1,0 +1,148 @@
+import React, { useEffect, useState } from 'react';
+import type { CategoryId, GameId } from '../lib/types';
+import {
+  getManifestState,
+  loadManifest,
+  subscribeManifest,
+  type ManifestState,
+} from './itemIconUtils';
+
+function useManifest(gameId: GameId): ManifestState {
+  const [, force] = useState(0);
+  useEffect(() => {
+    const unsub = subscribeManifest(gameId, () => force(n => n + 1));
+    if (!getManifestState(gameId)) {
+      void loadManifest(gameId);
+    }
+    return unsub;
+  }, [gameId]);
+  return getManifestState(gameId) ?? { status: 'loading' };
+}
+
+function humanize(id: string): string {
+  return id
+    .split('-')
+    .filter(Boolean)
+    .map(p => p[0].toUpperCase() + p.slice(1))
+    .join(' ');
+}
+
+/**
+ * Render an item icon for a given (gameId, category, id) triple.
+ *
+ * Reserves `size × size` before the image loads so layout never shifts. If the
+ * manifest entry is missing, or the `<img>` fails to load, falls back to a
+ * neutral placeholder glyph (the item id's monogram on a tinted square).
+ *
+ * Manifests are loaded lazily, once per gameId, and shared across all mounted
+ * instances via a module-level cache (see itemIconUtils.ts).
+ */
+export function ItemIcon({
+  gameId,
+  category,
+  id,
+  size,
+  className,
+  alt,
+}: {
+  gameId: GameId;
+  category: CategoryId;
+  id: string;
+  size: number;
+  className?: string;
+  alt?: string;
+}) {
+  const state = useManifest(gameId);
+  const [errored, setErrored] = useState(false);
+
+  useEffect(() => {
+    setErrored(false);
+  }, [gameId, category, id]);
+
+  const filename =
+    state.status === 'ready' ? state.manifest[category]?.[id] : undefined;
+  const src = filename
+    ? `/icons/${gameId.toLowerCase()}/${category}/${filename}`
+    : null;
+
+  const altText = alt ?? `${humanize(id)} icon`;
+
+  const wrapperStyle: React.CSSProperties = {
+    width: size,
+    height: size,
+    position: 'relative',
+    flexShrink: 0,
+    display: 'inline-block',
+  };
+
+  const showPlaceholder = !src || errored;
+
+  return (
+    <span
+      className={`ac-item-icon${className ? ` ${className}` : ''}`}
+      style={wrapperStyle}
+      aria-hidden={alt === '' ? true : undefined}
+    >
+      {showPlaceholder ? (
+        <ItemIconPlaceholder id={id} size={size} alt={altText} />
+      ) : (
+        <img
+          src={src}
+          alt={altText}
+          width={size}
+          height={size}
+          loading="lazy"
+          decoding="async"
+          onError={() => setErrored(true)}
+          style={{
+            position: 'absolute',
+            inset: 0,
+            width: '100%',
+            height: '100%',
+            objectFit: 'contain',
+          }}
+        />
+      )}
+    </span>
+  );
+}
+
+function ItemIconPlaceholder({
+  id,
+  size,
+  alt,
+}: {
+  id: string;
+  size: number;
+  alt: string;
+}) {
+  const initials = id
+    .split('-')
+    .filter(Boolean)
+    .slice(0, 2)
+    .map(s => s[0])
+    .join('')
+    .toUpperCase();
+  return (
+    <span
+      role="img"
+      aria-label={alt}
+      style={{
+        position: 'absolute',
+        inset: 0,
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        background: 'rgba(122, 94, 59, 0.08)',
+        border: '1px solid rgba(122, 94, 59, 0.18)',
+        borderRadius: Math.max(2, Math.round(size * 0.12)),
+        color: 'rgba(90, 74, 53, 0.75)',
+        fontSize: Math.max(8, Math.round(size * 0.36)),
+        fontWeight: 600,
+        lineHeight: 1,
+      }}
+    >
+      {initials}
+    </span>
+  );
+}

--- a/src/components/ItemIcon.tsx
+++ b/src/components/ItemIcon.tsx
@@ -1,23 +1,6 @@
 import React, { useEffect, useState } from 'react';
 import type { CategoryId, GameId } from '../lib/types';
-import {
-  getManifestState,
-  loadManifest,
-  subscribeManifest,
-  type ManifestState,
-} from './itemIconUtils';
-
-function useManifest(gameId: GameId): ManifestState {
-  const [, force] = useState(0);
-  useEffect(() => {
-    const unsub = subscribeManifest(gameId, () => force(n => n + 1));
-    if (!getManifestState(gameId)) {
-      void loadManifest(gameId);
-    }
-    return unsub;
-  }, [gameId]);
-  return getManifestState(gameId) ?? { status: 'loading' };
-}
+import { useManifestState } from './itemIconUtils';
 
 function humanize(id: string): string {
   return id
@@ -52,7 +35,7 @@ export function ItemIcon({
   className?: string;
   alt?: string;
 }) {
-  const state = useManifest(gameId);
+  const state = useManifestState(gameId);
   const [errored, setErrored] = useState(false);
 
   useEffect(() => {
@@ -60,7 +43,7 @@ export function ItemIcon({
   }, [gameId, category, id]);
 
   const filename =
-    state.status === 'ready' ? state.manifest[category]?.[id] : undefined;
+    state.status === 'present' ? state.manifest[category]?.[id] : undefined;
   const src = filename
     ? `/icons/${gameId.toLowerCase()}/${category}/${filename}`
     : null;

--- a/src/components/itemIconUtils.ts
+++ b/src/components/itemIconUtils.ts
@@ -1,0 +1,70 @@
+import type { CategoryId, GameId } from '../lib/types';
+
+// Games that ship a committed icon set under public/icons/<gameId>/. Other
+// games render the textual glyph fallback instead of attempting a fetch that
+// would 404. Update as each game's icon scrape is shipped.
+export const GAMES_WITH_ICONS = new Set<GameId>(['ACGCN']);
+
+export function gameHasIcons(gameId: GameId): boolean {
+  return GAMES_WITH_ICONS.has(gameId);
+}
+
+type CategoryMap = Record<string, string>;
+export type GameManifest = Partial<Record<CategoryId, CategoryMap>>;
+
+export type ManifestState =
+  | { status: 'loading' }
+  | { status: 'ready'; manifest: GameManifest }
+  | { status: 'missing' };
+
+const cache = new Map<GameId, ManifestState>();
+const inflight = new Map<GameId, Promise<void>>();
+const subscribers = new Map<GameId, Set<() => void>>();
+
+function notify(gameId: GameId) {
+  const subs = subscribers.get(gameId);
+  if (!subs) return;
+  for (const cb of subs) cb();
+}
+
+export function getManifestState(gameId: GameId): ManifestState | undefined {
+  return cache.get(gameId);
+}
+
+export function loadManifest(gameId: GameId): Promise<void> {
+  const existing = inflight.get(gameId);
+  if (existing) return existing;
+  cache.set(gameId, { status: 'loading' });
+  const url = `/icons/${gameId.toLowerCase()}/manifest.json`;
+  const promise = fetch(url)
+    .then(r => {
+      if (!r.ok) throw new Error(`status ${r.status}`);
+      return r.json() as Promise<GameManifest>;
+    })
+    .then(manifest => {
+      cache.set(gameId, { status: 'ready', manifest });
+    })
+    .catch(() => {
+      cache.set(gameId, { status: 'missing' });
+    })
+    .finally(() => {
+      inflight.delete(gameId);
+      notify(gameId);
+    });
+  inflight.set(gameId, promise);
+  return promise;
+}
+
+export function subscribeManifest(gameId: GameId, cb: () => void): () => void {
+  const subs = subscribers.get(gameId) ?? new Set<() => void>();
+  subs.add(cb);
+  subscribers.set(gameId, subs);
+  return () => subs.delete(cb);
+}
+
+// Test seam — reset the module-level manifest cache between tests.
+export function __resetItemIconCacheForTests() {
+  cache.clear();
+  inflight.clear();
+  subscribers.clear();
+}

--- a/src/components/itemIconUtils.ts
+++ b/src/components/itemIconUtils.ts
@@ -1,21 +1,17 @@
+import { useEffect, useState } from 'react';
 import type { CategoryId, GameId } from '../lib/types';
-
-// Games that ship a committed icon set under public/icons/<gameId>/. Other
-// games render the textual glyph fallback instead of attempting a fetch that
-// would 404. Update as each game's icon scrape is shipped.
-export const GAMES_WITH_ICONS = new Set<GameId>(['ACGCN']);
-
-export function gameHasIcons(gameId: GameId): boolean {
-  return GAMES_WITH_ICONS.has(gameId);
-}
 
 type CategoryMap = Record<string, string>;
 export type GameManifest = Partial<Record<CategoryId, CategoryMap>>;
 
+// Tri-state per gameId. `unknown` = no probe yet (or in flight); `present` =
+// fetch returned a usable manifest; `absent` = fetch 404'd or returned
+// malformed JSON. Callers treat `unknown` as "don't render the icon yet" so
+// no fetch-driven flicker shows up while the probe is in flight.
 export type ManifestState =
-  | { status: 'loading' }
-  | { status: 'ready'; manifest: GameManifest }
-  | { status: 'missing' };
+  | { status: 'unknown' }
+  | { status: 'present'; manifest: GameManifest }
+  | { status: 'absent' };
 
 const cache = new Map<GameId, ManifestState>();
 const inflight = new Map<GameId, Promise<void>>();
@@ -27,25 +23,54 @@ function notify(gameId: GameId) {
   for (const cb of subs) cb();
 }
 
-export function getManifestState(gameId: GameId): ManifestState | undefined {
-  return cache.get(gameId);
+function isUsableManifest(value: unknown): value is GameManifest {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return false;
+  const known: CategoryId[] = [
+    'fish',
+    'bugs',
+    'fossils',
+    'art',
+    'sea_creatures',
+  ];
+  for (const cat of known) {
+    const entry = (value as Record<string, unknown>)[cat];
+    if (entry === undefined) continue;
+    if (!entry || typeof entry !== 'object' || Array.isArray(entry)) {
+      return false;
+    }
+  }
+  // At least one recognised category must carry entries.
+  return known.some(cat => {
+    const entry = (value as Record<string, unknown>)[cat];
+    return entry && typeof entry === 'object' && Object.keys(entry).length > 0;
+  });
+}
+
+export function getManifestState(gameId: GameId): ManifestState {
+  return cache.get(gameId) ?? { status: 'unknown' };
 }
 
 export function loadManifest(gameId: GameId): Promise<void> {
   const existing = inflight.get(gameId);
   if (existing) return existing;
-  cache.set(gameId, { status: 'loading' });
+  // Mark in-flight as `unknown` (still indistinguishable from "not probed yet"
+  // for callers — the only thing they care about is `present` vs not).
+  if (!cache.has(gameId)) cache.set(gameId, { status: 'unknown' });
   const url = `/icons/${gameId.toLowerCase()}/manifest.json`;
   const promise = fetch(url)
     .then(r => {
       if (!r.ok) throw new Error(`status ${r.status}`);
-      return r.json() as Promise<GameManifest>;
+      return r.json();
     })
-    .then(manifest => {
-      cache.set(gameId, { status: 'ready', manifest });
+    .then((parsed: unknown) => {
+      if (!isUsableManifest(parsed)) {
+        cache.set(gameId, { status: 'absent' });
+        return;
+      }
+      cache.set(gameId, { status: 'present', manifest: parsed });
     })
     .catch(() => {
-      cache.set(gameId, { status: 'missing' });
+      cache.set(gameId, { status: 'absent' });
     })
     .finally(() => {
       inflight.delete(gameId);
@@ -60,6 +85,35 @@ export function subscribeManifest(gameId: GameId, cb: () => void): () => void {
   subs.add(cb);
   subscribers.set(gameId, subs);
   return () => subs.delete(cb);
+}
+
+/**
+ * Subscribe to a gameId's manifest state. Triggers a one-time lazy probe of
+ * `/icons/<gameId>/manifest.json` on first call per gameId. Returns the
+ * current state synchronously and re-renders when the probe settles.
+ */
+export function useManifestState(gameId: GameId): ManifestState {
+  const [, force] = useState(0);
+  useEffect(() => {
+    const unsub = subscribeManifest(gameId, () => force(n => n + 1));
+    if (!cache.has(gameId)) {
+      void loadManifest(gameId);
+    }
+    return unsub;
+  }, [gameId]);
+  return getManifestState(gameId);
+}
+
+/**
+ * True iff a usable `manifest.json` is committed for the given game. Probes
+ * the file lazily on first call; returns false during the in-flight window so
+ * callers fall back to the textual-glyph render path until the probe settles.
+ *
+ * No code change is needed when a new game's icon set ships — the probe sees
+ * the manifest the next time the page loads and `<ItemIcon>` lights up.
+ */
+export function useGameHasIcons(gameId: GameId): boolean {
+  return useManifestState(gameId).status === 'present';
 }
 
 // Test seam — reset the module-level manifest cache between tests.

--- a/src/components/search/GlobalSearchDropdown.tsx
+++ b/src/components/search/GlobalSearchDropdown.tsx
@@ -8,6 +8,8 @@ import {
   isArtPiece,
   isSeaCreature,
 } from '../../lib/utils';
+import { ItemIcon } from '../ItemIcon';
+import { gameHasIcons } from '../itemIconUtils';
 
 const SEARCH_HISTORY_KEY = 'ac-curator-search-history';
 const MAX_HISTORY = 8;
@@ -341,15 +343,26 @@ export function GlobalSearchDropdown({
                           onMouseEnter={() => setActiveIdx(idx)}
                           onClick={() => selectIndex(idx)}
                         >
-                          <div
-                            className="ac-gs-row-glyph"
-                            style={{
-                              borderColor: CHIP_VAR[cat],
-                              color: CHIP_VAR[cat],
-                            }}
-                          >
-                            {monogram(it.name)}
-                          </div>
+                          {gameHasIcons(gameId) ? (
+                            <ItemIcon
+                              gameId={gameId}
+                              category={cat}
+                              id={it.id}
+                              size={24}
+                              className="ac-gs-row-icon"
+                              alt=""
+                            />
+                          ) : (
+                            <div
+                              className="ac-gs-row-glyph"
+                              style={{
+                                borderColor: CHIP_VAR[cat],
+                                color: CHIP_VAR[cat],
+                              }}
+                            >
+                              {monogram(it.name)}
+                            </div>
+                          )}
                           <div className="ac-gs-row-text">
                             <div className="ac-gs-row-name">
                               <span>{it.name}</span>

--- a/src/components/search/GlobalSearchDropdown.tsx
+++ b/src/components/search/GlobalSearchDropdown.tsx
@@ -9,7 +9,7 @@ import {
   isSeaCreature,
 } from '../../lib/utils';
 import { ItemIcon } from '../ItemIcon';
-import { gameHasIcons } from '../itemIconUtils';
+import { useGameHasIcons } from '../itemIconUtils';
 
 const SEARCH_HISTORY_KEY = 'ac-curator-search-history';
 const MAX_HISTORY = 8;
@@ -113,6 +113,7 @@ export function GlobalSearchDropdown({
   const [activeIdx, setActiveIdx] = useState(0);
   const wrapRef = useRef<HTMLDivElement>(null);
   const inputRef = useRef<HTMLInputElement>(null);
+  const useIcons = useGameHasIcons(gameId);
 
   const visibleCategories = useMemo<CategoryId[]>(() => {
     const cats: CategoryId[] = ['fish', 'bugs', 'fossils'];
@@ -343,7 +344,7 @@ export function GlobalSearchDropdown({
                           onMouseEnter={() => setActiveIdx(idx)}
                           onClick={() => selectIndex(idx)}
                         >
-                          {gameHasIcons(gameId) ? (
+                          {useIcons ? (
                             <ItemIcon
                               gameId={gameId}
                               category={cat}

--- a/src/index.css
+++ b/src/index.css
@@ -902,7 +902,7 @@
   display: grid;
   grid-template-columns: 1fr 240px;
   gap: 28px;
-  padding: 4px 18px 22px 64px;
+  padding: 4px 18px 22px 88px;
   background: var(--surface-alt);
 }
 .ac-expand-no-months { grid-template-columns: 1fr; }
@@ -995,7 +995,10 @@
 }
 
 @media (max-width: 980px) {
-  .ac-expand { grid-template-columns: 1fr; padding-left: 18px; gap: 14px; }
+  .ac-expand { grid-template-columns: 1fr; gap: 14px; }
+}
+@media (max-width: 720px) {
+  .ac-expand { padding-left: 18px; }
 }
 
 /* ── Phase 6: Home + ProgressMeter ── */

--- a/src/index.css
+++ b/src/index.css
@@ -1502,3 +1502,22 @@
   .ac-topbar { flex-wrap: wrap; }
   .ac-search-wrap { max-width: 100%; min-width: 0; }
 }
+
+/* v0.9.1 — ItemIcon */
+.ac-expand { position: relative; }
+.ac-expand-icon {
+  position: absolute;
+  top: 12px;
+  left: 12px;
+  width: 64px;
+  height: 64px;
+  display: block;
+}
+@media (max-width: 720px) {
+  .ac-expand-icon { display: none; }
+}
+.ac-row-icon { display: inline-block; }
+.ac-gs-row-icon { display: inline-block; flex: none; }
+.ac-shelf-icon { display: inline-block; flex: none; }
+.ac-recent-icon { display: inline-block; flex: none; }
+


### PR DESCRIPTION
## Summary

PR (b) of the v0.9.1-beta icon track. PR (a) (#86) shipped the binaries, scripts, docs, and a per-game `manifest.json`. This PR wires those icons into the UI so they actually render, and adds a standalone manifest re-emitter.

Stacked on `feature/acgcn-icons` — review against that branch, not `development`.

Two commits, kept separate to preserve the lesson in history:

1. `85fc80c` — initial wiring with a `GAMES_WITH_ICONS = { ACGCN }` allowlist gate.
2. `aa7f934` — follow-up: replaces the allowlist with a data-driven `useGameHasIcons` probe (same lesson as the v0.9 `GAMES_WITH_ART` cleanup that double-bugged across `categoryMeta.ts` and `StatsTab.tsx`).

## What's in here

**`<ItemIcon>` component** (`src/components/ItemIcon.tsx`)
- Resolves `(gameId, category, id)` to `/icons/<gameId>/<category>/<filename>` via a lazily loaded, module-level-cached per-game `manifest.json`.
- Reserves `size × size` before the image loads to prevent CLS.
- Falls back to a tinted-monogram placeholder when the manifest entry is missing or the `<img>` errors at runtime.

**Data-driven gate** (`src/components/itemIconUtils.ts`)
- `useGameHasIcons(gameId)` probes `/icons/<gameId>/manifest.json` lazily on first call per game and caches a tri-state result at module scope: `unknown` (in flight or not yet probed), `present` (fetch succeeded with a usable manifest), or `absent` (404 or malformed JSON).
- Returns false synchronously while `unknown`, so the existing monogram fallback renders during the brief probe window — no flicker.
- `isUsableManifest()` schema-checks the parsed JSON (must be an object with at least one recognised non-empty category) so a corrupt deploy doesn't render `<ItemIcon>` against busted data.
- **No more allowlist constant.** Future v0.9.x icon-scrape releases for ACWW / ACCF / ACNL / ACNH light up automatically the moment their `manifest.json` is committed. No code change in `src/` needed.

**Slotted into four surfaces:**
| Surface | File | Size |
|---|---|---|
| Category-tab item row | `CollectibleRow.tsx` | 32×32 |
| Inline expand panel header | `ItemExpandPanel.tsx` | 64×64 (hidden ≤720px) |
| Global search results | `search/GlobalSearchDropdown.tsx` | 24×24 |
| Home tab — leaving / arrived shelves + recent activity | `HomeTab.tsx` | 24×24 |

`CategoryTab`, `CollectibleRow`, `ItemExpandPanel` gain a `gameId` prop forwarded from `ACCanvas`.

**Manifest mechanism** (`scripts/generate-icon-manifest.ts`)
- New `npm run icons:manifest` standalone re-emitter.
- Walks `public/icons/<gameId>/{fish,bugs,fossils,art,sea_creatures}/` and writes the same `{ category: { id: filename } }` shape that `fetch-icons.ts` already produces.
- Preserves catalog order from `public/data/<gameId>/<category>.json` so the output is identical to a clean scrape (verified: re-running on the existing ACGCN manifest is a no-op).
- Per-piece fossils share one icon by design.

## Decisions

- **Data-driven gate over capability allowlist.** `GAMES_WITH_ICONS` was the v0.9 `GAMES_WITH_ART` anti-pattern in miniature: a hand-maintained set that has to be touched on every asset release. Replaced with a manifest probe so the gate stays in lockstep with what's actually on disk.
- **`unknown → false` while in flight.** Treating the in-flight window as "no icons" (rather than rendering a placeholder) keeps the monogram visible for the ~tens-of-ms it takes the probe to settle, then promotes to icons once the cache flips. No flash of wrong content.
- **CSS-only placeholder, no committed `placeholder.png` binary.** The spec offered both — went with the CSS-only path. One fewer binary in the repo, zero extra HTTP requests, and the placeholder visually matches the existing `.ac-glyph` and `.ac-shelf-glyph` aesthetic.
- **Helpers split into `itemIconUtils.ts`.** Required to keep the lint config's react-refresh rule happy without bumping `--max-warnings`.

## Tests

- `src/components/ItemIcon.test.tsx` — 9 tests:
  - 5 component tests: URL construction, missing-entry fallback, fetch-failure fallback, runtime `<img>` error fallback, dimension reservation.
  - 4 hook tests: `unknown → false` while in flight, `unknown → present` on 200, `unknown → absent` on 404, `unknown → absent` on malformed JSON.
- Full suite: 72 / 72 passing.

## Build / lint

- `npm run build` — green
- `npm run lint` — clean, 0 warnings
- `npm test` — 72 / 72

## Smoke test

I have not exercised this in a browser — I can't run an interactive UI here. Please verify on the Vercel preview (link in the PR Checks tab):
- ACGCN town: icons appear in fish/bugs/fossils/art rows, in the expand panel header, in global search results, and in HomeTab shelves + recent activity.
- ACWW / ACCF / ACNL / ACNH towns: existing monogram glyphs render unchanged. The probe will 404 once per game per session and the gate will resolve to `absent`; no broken `<img>` tags.

## How to regenerate the manifest

After committing icons fetched outside of `fetch-icons.ts` (or after a manual icon swap):

```bash
npm run icons:manifest
```

Re-run after every icon commit. The UI lights up automatically when a new game's `manifest.json` lands — no companion code change in `src/` is required.