### PR TITLE
docs: v0.9.3 CSV/JSON import scoping plan

### DIFF
--- a/docs/v0.9.3-csv-import-plan.md
+++ b/docs/v0.9.3-csv-import-plan.md
@@ -60,7 +60,34 @@ To restore a town, an import needs: `name`, `gameId`, `hemisphere`, `createdAt` 
 
 ## 4. Schema delta — what export must add
 
-Two viable shapes. Recommend (B).
+**Locked decision (2026-05-06): JSON, not CSV.** The save file is `.json` — unambiguous, trivially validated, lossless round-trip. The (A)/(B) CSV comparison below is preserved for posterity; option (B)'s structure (versioned metadata + flat donation list) carries over directly to the JSON shape. The human-readable report CSV survives as a separate "Download report" button — it is no longer asked to double as a save-file artifact.
+
+Concrete JSON shape:
+
+```json
+{
+  "schemaVersion": 1,
+  "app": "ac-web",
+  "appVersion": "0.9.3",
+  "exportedAt": "2026-05-06T18:42:11.000Z",
+  "town": {
+    "name": "Bea's Island",
+    "gameId": "ACNH",
+    "hemisphere": "NH",
+    "createdAt": "2026-04-01T12:00:00.000Z"
+  },
+  "donations": [
+    { "itemId": "fish-sea_bass",   "category": "fish",    "donatedAt": "2026-04-15T18:42:11.000Z" },
+    { "itemId": "bug-tarantula",   "category": "bugs",    "donatedAt": "2026-04-16T02:11:08.000Z" },
+    { "itemId": "fossil-trex_skull","category": "fossils","donatedAt": "2026-04-17T..." },
+    { "itemId": "art-mona_lisa",   "category": "art",     "donatedAt": "2026-04-18T..." }
+  ]
+}
+```
+
+`hemisphere` is required for ACNH and omitted otherwise. The synthetic `townId` is intentionally not exported (matches §6 reasoning). Multi-town files would extend to a top-level `towns: [...]` array; deferred per §12 answer 3.
+
+The CSV options below remain for reference only.
 
 **(A) Augment the existing report CSV** — prepend a machine-readable metadata block and replace the activity-log columns with `itemId, category, donatedAt(ISO)`. Keep the human-readable summary sections unchanged so the file still opens cleanly in Excel. Pros: minimal disruption, single file, still readable. Cons: parser has to skip narrative sections; format is brittle (a user editing the file in Excel can break the metadata block).
 
@@ -80,8 +107,8 @@ Drop the Category Completion and Monthly Activity sections from the file the imp
 
 ## 5. Proposed import flow (UX)
 
-- **Entry point.** Add an "Import save" button to the **Settings** page, near the Export CSV control. The Danger zone is the wrong fit — those buttons are about local destructive resets; import is about *adding* state from elsewhere. Place it adjacent to Export so the round-trip is visually obvious.
-- **File picker.** `<input type="file" accept=".csv,text/csv">`. Drag-and-drop is a v1.0 nice-to-have, not v0.9.3.
+- **Entry point.** Two locations (locked 2026-05-06): (1) the **Settings** page adjacent to the Export control so the round-trip is visually obvious, and (2) the **onboarding empty state** — visible in the Sidebar / TownManager when `towns.length === 0`, so a fresh-device user can import before creating their first town. The Danger zone is the wrong fit — those buttons are about local destructive resets; import is about *adding* state from elsewhere.
+- **File picker.** `<input type="file" accept=".json,application/json">`. Drag-and-drop is a v1.0 nice-to-have, not v0.9.3.
 - **Parse + preview.** After parse, show a confirmation modal summarizing what the file contains: town name, game, hemisphere, donation count, exported-at timestamp, and any version mismatch warnings. The modal lists actions ("Will create new town 'Bea's Island' (ACNH, NH) with 47 donations"). User confirms before any state mutation.
 - **Conflict prompt.** If the import would collide with an existing town (see section 6), the modal offers Replace / Merge / Import as new town / Cancel.
 - **Result toast.** After commit, show a brief inline confirmation; activate the imported town.
@@ -168,3 +195,12 @@ A single-PR option is technically possible but couples two distinct review surfa
 4. **Filename convention.** Current export is `ac-museum-<town>-<date>.csv`. Keep, or shift to `ac-save-<town>-<date>.csv` to signal the new role?
 5. **Undo affordance.** Worth implementing a one-shot undo for a destructive Replace, or rely on confirmation alone?
 6. **JSON instead of CSV?** A `.json` save file would be unambiguous and easier to validate. CSV's only edge is human-readability, which the report sections were carrying. If the report is split off, the save file no longer needs to be CSV. Worth considering before locking the format.
