### PR TITLE
release: v0.9.2-beta

### DIFF
--- a/.claude/rules/architecture.md
+++ b/.claude/rules/architecture.md
@@ -1,4 +1,4 @@
-# Architecture Reference (v0.9.1-beta)
+# Architecture Reference (v0.9.2-beta)
 
 ## Stack
 Vite + React 19 + TypeScript + Tailwind CSS v4 + Zustand (persist + non-persisted UI store) + React Router v6. Meadow design tokens (CSS custom properties in `src/index.css` `@theme`); Fraunces (display) + Inter (UI).

--- a/.release-notes-v0.9.2-beta.md
+++ b/.release-notes-v0.9.2-beta.md
@@ -1,0 +1,49 @@
+## v0.9.2-beta — 2026-05-05
+
+### Changed
+
+**Cross-game icon routing**
+Items shared across games — sea bass, koi, common butterfly, every fossil
+that appears in more than one title — now share a single icon file. The
+flat hierarchy under `public/icons/<category>/<id>.png` replaces the
+previous per-game duplication; a `RENAME_OVERRIDES` map handles ids that
+differ slightly between games. New games light up automatically when their
+catalog ids match an existing icon.
+
+**Bigger icons in the expand panel**
+Item icons grew across every surface — 32→48 in category rows, 24→32 in
+search results and home strips, and up to 192×192 in the expand panel on
+wide screens. The hand-drawn pieces have room to breathe; wiki-sourced
+icons scale cleanly at these sizes.
+
+**ActivityFeed migrated to `<ItemIcon>`**
+The recent-donations card on Home now shows real item icons instead of
+category monograms. Last surface in the app to migrate.
+
+### Added
+
+**First two hand-drawn icons: sea bass and koi**
+A preview of the long-term direction — replacing wiki-sourced art with
+custom-painted icons one species at a time. The 2048×2048 source PNGs
+ship under `icon-sources/fish/`; the deploy build optimizes them down
+to 512×512.
+
+**`npm run icons:export` pipeline**
+Local-only build step that resizes 2048×2048 source paintings to 512×512,
+palette-quantizes via pngquant, and writes the deploy assets. Idempotent
+(skips when output is newer than source). Not run in CI — assets are
+committed.
+
+**`npm run audit:icons` script**
+Reports per-game icon coverage against catalog data, surfaces missing
+items and orphan files.
+
+### Fixed
+
+- Mona Lisa expand-panel icon no longer clips at the bottom
+- iOS overscroll bounce no longer reveals the wrong background colour
+
+---
+
+Live at https://animalcrossingwebapp.vercel.app · changelog at
+[CHANGELOG.md](./CHANGELOG.md).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,14 +2,25 @@
 
 All notable changes to this project are documented here.
 
-## [Unreleased] — v0.9.2 (in progress on `development`)
+## [v0.9.2-beta] — 2026-05-05
 
 ### Added
 - 2048×2048 hand-drawn source PNGs committed under `icon-sources/<category>/<id>.png` as the canonical originals. The first two land here: `icon-sources/fish/sea-bass.png` and `icon-sources/fish/koi.png`
 - `scripts/export-icons.ts` — local-only pipeline that resizes 2048 sources to 512×512, palette-quantizes via pngquant, and writes the deploy assets to `public/icons/<category>/<id>.png`. Idempotent (skips when the output is newer than its source); supports `--force` and `--dry-run`. Wired as `npm run icons:export`. Not run in CI
+- `scripts/audit-icon-coverage.ts` — reports per-game icon coverage against catalog data, surfaces missing items and orphan files. Wired as `npm run audit:icons`
 
 ### Changed
+- **Cross-game icon routing** — items shared across games (sea bass, koi, common butterfly, every shared fossil) now share a single icon file. Icon hierarchy flattened from per-game subdirectories to `public/icons/<category>/<id>.png`; a `RENAME_OVERRIDES` map handles ids that differ between games; resolver simplified accordingly. Adding a new game's catalog now lights up icon coverage automatically wherever ids match
 - Item icon render sizes increased to give the hand-drawn art room to read: category rows 32→48, expand panel 64→192 (with a 128 step at ≤1180px and existing hide-at-≤720 unchanged), search dropdown 24→32, home shelf + recent rows 24→32. Fallback monogram glyphs scaled to match: `.ac-glyph` 32→48, `.ac-gs-row-glyph` 28→32. Expand panel `padding-left` extended to clear the larger absolute-positioned icon
