### PR TITLE
feat(export): JSON save-file export (v0.9.3 PR 1/2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ All notable changes to this project are documented here.
 
 ### Added
 - Hand-drawn `bugs/ant.png` icon (ACGCN) — 2048 source committed at `icon-sources/bugs/ant.png`, exported through the v0.9.2 pipeline. Replaces the wiki-scraped placeholder. Third hand-drawn icon after sea-bass and koi
+- JSON save-file export (v0.9.3 PR 1/2) — new `Export save` button in the sidebar foot writes `ac-save-<town>-<date>.json`, a versioned, lossless format carrying `schemaVersion`, `app`, `appVersion`, `exportedAt`, full `town` metadata (name, gameId, hemisphere for ACNH, createdAt), and the donation list keyed by store-native `itemId` + `category` + ISO `donatedAt`. Schema lives in `src/lib/saveFile.ts`; format is documented in `docs/v0.9.3-csv-import-plan.md` §4. Round-trip importer follows in PR 2
+
+### Changed
+- The sidebar's single "Export CSV" control is now two distinct buttons — `Export save` (the new JSON save file) and `Download report` (the existing human-readable CSV, unchanged). The CSV remains for users pasting into spreadsheets; the JSON file is the new round-trip artifact
 
 ## [v0.9.2-beta] — 2026-05-05
 

--- a/src/components/ACCanvas.tsx
+++ b/src/components/ACCanvas.tsx
@@ -3,6 +3,7 @@ import { useParams, useNavigate } from 'react-router-dom';
 import { useAppStore } from '../lib/store';
 import { CATEGORY_META } from '../lib/categoryMeta';
 import { downloadCSV } from '../lib/csvExport';
+import { downloadSaveFile } from '../lib/saveFile';
 import { type AnyItem } from '../lib/utils';
 import type { CategoryId } from '../lib/types';
 import type { AppErrorKind } from '../lib/types';
@@ -154,6 +155,22 @@ export default function ACCanvas() {
 
   function handleExport() {
     if (!activeTown) return;
+    downloadSaveFile({
+      data,
+      donatedMap: activeTownDonated,
+      donatedAtMap: activeTownDonatedAt,
+      town: {
+        name: activeTown.name,
+        gameId: activeTown.gameId,
+        hemisphere: activeTown.hemisphere,
+        createdAt: activeTown.createdAt,
+      },
+      appVersion: import.meta.env.VITE_APP_VERSION ?? 'unknown',
+    });
+  }
+
+  function handleDownloadReport() {
+    if (!activeTown) return;
     downloadCSV(data, activeTownDonated, activeTownDonatedAt, activeTown.name);
   }
 
@@ -195,6 +212,7 @@ export default function ACCanvas() {
           data={data}
           catCounts={catCounts}
           onExport={handleExport}
+          onDownloadReport={handleDownloadReport}
         />
       )}
       <main className="ac-main">

--- a/src/components/CreditsRoute.tsx
+++ b/src/components/CreditsRoute.tsx
@@ -4,6 +4,7 @@ import { CreditsPage } from './CreditsPage';
 import { useMuseumData } from '../hooks/useMuseumData';
 import { useCategoryStats } from '../hooks/useCategoryStats';
 import { downloadCSV } from '../lib/csvExport';
+import { downloadSaveFile } from '../lib/saveFile';
 
 const EMPTY_DONATED: Record<string, boolean> = {};
 const EMPTY_DONATED_AT: Record<string, string> = {};
@@ -31,6 +32,22 @@ export default function CreditsRoute() {
 
   function handleExport() {
     if (!activeTown) return;
+    downloadSaveFile({
+      data,
+      donatedMap: activeTownDonated,
+      donatedAtMap: activeTownDonatedAt,
+      town: {
+        name: activeTown.name,
+        gameId: activeTown.gameId,
+        hemisphere: activeTown.hemisphere,
+        createdAt: activeTown.createdAt,
+      },
+      appVersion: import.meta.env.VITE_APP_VERSION ?? 'unknown',
+    });
+  }
+
+  function handleDownloadReport() {
+    if (!activeTown) return;
     downloadCSV(data, activeTownDonated, activeTownDonatedAt, activeTown.name);
   }
 
@@ -42,6 +59,7 @@ export default function CreditsRoute() {
           data={data}
           catCounts={catCounts}
           onExport={handleExport}
+          onDownloadReport={handleDownloadReport}
         />
       )}
       <main className="ac-main">

--- a/src/components/SettingsRoute.tsx
+++ b/src/components/SettingsRoute.tsx
@@ -4,6 +4,7 @@ import { SettingsPage } from './SettingsPage';
 import { useMuseumData } from '../hooks/useMuseumData';
 import { useCategoryStats } from '../hooks/useCategoryStats';
 import { downloadCSV } from '../lib/csvExport';
+import { downloadSaveFile } from '../lib/saveFile';
 
 // Stable empty fallbacks
 const EMPTY_DONATED: Record<string, boolean> = {};
@@ -32,6 +33,22 @@ export default function SettingsRoute() {
 
   function handleExport() {
     if (!activeTown) return;
+    downloadSaveFile({
+      data,
+      donatedMap: activeTownDonated,
+      donatedAtMap: activeTownDonatedAt,
+      town: {
+        name: activeTown.name,
+        gameId: activeTown.gameId,
+        hemisphere: activeTown.hemisphere,
+        createdAt: activeTown.createdAt,
+      },
+      appVersion: import.meta.env.VITE_APP_VERSION ?? 'unknown',
+    });
+  }
+
+  function handleDownloadReport() {
+    if (!activeTown) return;
     downloadCSV(data, activeTownDonated, activeTownDonatedAt, activeTown.name);
   }
 
@@ -43,6 +60,7 @@ export default function SettingsRoute() {
           data={data}
           catCounts={catCounts}
           onExport={handleExport}
+          onDownloadReport={handleDownloadReport}
         />
       )}
       <main className="ac-main">

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -22,11 +22,13 @@ export function Sidebar({
   data,
   catCounts,
   onExport,
+  onDownloadReport,
 }: {
   townId: string;
   data: AllData;
   catCounts: Stats;
   onExport: () => void;
+  onDownloadReport: () => void;
 }) {
   const navigate = useNavigate();
   const towns = useAppStore(s => s.towns);
@@ -145,7 +147,14 @@ export function Sidebar({
 
       <div className="ac-sidebar-foot">
         <button className="ac-foot-link" onClick={onExport}>
-          Export CSV
+          Export save
+        </button>
+        <button
+          className="ac-foot-link"
+          onClick={onDownloadReport}
+          title="Human-readable CSV report"
+        >
+          Download report
         </button>
         <button
           className="ac-foot-link"

--- a/src/lib/saveFile.test.ts
+++ b/src/lib/saveFile.test.ts
@@ -1,0 +1,249 @@
+import { describe, it, expect } from 'vitest';
+import {
+  buildSaveFile,
+  serializeSaveFile,
+  saveFileName,
+  SAVE_FILE_APP,
+  SAVE_FILE_SCHEMA_VERSION,
+  type BuildSaveFileArgs,
+} from './saveFile';
+import type { AllData } from './viewTypes';
+import type { GameId } from './types';
+import type { Hemisphere } from './store';
+
+function emptyData(): AllData {
+  return { fish: [], bugs: [], fossils: [], art: [], sea_creatures: [] };
+}
+
+function sampleData(): AllData {
+  return {
+    fish: [
+      { id: 'sea-bass', name: 'Sea Bass' } as AllData['fish'][number],
+      { id: 'koi', name: 'Koi' } as AllData['fish'][number],
+    ],
+    bugs: [{ id: 'tarantula', name: 'Tarantula' } as AllData['bugs'][number]],
+    fossils: [
+      { id: 'trex_skull', name: 'T. Rex Skull' } as AllData['fossils'][number],
+    ],
+    art: [
+      { id: 'mona-lisa', name: 'Famous Painting' } as AllData['art'][number],
+    ],
+    sea_creatures: [],
+  };
+}
+
+function baseArgs(
+  overrides: Partial<BuildSaveFileArgs> = {}
+): BuildSaveFileArgs {
+  return {
+    data: sampleData(),
+    donatedMap: {},
+    donatedAtMap: {},
+    town: {
+      name: 'Pelican Town',
+      gameId: 'ACGCN' as GameId,
+      hemisphere: 'NH' as Hemisphere,
+      createdAt: '2026-04-01T12:00:00.000Z',
+    },
+    appVersion: '0.9.3-beta',
+    now: new Date('2026-05-06T18:42:11.000Z'),
+    ...overrides,
+  };
+}
+
+describe('buildSaveFile — shape', () => {
+  it('emits the locked top-level fields', () => {
+    const file = buildSaveFile(baseArgs());
+    expect(file.schemaVersion).toBe(SAVE_FILE_SCHEMA_VERSION);
+    expect(file.schemaVersion).toBe(1);
+    expect(file.app).toBe(SAVE_FILE_APP);
+    expect(file.app).toBe('ac-web');
+    expect(file.appVersion).toBe('0.9.3-beta');
+    expect(file.exportedAt).toBe('2026-05-06T18:42:11.000Z');
+    expect(() => new Date(file.exportedAt).toISOString()).not.toThrow();
+  });
+
+  it('writes town name, gameId, createdAt', () => {
+    const file = buildSaveFile(baseArgs());
+    expect(file.town.name).toBe('Pelican Town');
+    expect(file.town.gameId).toBe('ACGCN');
+    expect(file.town.createdAt).toBe('2026-04-01T12:00:00.000Z');
+  });
+});
+
+describe('buildSaveFile — hemisphere gating', () => {
+  it('omits hemisphere outside ACNH', () => {
+    const file = buildSaveFile(
+      baseArgs({ town: { ...baseArgs().town, gameId: 'ACGCN' } })
+    );
+    expect('hemisphere' in file.town).toBe(false);
+    expect(file.town.hemisphere).toBeUndefined();
+  });
+
+  it('includes hemisphere for ACNH (NH)', () => {
+    const file = buildSaveFile(
+      baseArgs({
+        town: { ...baseArgs().town, gameId: 'ACNH', hemisphere: 'NH' },
+      })
+    );
+    expect(file.town.hemisphere).toBe('NH');
+  });
+
+  it('includes hemisphere for ACNH (SH)', () => {
+    const file = buildSaveFile(
+      baseArgs({
+        town: { ...baseArgs().town, gameId: 'ACNH', hemisphere: 'SH' },
+      })
+    );
+    expect(file.town.hemisphere).toBe('SH');
+  });
+
+  it.each<GameId>(['ACWW', 'ACCF', 'ACNL'])(
+    'omits hemisphere for %s',
+    gameId => {
+      const file = buildSaveFile(
+        baseArgs({ town: { ...baseArgs().town, gameId } })
+      );
+      expect('hemisphere' in file.town).toBe(false);
+    }
+  );
+});
+
+describe('buildSaveFile — donations', () => {
+  it('emits empty array when nothing is donated', () => {
+    const file = buildSaveFile(baseArgs());
+    expect(file.donations).toEqual([]);
+  });
+
+  it('only includes items present in data', () => {
+    const file = buildSaveFile(
+      baseArgs({
+        donatedMap: { 'sea-bass': true, 'ghost-id': true },
+        donatedAtMap: { 'sea-bass': '2026-04-15T18:42:11.000Z' },
+      })
+    );
+    expect(file.donations.map(d => d.itemId)).toEqual(['sea-bass']);
+  });
+
+  it('tags rows with their CategoryId', () => {
+    const file = buildSaveFile(
+      baseArgs({
+        donatedMap: {
+          'sea-bass': true,
+          tarantula: true,
+          trex_skull: true,
+          'mona-lisa': true,
+        },
+        donatedAtMap: {
+          'sea-bass': '2026-04-15T00:00:00.000Z',
+          tarantula: '2026-04-16T00:00:00.000Z',
+          trex_skull: '2026-04-17T00:00:00.000Z',
+          'mona-lisa': '2026-04-18T00:00:00.000Z',
+        },
+      })
+    );
+    const byItem = Object.fromEntries(
+      file.donations.map(d => [d.itemId, d.category])
+    );
+    expect(byItem['sea-bass']).toBe('fish');
+    expect(byItem.tarantula).toBe('bugs');
+    expect(byItem.trex_skull).toBe('fossils');
+    expect(byItem['mona-lisa']).toBe('art');
+  });
+
+  it('sorts donations ascending by donatedAt', () => {
+    const file = buildSaveFile(
+      baseArgs({
+        donatedMap: { koi: true, 'sea-bass': true, tarantula: true },
+        donatedAtMap: {
+          koi: '2026-04-20T00:00:00.000Z',
+          'sea-bass': '2026-04-10T00:00:00.000Z',
+          tarantula: '2026-04-15T00:00:00.000Z',
+        },
+      })
+    );
+    expect(file.donations.map(d => d.itemId)).toEqual([
+      'sea-bass',
+      'tarantula',
+      'koi',
+    ]);
+  });
+
+  it('sinks rows with empty donatedAt to the end', () => {
+    const file = buildSaveFile(
+      baseArgs({
+        donatedMap: { koi: true, 'sea-bass': true },
+        donatedAtMap: { 'sea-bass': '2026-04-10T00:00:00.000Z' },
+      })
+    );
+    expect(file.donations.map(d => d.itemId)).toEqual(['sea-bass', 'koi']);
+    expect(file.donations[1].donatedAt).toBe('');
+  });
+
+  it('includes sea_creatures when the data file has them', () => {
+    const data = sampleData();
+    data.sea_creatures = [
+      { id: 'lobster', name: 'Lobster' } as AllData['sea_creatures'][number],
+    ];
+    const file = buildSaveFile(
+      baseArgs({
+        data,
+        donatedMap: { lobster: true },
+        donatedAtMap: { lobster: '2026-04-20T00:00:00.000Z' },
+        town: { ...baseArgs().town, gameId: 'ACNH', hemisphere: 'NH' },
+      })
+    );
+    expect(file.donations).toEqual([
+      {
+        itemId: 'lobster',
+        category: 'sea_creatures',
+        donatedAt: '2026-04-20T00:00:00.000Z',
+      },
+    ]);
+  });
+});
+
+describe('saveFileName', () => {
+  it('uses the ac-save-<safeTown>-<date>.json shape', () => {
+    expect(
+      saveFileName('Pelican Town', new Date('2026-05-06T00:00:00.000Z'))
+    ).toBe('ac-save-Pelican_Town-2026-05-06.json');
+  });
+
+  it('sanitizes non-alphanumerics', () => {
+    expect(saveFileName('My Town!', new Date('2026-05-06T00:00:00.000Z'))).toBe(
+      'ac-save-My_Town_-2026-05-06.json'
+    );
+  });
+});
+
+describe('serialize → parse round-trip', () => {
+  it('JSON.parse(serializeSaveFile(...)) deep-equals the build output', () => {
+    const file = buildSaveFile(
+      baseArgs({
+        donatedMap: { 'sea-bass': true, tarantula: true },
+        donatedAtMap: {
+          'sea-bass': '2026-04-15T18:42:11.000Z',
+          tarantula: '2026-04-16T02:11:08.000Z',
+        },
+        town: {
+          name: 'Pelican Town',
+          gameId: 'ACNH',
+          hemisphere: 'SH',
+          createdAt: '2026-04-01T12:00:00.000Z',
+        },
+      })
+    );
+    const json = serializeSaveFile(file);
+    const parsed = JSON.parse(json);
+    expect(parsed).toEqual(file);
+    expect(parsed.town.hemisphere).toBe('SH');
+  });
+
+  it('produces valid JSON for an empty town', () => {
+    const file = buildSaveFile(baseArgs({ data: emptyData() }));
+    const json = serializeSaveFile(file);
+    expect(() => JSON.parse(json)).not.toThrow();
+    expect(JSON.parse(json).donations).toEqual([]);
+  });
+});

--- a/src/lib/saveFile.ts
+++ b/src/lib/saveFile.ts
@@ -1,0 +1,135 @@
+/**
+ * JSON save-file export — versioned, lossless round-trip format.
+ *
+ * Schema is documented in docs/v0.9.3-csv-import-plan.md §4. The human-readable
+ * report still lives in csvExport.ts; this module is strictly the save-file
+ * artifact that the v0.9.3 importer (PR 2) will consume.
+ */
+
+import type { CategoryId, GameId } from './types';
+import type { Hemisphere } from './store';
+import type { AllData } from './viewTypes';
+
+export const SAVE_FILE_SCHEMA_VERSION = 1 as const;
+export const SAVE_FILE_APP = 'ac-web' as const;
+
+export interface SaveDonationV1 {
+  itemId: string;
+  category: CategoryId;
+  donatedAt: string;
+}
+
+export interface SaveTownV1 {
+  name: string;
+  gameId: GameId;
+  createdAt: string;
+  hemisphere?: Hemisphere;
+}
+
+export interface SaveFileV1 {
+  schemaVersion: typeof SAVE_FILE_SCHEMA_VERSION;
+  app: typeof SAVE_FILE_APP;
+  appVersion: string;
+  exportedAt: string;
+  town: SaveTownV1;
+  donations: SaveDonationV1[];
+}
+
+export interface BuildSaveFileArgs {
+  data: AllData;
+  donatedMap: Record<string, boolean>;
+  donatedAtMap: Record<string, string>;
+  town: {
+    name: string;
+    gameId: GameId;
+    hemisphere: Hemisphere;
+    createdAt: string;
+  };
+  appVersion: string;
+  now?: Date;
+}
+
+const CATEGORY_ORDER: CategoryId[] = [
+  'fish',
+  'bugs',
+  'fossils',
+  'art',
+  'sea_creatures',
+];
+
+/**
+ * Build a SaveFileV1 object from the active-town slice of state.
+ *
+ * Items present in donatedMap but missing from the loaded data files are
+ * dropped, matching csvExport.ts behaviour. Donations are sorted by donatedAt
+ * ascending; rows with an empty donatedAt sink to the end.
+ */
+export function buildSaveFile(args: BuildSaveFileArgs): SaveFileV1 {
+  const { data, donatedMap, donatedAtMap, town, appVersion } = args;
+  const now = args.now ?? new Date();
+
+  const donations: SaveDonationV1[] = [];
+  for (const category of CATEGORY_ORDER) {
+    const items = data[category];
+    if (!items || items.length === 0) continue;
+    for (const item of items) {
+      if (!donatedMap[item.id]) continue;
+      donations.push({
+        itemId: item.id,
+        category,
+        donatedAt: donatedAtMap[item.id] ?? '',
+      });
+    }
+  }
+
+  donations.sort((a, b) => {
+    if (!a.donatedAt && !b.donatedAt) return 0;
+    if (!a.donatedAt) return 1;
+    if (!b.donatedAt) return -1;
+    return a.donatedAt.localeCompare(b.donatedAt);
+  });
+
+  const saveTown: SaveTownV1 = {
+    name: town.name,
+    gameId: town.gameId,
+    createdAt: town.createdAt,
+  };
+  if (town.gameId === 'ACNH') {
+    saveTown.hemisphere = town.hemisphere;
+  }
+
+  return {
+    schemaVersion: SAVE_FILE_SCHEMA_VERSION,
+    app: SAVE_FILE_APP,
+    appVersion,
+    exportedAt: now.toISOString(),
+    town: saveTown,
+    donations,
+  };
+}
+
+export function serializeSaveFile(file: SaveFileV1): string {
+  return JSON.stringify(file, null, 2);
+}
+
+export function saveFileName(townName: string, date: Date): string {
+  const safeTown = townName.replace(/[^a-z0-9]/gi, '_');
+  const day = date.toISOString().slice(0, 10);
+  return `ac-save-${safeTown}-${day}.json`;
+}
+
+/**
+ * Build the save file and trigger a browser download.
+ */
+export function downloadSaveFile(args: BuildSaveFileArgs): void {
+  const now = args.now ?? new Date();
+  const file = buildSaveFile({ ...args, now });
+  const json = serializeSaveFile(file);
+  const blob = new Blob([json], { type: 'application/json;charset=utf-8;' });
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement('a');
+  a.href = url;
+  a.download = saveFileName(args.town.name, now);
+  a.click();
+  setTimeout(() => URL.revokeObjectURL(url), 100);
+}


### PR DESCRIPTION
## Summary

First half of the v0.9.3 round-trip work. Adds a JSON save-file export alongside the existing CSV report — the new format carries enough structure to round-trip into an import (PR 2) without losing item ids, gameId, hemisphere, or timestamps.

- New `src/lib/saveFile.ts` builds and downloads a versioned JSON file matching the schema locked in `docs/v0.9.3-csv-import-plan.md` §4.
- Sidebar foot now offers two distinct controls: **Export save** (JSON, the new save-file artifact) and **Download report** (existing CSV, kept for users pasting into spreadsheets).
- Filename shifts from `ac-museum-<town>-<date>.csv` to `ac-save-<town>-<date>.json` per the scoping doc's locked answer 4.
- Vitest coverage (18 new tests) for the JSON shape, hemisphere gating, empty state, sort order, filename, and a serialize / parse round-trip.

Import logic, conflict resolution, and the Settings entry point all land in PR 2.

## Decisions

- Format follows the locked JSON shape in §4 of the scoping doc — `schemaVersion: 1`, top-level `app` / `appVersion` / `exportedAt` / `town` / `donations`. No synthetic `townId` in the file (per §6 reasoning).
- `hemisphere` is omitted (key absent, not `null`) outside ACNH so the file stays minimal and the importer can rely on `'hemisphere' in town`.
- `itemId` values are bare data-file ids (e.g. `sea-bass`, `tarantula`, `trex_skull`) — the doc's `fish-…` / `bug-…` example was prose; the store's actual keys carry no category prefix and emitting the bare id is what round-trips cleanly.
- Empty `donatedAt` is preserved end-to-end (sinks to the bottom of the donation list) rather than dropped — keeps export lossless and lets PR 2's importer decide tolerance.
- Report CSV preserved as a separate button per locked answer 1; not folded into the new format.
- Single-town scope retained per locked answer 3.

## Test plan

- `npm run lint` ✅
- `npm run build` ✅
- `npm test` ✅ (97/97, including 18 new `saveFile.test.ts` cases)
- Manual (to verify in the dev preview): trigger **Export save** from a populated ACNH town and an empty ACGCN town; confirm the file downloads, opens as valid JSON, and matches the schema. Trigger **Download report** to confirm the existing CSV is unchanged.

Refs: PR #105, `docs/v0.9.3-csv-import-plan.md`.