+
+### Answers (locked 2026-05-06)
+
+1. **Report CSV — keep.** The current human-readable export survives as a separate "Download report" button. The new JSON save file does not double as a spreadsheet-paste artifact, so the report case stays distinct.
+2. **Import button placement — both.** Visible during onboarding (empty-state Sidebar / TownManager when `towns.length === 0`) and adjacent to the existing Export control (Settings or wherever Export currently lives — match its placement).
+3. **Single-file multi-town export — defer.** Out of scope for v0.9.3; revisit post-release. v0.9.3 export remains scoped to a single town.
+4. **Filename convention — `ac-save-<town>-<date>.json`.** Shift away from `ac-museum-<town>-<date>.csv` to signal the new save-file role and the JSON format.
+5. **Undo for destructive Replace — confirmation only, no undo.** Two-step destructive-action UX: a heavy red-text warning ("this cannot be undone") with a confirm-twice gate. Gate the heavy warning on whether the matched town actually has data to lose — replacing into a fresh empty town gets a light warning or none at all. No sessionStorage snapshot, no in-session undo affordance.
+6. **JSON instead of CSV — yes, JSON.** Save file is `.json`. Overrides §4's option (B) "versioned CSV with metadata header" recommendation. The JSON shape is specified at the top of §4.

--- a/docs/v0.9.3-csv-import-plan.md
+++ b/docs/v0.9.3-csv-import-plan.md
@@ -1,0 +1,170 @@
+# v0.9.3 — CSV Import Scoping
+
+Status: scoping doc, not an implementation plan. Closes the round-trip half of Issue #88 ("digital cartridge" save file). Frame: the user exports progress on one device, imports on another, and ends up in an equivalent state.
+
+## Table of Contents
+
+1. Headline finding
+2. What the current export actually writes
+3. What the store needs to reconstruct
+4. Schema delta — what export must add
+5. Proposed import flow (UX)
+6. State reconciliation
+7. Validation
+8. Edge cases
+9. Test plan
+10. Phasing recommendation
+11. Risks
+12. Open questions
+
+---
+
+## 1. Headline finding
+
+**The existing CSV export is a human-readable report, not a save file. It cannot round-trip.** Building import on top of it is not viable; the export format must be redesigned (or augmented with a structured machine-readable section) before import work begins. This bumps v0.9.3 scope: the work is "design + ship a new export format AND build the import side," not "add the missing import half."
+
+Concretely, the current `src/lib/csvExport.ts` writes three narrative sections (Donation Activity Log, Category Completion, Monthly Activity) plus a header. It is missing:
+
+- **Item IDs.** Rows carry display names ("Sea Bass", "Tarantula"), not the canonical `item.id` the store keys off.
+- **gameId.** A single export covers one town's active game, but the file never names it. There is no way to know whether "Sea Bass" means the ACGCN entry or the ACNH entry.
+- **Hemisphere.** ACNH-only field, never written.
+- **townId.** The town's display name is written; the synthetic `id` (used as a key in `donated[townId]`) is not.
+- **Machine-grade dates.** Donation dates are formatted (`Apr 15, 2026`), not ISO. Original `donatedAt` precision is lost.
+- **Fossil disambiguation.** Fossils are written as `"T. Rex Skull — Skull"` (display name with the part appended). The structured `id`/`part` split is gone.
+
+Sections 2 and 3 (Category Completion, Monthly Activity) are derivable from section 2 if it carried IDs. They are pure summaries and import should ignore them — they exist for users opening the file in Excel.
+
+## 2. What the current export actually writes
+
+Per `src/lib/csvExport.ts`:
+
+- Header: app name, town name (display), export timestamp (locale string).
+- Activity log: `Item, Category, Date Donated` — display name, human label, formatted date.
+- Category completion: per-category counts and percentages.
+- Monthly activity: per-month counts split by category.
+
+Scope: one town, one game (the active town's game). Multi-town export is not supported.
+
+## 3. What the store needs to reconstruct
+
+Per `src/lib/store.ts` (persist key `ac-web`, schema v3):
+
+```
+towns: Town[]                      // id, name, gameId, hemisphere, createdAt
+activeTownId: string | null
+donated:   Record<townId, Record<gameId, Record<itemId, true>>>
+donatedAt: Record<townId, Record<gameId, Record<itemId, ISO string>>>
+```
+
+To restore a town, an import needs: `name`, `gameId`, `hemisphere`, `createdAt` (or a sensible synthetic), and the `(itemId, ISO date)` tuples. `id` and `activeTownId` can be regenerated locally.
+
+## 4. Schema delta — what export must add
+
+Two viable shapes. Recommend (B).
+
+**(A) Augment the existing report CSV** — prepend a machine-readable metadata block and replace the activity-log columns with `itemId, category, donatedAt(ISO)`. Keep the human-readable summary sections unchanged so the file still opens cleanly in Excel. Pros: minimal disruption, single file, still readable. Cons: parser has to skip narrative sections; format is brittle (a user editing the file in Excel can break the metadata block).
+
+**(B) Versioned, structured CSV with a metadata header — recommended.** First N rows are key/value metadata (`# schemaVersion,1`, `# app,ac-web`, `# appVersion,0.9.3`, `# townName,...`, `# gameId,...`, `# hemisphere,...`, `# createdAt,...`, `# exportedAt,...`). Then a single data table:
+
+```
+itemId,category,donatedAt
+fish-sea_bass,fish,2026-04-15T18:42:11.000Z
+bug-tarantula,bugs,2026-04-16T02:11:08.000Z
+fossil-trex_skull,fossils,2026-04-17T...
+art-mona_lisa,art,2026-04-18T...
+```
+
+Drop the Category Completion and Monthly Activity sections from the file the import reads. They were never load-bearing; they are derivable. Optionally keep them as a separate "Report" download if there's demand — but stop conflating "save file" and "summary report."
+
+**Multi-town export.** v0.9.3 should keep export scoped to a single town for simplicity. A "Save All" that writes one file containing every town can come later; doing it now risks bloating the format. Note this in the file metadata so importers know whether the file is single-town or multi-town.
+
+## 5. Proposed import flow (UX)
+
+- **Entry point.** Add an "Import save" button to the **Settings** page, near the Export CSV control. The Danger zone is the wrong fit — those buttons are about local destructive resets; import is about *adding* state from elsewhere. Place it adjacent to Export so the round-trip is visually obvious.
+- **File picker.** `<input type="file" accept=".csv,text/csv">`. Drag-and-drop is a v1.0 nice-to-have, not v0.9.3.
+- **Parse + preview.** After parse, show a confirmation modal summarizing what the file contains: town name, game, hemisphere, donation count, exported-at timestamp, and any version mismatch warnings. The modal lists actions ("Will create new town 'Bea's Island' (ACNH, NH) with 47 donations"). User confirms before any state mutation.
+- **Conflict prompt.** If the import would collide with an existing town (see section 6), the modal offers Replace / Merge / Import as new town / Cancel.
+- **Result toast.** After commit, show a brief inline confirmation; activate the imported town.
+- **No silent overwrites, ever.** This is the user's data. Any path that mutates existing state must require explicit confirmation in the same modal.
+
+## 6. State reconciliation
+
+The export carries the original `townId` only if it is included in the metadata. Recommend **not** including the synthetic `id` — it leaks an internal detail and is never useful (IDs are timestamp + random). Instead, treat each import as a **new town by default**, with the user able to opt into Merge or Replace via the confirmation modal.
+
+Matching rule: identify a "candidate match" by `(name, gameId)` tuple. If exactly one local town matches, surface it as the suggested target for Replace/Merge. Otherwise default to "Import as new town." A `name` collision alone is not enough — the user can legitimately have two towns named "Pelican Town" on different games.
+
+- **Replace.** Wipe the matched town's `donated[townId][gameId]` and `donatedAt[townId][gameId]`, write the imported set. Town name and hemisphere are updated from the file. `createdAt` is preserved from the local town (don't rewrite history).
+- **Merge.** Union of items. For collisions (item donated locally and in import), prefer the **earlier** `donatedAt` so the user keeps their actual first-donation timestamp.
+- **Import as new town.** Generate a fresh `id`, append to `towns`, write donations under the new id.
+
+**Unknown gameId.** If the file's `gameId` is not in the current `GameId` union (older or future export), reject with a clear message. Do not fall back to a default.
+
+**Unknown itemIds.** If the file references item IDs that don't exist in the current `public/data/<gameId>/` set, drop those rows with a warning count in the result toast — don't fail the whole import. This handles the case where the data files gain or lose entries between versions.
+
+## 7. Validation
+
+A valid file:
+- Parses as CSV (use a small dependency like `papaparse`, or hand-roll — the format is simple). Hand-rolling is reasonable here; the export is also hand-rolled and the parsing job is small.
+- Has the metadata header with required keys: `schemaVersion`, `app=ac-web`, `gameId`, `townName`. `hemisphere` required only for ACNH.
+- Has the `itemId,category,donatedAt` data table with valid header row.
+- All `donatedAt` values parse as `Date`.
+- All `category` values are in the known set.
+- `schemaVersion` is `<= currentImportVersion`. Higher = reject ("This file was exported by a newer version of the app").
+
+Reject hard on missing metadata or malformed structure. Tolerate within-data warnings (unknown itemIds, etc.) by dropping rows and reporting.
+
+## 8. Edge cases
+
+- **Empty CSV / 0 rows.** Allowed — imports an empty town. Useful for "set up the same town on a new device, fill from scratch."
+- **CSV from older app version.** If the export predates v0.9.3 (i.e. is the current report-style format), detect the absence of the metadata header and surface a specific error: "This file was exported before save-file support shipped in v0.9.3. It cannot be imported." Do **not** attempt heuristic recovery; it will silently lose data.
+- **CSV from a future version.** Detect via `schemaVersion`. Reject with a clear "update the app" message.
+- **Bogus data.** Random text file with `.csv` extension — fail at the metadata-header step, friendly error.
+- **Very large CSV.** All categories combined for ACNH = ~330 items. Even 100 towns of donations is trivial. No streaming needed.
+- **Excel-mangled file.** Excel rewrites quoting rules, can change date columns to its own format, drops leading zeros. The `# metadata` header rows survive Excel because they are valid CSV; ISO datetimes survive Excel because we write them in a column Excel doesn't auto-detect as a date if it's wrapped or formatted carefully. Document "if you opened this in Excel and saved it, import may fail" in the user-facing error.
+- **Browser without `<input type=file>` working** (extreme edge): not a v0.9.3 concern.
+- **User imports their own export back into the same device.** Should match the existing town and offer Replace, which round-trips cleanly.
+
+## 9. Test plan
+
+Vitest unit tests:
+- **Round-trip.** Build a sample state, run `buildCSV`, parse with the new importer, assert the resulting state matches (donations + donatedAt + town fields). Run for each gameId (ACGCN, ACWW, ACCF, ACNL, ACNH-NH, ACNH-SH).
+- **Metadata header parsing.** Valid headers, missing required keys, unknown keys ignored, malformed lines.
+- **Schema version.** `schemaVersion=1` accepted; `schemaVersion=999` rejected with a typed error.
+- **Unknown itemId.** Drops the row, reports a warning count, doesn't throw.
+- **Unknown gameId.** Rejects.
+- **Merge collision logic.** Local item donated 2026-04-01, imported with date 2026-03-15 → merged record keeps `2026-03-15`.
+- **Replace.** Existing donations under matched town are wiped before write.
+
+Manual:
+- Round-trip across two browsers (one local, one private window simulating a fresh device).
+- Excel-saved file (open + save, attempt import, confirm graceful failure or success).
+- Pre-v0.9.3 export attempted as import (must fail with the specific message).
+
+## 10. Phasing recommendation
+
+**Two PRs, one release.**
+
+- **PR 1 — export format redesign.** New metadata-header CSV. Update `csvExport.ts` (or split into a `csvSaveFile.ts` and keep the old "report" export available behind a button if desired). Update tests. No import code yet. Ships behind no flag — the new file is just a better export.
+- **PR 2 — import.** Parser, conflict-resolution UI, state-mutation hook, settings entry point, tests.
+
+Estimate: PR 1 is ~1 day. PR 2 is ~3–4 days (the UI for the confirmation modal is the bulk of it). Total ~5 days of focused work, comfortable for a v0.9.3 minor.
+
+A single-PR option is technically possible but couples two distinct review surfaces (file format design + import UX) and makes rollback ugly if either half is wrong.
+
+## 11. Risks
+
+- **Data loss on Replace.** Replace wipes existing donation state for the matched town. Mitigation: explicit modal copy ("This will replace 47 existing donations"), require a checkbox or typed-confirmation to enable the Replace button. Consider auto-snapshotting the pre-import state to a sessionStorage key for a single Undo within the same session.
+- **Silent partial imports.** Dropping unknown-itemId rows is convenient but could be surprising if a user's export references many items missing locally (e.g. game data files diverge). Mitigation: surface the dropped count prominently in the result toast, and log to console for debug.
+- **Schema drift.** The current store is at persist v3. If v4 lands before v0.9.3 ships, the import format must track. Mitigation: keep the export format independent of the persist schema — export carries app-level facts (town, gameId, donations), not the literal localStorage shape.
+- **Confidence in "round-trip"** — there are at least three timestamp formats in play (the store's ISO strings, the export's locale-formatted dates, the new ISO column). The redesigned export must commit to ISO end-to-end and the old format must be flagged as not-importable. Mitigation: the round-trip Vitest is the contract.
+- **User opens save file in Excel and corrupts it.** Out of scope to prevent, in scope to fail gracefully.
+- **Multi-game towns?** None exist today (gameId is immutable post-create per Decision 1), so the format is safe. If that ever changes, the export shape needs revisiting.
+
+## 12. Open questions
+
+1. **Is "report CSV" worth keeping?** The existing format is genuinely useful for users who want to paste numbers into a spreadsheet. Should it remain available as a separate "Download report" button, or fold everything into the new save-file format?
+2. **Should the import button live in Settings, or also in the empty-state Sidebar / TownManager?** A new user with zero towns might benefit from "Import save" being prominent at first run.
+3. **Single-file multi-town export — defer to v1.0, or fold into v0.9.3?** Recommend defer; it doubles the conflict-resolution surface area.
+4. **Filename convention.** Current export is `ac-museum-<town>-<date>.csv`. Keep, or shift to `ac-save-<town>-<date>.csv` to signal the new role?
+5. **Undo affordance.** Worth implementing a one-shot undo for a destructive Replace, or rely on confirmation alone?
+6. **JSON instead of CSV?** A `.json` save file would be unambiguous and easier to validate. CSV's only edge is human-readability, which the report sections were carrying. If the report is split off, the save file no longer needs to be CSV. Worth considering before locking the format.