+- `ActivityFeed` (recent donations card on Home) renders `<ItemIcon>` instead of the legacy `CATEGORY_META` monogram tile — final surface migrated to the shared icon component (Closes #97)
+- `public/version-history.html` trimmed for clarity; v0.9.0 release date corrected; emoji removed from the velocity banner
+
+### Fixed
+- Mona Lisa icon clipped at the bottom of the expand panel — added a min-height for the art icon slot
+- iOS overscroll bounce revealed the wrong background colour — `html` and `body` background unified
+
+### Notes
+- ACGCN icons remain wiki-sourced; the two hand-drawn replacements (sea-bass, koi) preview the long-term direction. No regression to existing ACGCN coverage
 
 ## [v0.9.1-beta] — 2026-05-04
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,7 +16,7 @@ See `docs/architecture.md` — deep architectural context (store schema, migrati
 ## Project Overview
 
 Animal Crossing multi-game companion web app. Tracks museum donations (fish, bugs, fossils, art) across multiple towns and games.
-Meadow design language (Fraunces + Inter, moss-green accent) as of v0.9. **Current release: v0.9.1-beta (2026-05-04) — adds Animal Crossing (GameCube) item icons across category rows, expand panels, global search, and home tab. Previous: v0.9.0-beta (full UI revamp — Sidebar, TownManager, sectioned CategoryTab, redesigned HomeTab + StatsTab, GlobalSearchDropdown, mobile responsive). See `docs/v0.9-plan.md` and `docs/v0.9.1-icons-plan.md` for plans, `CHANGELOG.md` for the full entries.**
+Meadow design language (Fraunces + Inter, moss-green accent) as of v0.9. **Current release: v0.9.2-beta (2026-05-05) — cross-game icon routing (flat hierarchy + RENAME_OVERRIDES), first two hand-drawn icons (sea bass, koi), bigger expand-panel icons, `npm run icons:export` pipeline, ActivityFeed migrated to `<ItemIcon>`. Previous: v0.9.1-beta (ACGCN item icons), v0.9.0-beta (full UI revamp). See `docs/v0.9-plan.md`, `docs/v0.9.1-icons-plan.md`, and `docs/v0.9.2-icon-routing-plan.md` for plans, `CHANGELOG.md` for the full entries.**
 Live at: https://animalcrossingwebapp.vercel.app | Dev preview: https://development-animalcrossingwebapp.vercel.app
 
 ## Commands

--- a/README.md
+++ b/README.md
@@ -66,6 +66,6 @@ Museum data lives in `public/data/<game>/`:
 
 ## Version
 
-Current release: **v0.9.1-beta** (2026-05-04) — adds Animal Crossing (GameCube) item icons across all category surfaces. Previous beta: **v0.9.0-beta** (full UI revamp). Last stable on `main`: **v0.8.2-alpha**. See [CHANGELOG.md](CHANGELOG.md) for history and [docs/v0.9-plan.md](docs/v0.9-plan.md) for the v0.9 plan.
+Current release: **v0.9.2-beta** (2026-05-05) — cross-game icon routing, first two hand-drawn icons (sea bass, koi), bigger expand-panel icons, `npm run icons:export` pipeline. Previous betas: **v0.9.1-beta** (ACGCN item icons), **v0.9.0-beta** (full UI revamp). Last stable on `main`: **v0.8.2-alpha**. See [CHANGELOG.md](CHANGELOG.md) for history and [docs/v0.9-plan.md](docs/v0.9-plan.md) for the v0.9 plan.
 
 Significant design decisions are logged in [docs/decisions.md](docs/decisions.md).

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,4 +1,4 @@
-# Architecture Reference (v0.9.1-beta)
+# Architecture Reference (v0.9.2-beta)
 
 This document mirrors `.claude/rules/architecture.md` — the canonical copy that Claude Code sessions auto-load. They are kept in lockstep; if they diverge, the `.claude/rules/` copy wins. Update both together.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "animalcrossingwebapp",
-  "version": "0.9.1-beta",
+  "version": "0.9.2-beta",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "animalcrossingwebapp",
-      "version": "0.9.1-beta",
+      "version": "0.9.2-beta",
       "license": "MIT",
       "dependencies": {
         "@types/react": "^19.1.10",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "animalcrossingwebapp",
-  "version": "0.9.1-beta",
+  "version": "0.9.2-beta",
   "description": "Web companion app for tracking museum donations across all five Animal Crossing main-line games (GCN, WW, CF, NL, NH). Live at https://animalcrossingwebapp.vercel.app/",
   "type": "module",
   "main": "index.js",

--- a/public/version-history.html
+++ b/public/version-history.html
@@ -415,22 +415,22 @@
 
   <header>
     <h1>Animal Crossing Web App</h1>
-    <p>Version history &amp; roadmap · Updated May 4, 2026</p>
+    <p>Version history &amp; roadmap · Updated May 5, 2026</p>
   </header>
 
   <!-- Velocity banner -->
   <div class="velocity-banner">
     <div>
-      <div class="headline">v0.1 to v0.9 in 24 days</div>
-      <div class="sub">Twelve releases. Blathers can't keep up.</div>
+      <div class="headline">v0.1 to v0.9 in 25 days</div>
+      <div class="sub">Thirteen releases. Blathers can't keep up.</div>
     </div>
     <div class="vel-stats">
       <div class="vel-stat">
-        <div class="num">12</div>
+        <div class="num">13</div>
         <div class="label">releases shipped</div>
       </div>
       <div class="vel-stat">
-        <div class="num">24</div>
+        <div class="num">25</div>
         <div class="label">days elapsed</div>
       </div>
       <div class="vel-stat">
@@ -448,6 +448,29 @@
   <section>
     <h2>Shipped versions</h2>
     <div class="timeline">
+
+      <!-- v0.9.2-beta -->
+      <div class="tl-entry">
+        <div class="tl-date">May 5<br/>2026</div>
+        <div class="tl-spine">
+          <div class="tl-dot"></div>
+          <div class="tl-line"></div>
+        </div>
+        <div class="tl-card">
+          <div class="tl-card-head">
+            <span class="version-badge">v0.9.2-beta</span>
+            <span class="version-title">Cross-game icons + first hand-drawn pieces</span>
+            <span class="velocity-chip">1 day after v0.9.1</span>
+          </div>
+          <ul class="tl-bullets">
+            <li>Cross-game icon routing — items shared across games (sea bass, koi, common butterfly) now share a single icon file rather than duplicating per game</li>
+            <li>First two hand-drawn icons land — sea bass and koi — a preview of the long-term direction away from wiki-sourced art</li>
+            <li>Bigger icons in the expand panel, up to 192px on wide screens, so the artwork has room to read</li>
+            <li>New <code>npm run icons:export</code> pipeline turns 2048 source paintings into optimized 512 deploy assets</li>
+            <li>Polish: Mona Lisa expand-panel clipping fixed; iOS overscroll background no longer flashes the wrong colour</li>
+          </ul>
+        </div>
+      </div>
 
       <!-- v0.9.1-beta -->
       <div class="tl-entry">
@@ -937,13 +960,19 @@
             <td style="padding:.6rem 1rem;">1 day</td>
             <td style="padding:.6rem 1rem;">ACGCN item icons + /credits route + MIT LICENSE/NOTICE</td>
           </tr>
+          <tr style="border-top:1px solid var(--border); background:#fafafa;">
+            <td style="padding:.6rem 1rem; color:var(--leaf); font-weight:bold;">v0.9.2-beta</td>
+            <td style="padding:.6rem 1rem;">May 5</td>
+            <td style="padding:.6rem 1rem;">1 day</td>
+            <td style="padding:.6rem 1rem;">Cross-game icon routing + first hand-drawn icons + bigger sizes</td>
+          </tr>
         </tbody>
       </table>
     </div>
   </section>
 
   <footer>
-    <p><a href="https://animalcrossingwebapp.vercel.app">animalcrossingwebapp.vercel.app</a> · v0.9.1-beta shipped · v1.0 next · Dev preview at <a href="https://development-animalcrossingwebapp.vercel.app">development-animalcrossingwebapp.vercel.app</a></p>
+    <p><a href="https://animalcrossingwebapp.vercel.app">animalcrossingwebapp.vercel.app</a> · v0.9.2-beta shipped · v1.0 next · Dev preview at <a href="https://development-animalcrossingwebapp.vercel.app">development-animalcrossingwebapp.vercel.app</a></p>
   </footer>
 
 </div>

--- a/src/components/CreditsPage.tsx
+++ b/src/components/CreditsPage.tsx
@@ -67,8 +67,9 @@ export function CreditsPage() {
           </p>
           <p>
             Animal Crossing (GameCube) icons were added in v0.9.1-beta.
-            Additional games will be added in subsequent v0.9.x releases.
-            Hand-drawn replacements are planned for a later polish pass.
+            Cross-game icon routing landed in v0.9.2-beta along with the first
+            two hand-drawn replacements (sea bass, koi). Additional games and
+            hand-drawn icons will land in subsequent v0.9.x releases.
           </p>
         </div>
       </section>

--- a/src/components/SettingsPage.tsx
+++ b/src/components/SettingsPage.tsx
@@ -21,7 +21,7 @@ export function SettingsPage() {
   }, [donated]);
 
   const townCount = towns.length;
-  const version = import.meta.env.VITE_APP_VERSION ?? '0.9.1-beta';
+  const version = import.meta.env.VITE_APP_VERSION ?? '0.9.2-beta';
 
   function handleClose() {
     if (activeTownId) {

--- a/src/components/views/ActivityFeed.tsx
+++ b/src/components/views/ActivityFeed.tsx
@@ -1,7 +1,7 @@
-import React, { useMemo } from 'react';
-import { CATEGORY_META } from '../../lib/categoryMeta';
+import { useMemo } from 'react';
 import { CATEGORY_ORDER } from '../../lib/constants';
 import { EmptyState } from '../shared/EmptyState';
+import { ItemIcon } from '../ItemIcon';
 import {
   displayName,
   formatRelativeDate,
@@ -75,23 +75,18 @@ export function ActivityFeed({
           </div>
           <div className="space-y-2">
             {group.items.map(entry => {
-              const { Icon } = CATEGORY_META[entry.category];
               return (
                 <div
                   key={`${entry.itemId}-${entry.ts}`}
                   className="flex items-center gap-3 rounded-[14px] border px-4 py-3"
                   style={{ borderColor: '#b8dfc8', backgroundColor: '#f2faf6' }}
                 >
-                  <div
-                    className="shrink-0 rounded-xl p-2"
-                    style={{
-                      backgroundColor: '#EDE3D0',
-                      border: '1px solid #E7DAC4',
-                    }}
-                    aria-hidden
-                  >
-                    <Icon className="w-4 h-4" />
-                  </div>
+                  <ItemIcon
+                    category={entry.category}
+                    id={entry.itemId}
+                    size={32}
+                    alt=""
+                  />
                   <div className="min-w-0 flex-1">
                     <div
                       className="font-medium text-sm truncate"


### PR DESCRIPTION
## Summary

Release branch for v0.9.2-beta — cross-game icon routing, first two hand-drawn icons, bigger expand-panel icons, `npm run icons:export` pipeline, ActivityFeed migrated to `<ItemIcon>`.

Six commits on top of `development`:

- `feat: migrate ActivityFeed to <ItemIcon> (Closes #97)` — last legacy `CATEGORY_META` monogram surface migrated
- `chore: bump version to 0.9.2-beta` — package.json + lockfile
- `docs: changelog for v0.9.2-beta` — replaces `[Unreleased]` with the dated entry; covers PR #94 (cross-game routing), PR #98 (release-history trim), PR #99 (icon sizes + export pipeline + 2 hand-drawn icons + post-merge fixes), and Issue #97
- `docs: version-history entry for v0.9.2-beta` — header date bump, velocity banner 24→25 days / 12→13 releases, new timeline entry, new velocity-table row, footer
- `docs: update current-release prose for v0.9.2-beta` — CLAUDE.md, README.md, docs/architecture.md, .claude/rules/architecture.md, plus SettingsPage hardcoded version fallback and CreditsPage prose
- `docs: release notes for v0.9.2-beta` — `.release-notes-v0.9.2-beta.md` for the GitHub release

## Verification

- `npm run build` — clean, dist contains 5× `0.9.2-beta` and 1× `0.9.1-beta` (intentional historical reference in CreditsPage prose)
- `npm test` — 1898 tests pass
- `npm run audit:icons` — coverage unchanged from `development` (ACGCN 118/118, ACWW 100/184, ACCF 105/155, ACNL 91/285, ACNH 77/330)
- Lint baseline unchanged (pre-existing noise in `.claude/worktrees/*` paths; lint-staged passed cleanly on all six commits)

## After merge

1. Open `development` → `main` PR (`release: merge v0.9.2-beta to main`)
2. Tag annotated `v0.9.2-beta` from `main`
3. `gh release create v0.9.2-beta --notes-file .release-notes-v0.9.2-beta.md --prerelease`
4. Back-merge `main` → `development`
5. Delete release branch on origin