--- a/docs/v0.9.3-csv-import-plan.md
+++ b/docs/v0.9.3-csv-import-plan.md
@@ -71,7 +71,7 @@ Concrete JSON shape:
   "appVersion": "0.9.3",
   "exportedAt": "2026-05-06T18:42:11.000Z",
   "town": {
-    "name": "Bea's Island",
+    "name": "Pelican Town",
     "gameId": "ACNH",
     "hemisphere": "NH",
     "createdAt": "2026-04-01T12:00:00.000Z"


### PR DESCRIPTION
## Summary

Adds `docs/v0.9.3-csv-import-plan.md` — a scoping doc (not an implementation plan) for the round-trip half of Issue #88 ("digital cartridge" save file). Frames the work as designing a new export format AND building the import side, since the existing CSV is a human-readable report and cannot round-trip (no item IDs, no gameId, no hemisphere, locale-formatted dates).

The doc covers: current export gaps, store schema needs, schema delta, import UX flow, state reconciliation (Replace / Merge / Import as new), validation, edge cases, test plan, phasing, and risks.

## Locked decisions (2026-05-06)

- **Save format: JSON, not CSV.** Overrides the doc's earlier (B) "versioned CSV with metadata header" recommendation. Concrete JSON shape specified at the top of §4. Lossless, trivially validated, no Excel-mangling concerns.
- **Report CSV kept.** The current human-readable export survives as a separate "Download report" button — distinct from the save file.
- **Dual import entry-point.** Settings page adjacent to Export, AND the onboarding empty state (Sidebar / TownManager when `towns.length === 0`).
- **Filename:** `ac-save-<town>-<date>.json` (was `ac-museum-<town>-<date>.csv`).
- **Replace UX: confirmation-only, no undo.** Two-step destructive confirm with a heavy red warning, gated on whether the matched town actually has data to lose.
- **Multi-town single-file export: deferred** post-v0.9.3.

Locked answers live in §12; original questions are preserved above them.

## Phasing (recommended)

Two PRs, one release. PR 1 = export format redesign (~1 day). PR 2 = import UI + parser + state mutation (~3–4 days). Total ~5 days.

## Review gate

This PR is the approval surface for the plan itself. Once merged (or the discussion settles), PR 1 — the format redesign — spins off `development`.

## Test plan

- [ ] Doc reads coherently top to bottom
- [ ] §4 JSON shape matches the store's actual data model (towns + 3-level donation schema)
- [ ] §12 locked answers cover all six original questions
- [ ] No stale CSV references in sections describing the save file (option comparison in §4 is intentionally preserved for posterity)

🤖 Generated with [Claude Code](https://claude.com/claude-code)