### PR TITLE
feat(import): JSON save-file import (v0.9.3 PR 2/2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,11 @@ All notable changes to this project are documented here.
 ### Added
 - Hand-drawn `bugs/ant.png` icon (ACGCN) — 2048 source committed at `icon-sources/bugs/ant.png`, exported through the v0.9.2 pipeline. Replaces the wiki-scraped placeholder. Third hand-drawn icon after sea-bass and koi
 - JSON save-file export (v0.9.3 PR 1/2) — new `Export save` button in the sidebar foot writes `ac-save-<town>-<date>.json`, a versioned, lossless format carrying `schemaVersion`, `app`, `appVersion`, `exportedAt`, full `town` metadata (name, gameId, hemisphere for ACNH, createdAt), and the donation list keyed by store-native `itemId` + `category` + ISO `donatedAt`. Schema lives in `src/lib/saveFile.ts`; format is documented in `docs/v0.9.3-csv-import-plan.md` §4. Round-trip importer follows in PR 2
+- JSON save-file import (v0.9.3 PR 2/2) — round-trip companion to the export. New `Import save` button in the sidebar footer and an `Import save instead` affordance in the empty-state TownManager open the import modal. Parser + validator in `src/lib/saveFileImport.ts` rejects non-`schemaVersion=1` files, wrong-app files, missing/malformed required fields, unknown `gameId`, and ACNH saves missing a hemisphere; tolerates malformed donation rows by dropping them with a count. Reconciliation in `src/lib/saveFileReconcile.ts` matches on `(name, gameId)` and produces one of three plans — Replace (wipe + write), Merge (union, earlier `donatedAt` wins on conflict), or Import-as-new (create a fresh town). Items missing from the loaded data files are dropped silently with a count surfaced in the modal. Replace into a town with existing donations gates behind a heavy two-step "YOU CAN NOT GO BACK" confirmation; Replace into an empty town skips it. The store gets a single atomic `applyImportedSave(plan)` action
 
 ### Changed
 - The sidebar's single "Export CSV" control is now two distinct buttons — `Export save` (the new JSON save file) and `Download report` (the existing human-readable CSV, unchanged). The CSV remains for users pasting into spreadsheets; the JSON file is the new round-trip artifact
+- The empty-state TownManager (no towns yet) gained an "Import save instead" affordance, so a fresh-device user can restore from a save file without first creating a placeholder town
 
 ## [v0.9.2-beta] — 2026-05-05
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,6 +5,7 @@ import ACCanvas from './components/ACCanvas';
 import SettingsRoute from './components/SettingsRoute';
 import CreditsRoute from './components/CreditsRoute';
 import { TownManager } from './components/TownManager';
+import { ImportSaveModal } from './components/ImportSaveModal';
 import { useHydration } from './hooks/useHydration';
 import ErrorBoundary from './components/ErrorBoundary';
 import { useAppStore } from './lib/store';
@@ -27,13 +28,22 @@ function App() {
   const towns = useAppStore(s => s.towns);
   const openTownManager = useUIStore(s => s.openTownManager);
   const townManagerOpen = useUIStore(s => s.townManagerOpen);
+  const importSaveOpen = useUIStore(s => s.importSaveOpen);
 
-  // Force the TownManager open in create mode whenever there are no towns.
+  // Force the TownManager open in create mode whenever there are no towns,
+  // unless the import-save modal is currently open (the user might be importing
+  // a fresh save instead of creating a town from scratch).
   useEffect(() => {
-    if (hydrated && towns.length === 0 && !townManagerOpen) {
+    if (hydrated && towns.length === 0 && !townManagerOpen && !importSaveOpen) {
       openTownManager(true);
     }
-  }, [hydrated, towns.length, townManagerOpen, openTownManager]);
+  }, [
+    hydrated,
+    towns.length,
+    townManagerOpen,
+    importSaveOpen,
+    openTownManager,
+  ]);
 
   if (!hydrated) {
     return (
@@ -70,6 +80,7 @@ function App() {
         <Route path="*" element={<Navigate to="/" replace />} />
       </Routes>
       <TownManager />
+      <ImportSaveModal />
       <Analytics />
       {typeof window !== 'undefined' && (
         <div

--- a/src/components/ImportSaveModal.tsx
+++ b/src/components/ImportSaveModal.tsx
@@ -1,0 +1,465 @@
+import { useEffect, useMemo, useRef, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { useAppStore } from '../lib/store';
+import { useUIStore } from '../lib/uiStore';
+import { GAMES } from '../lib/types';
+import { useMuseumData } from '../hooks/useMuseumData';
+import { parseSaveFile, formatParseError } from '../lib/saveFileImport';
+import {
+  buildImportPlan,
+  findCandidateMatch,
+  type ImportPlan,
+  type ReconcileMode,
+} from '../lib/saveFileReconcile';
+import type { SaveFileV1 } from '../lib/saveFile';
+import type { Town } from '../lib/store';
+import type { AllData } from '../lib/viewTypes';
+import type { CategoryId } from '../lib/types';
+
+const CATEGORY_KEYS: CategoryId[] = [
+  'fish',
+  'bugs',
+  'fossils',
+  'art',
+  'sea_creatures',
+];
+
+function collectKnownIds(data: AllData): Set<string> {
+  const ids = new Set<string>();
+  for (const cat of CATEGORY_KEYS) {
+    for (const item of data[cat] ?? []) ids.add(item.id);
+  }
+  return ids;
+}
+
+export function ImportSaveModal() {
+  const open = useUIStore(s => s.importSaveOpen);
+  const close = useUIStore(s => s.closeImportSave);
+  const towns = useAppStore(s => s.towns);
+  const donatedAt = useAppStore(s => s.donatedAt);
+  const applyImportedSave = useAppStore(s => s.applyImportedSave);
+  const navigate = useNavigate();
+
+  const [file, setFile] = useState<SaveFileV1 | null>(null);
+  const [parseWarn, setParseWarn] = useState<{
+    droppedMalformedRows: number;
+  } | null>(null);
+  const [parseError, setParseError] = useState<string | null>(null);
+  const [mode, setMode] = useState<ReconcileMode>('create');
+  const [confirmStep, setConfirmStep] = useState(false);
+  const [confirmAck, setConfirmAck] = useState(false);
+  const fileInputRef = useRef<HTMLInputElement>(null);
+
+  // Match candidate (existing town with same name + gameId)
+  const candidate: Town | null = useMemo(
+    () => (file ? findCandidateMatch(towns, file) : null),
+    [file, towns]
+  );
+
+  // When the file (and therefore candidate) changes, choose a sensible default mode.
+  useEffect(() => {
+    if (!file) return;
+    setMode(candidate ? 'replace' : 'create');
+    setConfirmStep(false);
+    setConfirmAck(false);
+  }, [file, candidate]);
+
+  // Reset everything when the modal closes.
+  useEffect(() => {
+    if (open) return;
+    setFile(null);
+    setParseWarn(null);
+    setParseError(null);
+    setMode('create');
+    setConfirmStep(false);
+    setConfirmAck(false);
+  }, [open]);
+
+  // Esc to close (when not mid-confirm).
+  useEffect(() => {
+    if (!open) return;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') close();
+    };
+    window.addEventListener('keydown', onKey);
+    return () => window.removeEventListener('keydown', onKey);
+  }, [open, close]);
+
+  // Load data files for the imported gameId so we can drop unknown itemIds.
+  const { data, loading: dataLoading } = useMuseumData(
+    file?.town.gameId ?? 'ACGCN'
+  );
+  const knownIds = useMemo(() => collectKnownIds(data), [data]);
+
+  // Donation count we'd be wiping if Replace targets the candidate.
+  const candidateDonationCount = useMemo(() => {
+    if (!candidate) return 0;
+    const m = donatedAt[candidate.id]?.[candidate.gameId] ?? {};
+    return Object.keys(m).length;
+  }, [candidate, donatedAt]);
+
+  if (!open) return null;
+
+  function handleFile(input: File) {
+    setParseError(null);
+    setParseWarn(null);
+    setFile(null);
+    input
+      .text()
+      .then(text => {
+        const result = parseSaveFile(text);
+        if (!result.ok) {
+          setParseError(formatParseError(result.error));
+          return;
+        }
+        setFile(result.file);
+        setParseWarn(result.warnings);
+      })
+      .catch(err => {
+        setParseError(
+          err instanceof Error ? err.message : 'Could not read file.'
+        );
+      });
+  }
+
+  function buildPlan(): ImportPlan | null {
+    if (!file) return null;
+    const existingDonatedAt = candidate
+      ? (donatedAt[candidate.id]?.[candidate.gameId] ?? {})
+      : {};
+    return buildImportPlan({
+      file,
+      mode,
+      existing: candidate,
+      existingDonatedAt,
+      knownItemIds: knownIds,
+    });
+  }
+
+  function handlePrimary() {
+    if (!file) return;
+    // Replace into a town with data → require the heavy two-step gate.
+    if (mode === 'replace' && candidateDonationCount > 0 && !confirmStep) {
+      setConfirmStep(true);
+      return;
+    }
+    const plan = buildPlan();
+    if (!plan) return;
+    const townId = applyImportedSave(plan);
+    close();
+    if (townId) navigate(`/town/${townId}/home`);
+  }
+
+  function handleScrim() {
+    if (confirmStep) return;
+    close();
+  }
+
+  // ── Render branches ────────────────────────────────────────────────────────
+
+  const showFilePicker = !file && !parseError;
+
+  return (
+    <div className="ac-im-scrim" onClick={handleScrim}>
+      <aside
+        className="ac-im-modal"
+        role="dialog"
+        aria-label="Import save"
+        onClick={e => e.stopPropagation()}
+      >
+        <header className="ac-im-head">
+          <div>
+            <div className="ac-im-eyebrow">Save file</div>
+            <h2 className="ac-im-title">Import save</h2>
+          </div>
+          <button className="ac-im-close" onClick={close} aria-label="Close">
+            ×
+          </button>
+        </header>
+
+        {showFilePicker && (
+          <div className="ac-im-body">
+            <p className="ac-im-help">
+              Choose a <code>.json</code> save file exported from Museum
+              Tracker. Donations and town details will be reconstructed from the
+              file.
+            </p>
+            <button
+              className="ac-im-cta"
+              onClick={() => fileInputRef.current?.click()}
+            >
+              Choose file…
+            </button>
+            <input
+              ref={fileInputRef}
+              type="file"
+              accept=".json,application/json"
+              style={{ display: 'none' }}
+              onChange={e => {
+                const f = e.target.files?.[0];
+                if (f) handleFile(f);
+                // Allow re-selecting the same file later.
+                e.target.value = '';
+              }}
+            />
+          </div>
+        )}
+
+        {parseError && (
+          <div className="ac-im-body">
+            <div className="ac-im-error">{parseError}</div>
+            <button
+              className="ac-im-cta-secondary"
+              onClick={() => {
+                setParseError(null);
+                setFile(null);
+              }}
+            >
+              Try a different file
+            </button>
+          </div>
+        )}
+
+        {file && !parseError && !confirmStep && (
+          <div className="ac-im-body">
+            <PreviewCard
+              file={file}
+              candidate={candidate}
+              warnings={parseWarn}
+              dataLoading={dataLoading}
+              knownIds={knownIds}
+            />
+
+            {candidate ? (
+              <ModeSelector mode={mode} setMode={setMode} />
+            ) : (
+              <p className="ac-im-help" style={{ marginTop: 12 }}>
+                No existing town matches <strong>{file.town.name}</strong> on{' '}
+                {GAMES[file.town.gameId].shortName}. A new town will be created.
+              </p>
+            )}
+
+            <div className="ac-im-actions">
+              <button className="ac-im-cta-secondary" onClick={close}>
+                Cancel
+              </button>
+              <button
+                className={
+                  mode === 'replace' && candidateDonationCount > 0
+                    ? 'ac-im-cta ac-im-cta-danger'
+                    : 'ac-im-cta'
+                }
+                onClick={handlePrimary}
+                disabled={dataLoading}
+              >
+                {mode === 'replace'
+                  ? candidateDonationCount > 0
+                    ? 'Replace…'
+                    : 'Replace'
+                  : mode === 'merge'
+                    ? 'Merge'
+                    : candidate
+                      ? 'Import as new town'
+                      : 'Import'}
+              </button>
+            </div>
+          </div>
+        )}
+
+        {file && confirmStep && candidate && (
+          <div className="ac-im-body">
+            <div className="ac-im-danger-panel">
+              <div className="ac-im-danger-title">YOU CAN NOT GO BACK.</div>
+              <p>
+                Replacing <strong>{candidate.name}</strong> will permanently
+                delete <strong>{candidateDonationCount}</strong> existing
+                donation
+                {candidateDonationCount === 1 ? '' : 's'} for this town. This
+                cannot be undone.
+              </p>
+              <label className="ac-im-danger-ack">
+                <input
+                  type="checkbox"
+                  checked={confirmAck}
+                  onChange={e => setConfirmAck(e.target.checked)}
+                />
+                <span>
+                  I understand this will erase my existing donation history.
+                </span>
+              </label>
+            </div>
+            <div className="ac-im-actions">
+              <button
+                className="ac-im-cta-secondary"
+                onClick={() => {
+                  setConfirmStep(false);
+                  setConfirmAck(false);
+                }}
+              >
+                Back
+              </button>
+              <button
+                className="ac-im-cta ac-im-cta-danger"
+                onClick={() => {
+                  if (!confirmAck) return;
+                  const plan = buildPlan();
+                  if (!plan) return;
+                  const townId = applyImportedSave(plan);
+                  close();
+                  if (townId) navigate(`/town/${townId}/home`);
+                }}
+                disabled={!confirmAck}
+              >
+                Replace donations
+              </button>
+            </div>
+          </div>
+        )}
+      </aside>
+    </div>
+  );
+}
+
+function PreviewCard({
+  file,
+  candidate,
+  warnings,
+  dataLoading,
+  knownIds,
+}: {
+  file: SaveFileV1;
+  candidate: Town | null;
+  warnings: { droppedMalformedRows: number } | null;
+  dataLoading: boolean;
+  knownIds: Set<string>;
+}) {
+  const game = GAMES[file.town.gameId];
+  const droppedUnknown = useMemo(() => {
+    if (dataLoading) return null;
+    let n = 0;
+    for (const d of file.donations) if (!knownIds.has(d.itemId)) n += 1;
+    return n;
+  }, [file, knownIds, dataLoading]);
+
+  return (
+    <div className="ac-im-preview">
+      <div className="ac-im-preview-head">
+        <div className="ac-im-preview-name">{file.town.name}</div>
+        <div className="ac-im-preview-meta">
+          <span className="ac-im-badge">{game.shortName}</span>
+          {file.town.hemisphere && (
+            <>
+              <span className="ac-im-dot">·</span>
+              <span>Hem. {file.town.hemisphere}</span>
+            </>
+          )}
+          <span className="ac-im-dot">·</span>
+          <span>
+            {file.donations.length} donation
+            {file.donations.length === 1 ? '' : 's'}
+          </span>
+        </div>
+      </div>
+      <dl className="ac-im-preview-list">
+        <div>
+          <dt>Exported</dt>
+          <dd>{new Date(file.exportedAt).toLocaleString()}</dd>
+        </div>
+        <div>
+          <dt>App version</dt>
+          <dd>{file.appVersion}</dd>
+        </div>
+        {candidate && (
+          <div>
+            <dt>Match</dt>
+            <dd>
+              Existing town &ldquo;{candidate.name}&rdquo; ({game.shortName})
+            </dd>
+          </div>
+        )}
+      </dl>
+      {(warnings?.droppedMalformedRows ?? 0) > 0 && (
+        <div className="ac-im-warn">
+          {warnings!.droppedMalformedRows} donation row
+          {warnings!.droppedMalformedRows === 1 ? '' : 's'} were malformed and
+          will be skipped.
+        </div>
+      )}
+      {droppedUnknown !== null && droppedUnknown > 0 && (
+        <div className="ac-im-warn">
+          {droppedUnknown} donation
+          {droppedUnknown === 1 ? '' : 's'} reference items not in the current
+          data files and will be dropped.
+        </div>
+      )}
+    </div>
+  );
+}
+
+function ModeSelector({
+  mode,
+  setMode,
+}: {
+  mode: ReconcileMode;
+  setMode: (m: ReconcileMode) => void;
+}) {
+  return (
+    <fieldset className="ac-im-modes">
+      <legend className="ac-im-modes-legend">A matching town exists</legend>
+      <label
+        className={
+          mode === 'replace' ? 'ac-im-mode ac-im-mode-on' : 'ac-im-mode'
+        }
+      >
+        <input
+          type="radio"
+          name="mode"
+          checked={mode === 'replace'}
+          onChange={() => setMode('replace')}
+        />
+        <div>
+          <div className="ac-im-mode-name">Replace</div>
+          <div className="ac-im-mode-sub">
+            Wipe the existing donations and write the imported set.
+          </div>
+        </div>
+      </label>
+      <label
+        className={mode === 'merge' ? 'ac-im-mode ac-im-mode-on' : 'ac-im-mode'}
+      >
+        <input
+          type="radio"
+          name="mode"
+          checked={mode === 'merge'}
+          onChange={() => setMode('merge')}
+        />
+        <div>
+          <div className="ac-im-mode-name">Merge</div>
+          <div className="ac-im-mode-sub">
+            Union of donations. On collision the earlier date wins.
+          </div>
+        </div>
+      </label>
+      <label
+        className={
+          mode === 'create' ? 'ac-im-mode ac-im-mode-on' : 'ac-im-mode'
+        }
+      >
+        <input
+          type="radio"
+          name="mode"
+          checked={mode === 'create'}
+          onChange={() => setMode('create')}
+        />
+        <div>
+          <div className="ac-im-mode-name">Import as new town</div>
+          <div className="ac-im-mode-sub">
+            Leave the existing town alone and add a new one.
+          </div>
+        </div>
+      </label>
+    </fieldset>
+  );
+}
+
+export default ImportSaveModal;

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -33,6 +33,7 @@ export function Sidebar({
   const navigate = useNavigate();
   const towns = useAppStore(s => s.towns);
   const openTownManager = useUIStore(s => s.openTownManager);
+  const openImportSave = useUIStore(s => s.openImportSave);
   const activeTown = towns.find(t => t.id === townId);
 
   const gameId = activeTown?.gameId ?? 'ACGCN';
@@ -148,6 +149,13 @@ export function Sidebar({
       <div className="ac-sidebar-foot">
         <button className="ac-foot-link" onClick={onExport}>
           Export save
+        </button>
+        <button
+          className="ac-foot-link"
+          onClick={openImportSave}
+          title="Import a JSON save file"
+        >
+          Import save
         </button>
         <button
           className="ac-foot-link"

--- a/src/components/TownManager.tsx
+++ b/src/components/TownManager.tsx
@@ -10,6 +10,7 @@ export function TownManager() {
   const open = useUIStore(s => s.townManagerOpen);
   const forceCreate = useUIStore(s => s.townManagerForceCreate);
   const close = useUIStore(s => s.closeTownManager);
+  const openImportSave = useUIStore(s => s.openImportSave);
 
   const towns = useAppStore(s => s.towns);
   const activeTownId = useAppStore(s => s.activeTownId);
@@ -125,8 +126,19 @@ export function TownManager() {
             <div className="ac-tm-empty-glyph">○</div>
             <div className="ac-tm-empty-title">No towns yet</div>
             <div className="ac-tm-empty-sub">
-              Create your first town to start tracking donations.
+              Create your first town to start tracking donations, or import a
+              save file from another device.
             </div>
+            <button
+              type="button"
+              className="ac-tm-empty-import"
+              onClick={() => {
+                close();
+                openImportSave();
+              }}
+            >
+              Import save instead
+            </button>
           </div>
         )}
 

--- a/src/index.css
+++ b/src/index.css
@@ -1543,3 +1543,202 @@ body {
 .ac-shelf-icon { display: inline-block; flex: none; }
 .ac-recent-icon { display: inline-block; flex: none; }
 
+
+/* ─── Import save modal (v0.9.3 PR 2/2) ──────────────────────────────────── */
+.ac-im-scrim {
+  position: fixed; inset: 0; z-index: 60;
+  background: rgba(35, 36, 31, 0.45);
+  display: flex; align-items: center; justify-content: center;
+  padding: 24px;
+}
+.ac-im-modal {
+  background: var(--surface);
+  border: 1px solid var(--border-strong);
+  border-radius: 16px;
+  width: min(560px, 100%);
+  max-height: calc(100vh - 48px);
+  overflow-y: auto;
+  box-shadow: 0 24px 60px rgba(0, 0, 0, 0.18);
+  display: flex; flex-direction: column;
+}
+.ac-im-head {
+  display: flex; align-items: flex-start; justify-content: space-between;
+  padding: 22px 24px 12px;
+  border-bottom: 1px solid var(--border);
+}
+.ac-im-eyebrow {
+  font-size: 11px; letter-spacing: 0.08em; text-transform: uppercase;
+  color: var(--ink-muted);
+}
+.ac-im-title {
+  font-family: var(--font-display);
+  font-size: 22px;
+  color: var(--ink);
+  margin: 2px 0 0;
+}
+.ac-im-close {
+  background: none; border: none; cursor: pointer;
+  font-size: 24px; line-height: 1; color: var(--ink-muted);
+  padding: 4px 8px;
+}
+.ac-im-close:hover { color: var(--ink); }
+
+.ac-im-body { padding: 18px 24px 22px; display: flex; flex-direction: column; gap: 14px; }
+.ac-im-help { color: var(--ink-soft); font-size: 14px; line-height: 1.5; }
+.ac-im-help code {
+  background: var(--surface-alt);
+  padding: 1px 6px;
+  border-radius: 4px;
+  font-size: 12px;
+}
+
+.ac-im-cta {
+  align-self: flex-start;
+  background: var(--accent);
+  color: var(--accent-ink);
+  border: none; border-radius: 10px;
+  padding: 10px 18px;
+  font-weight: 600; font-size: 14px;
+  cursor: pointer;
+}
+.ac-im-cta:hover { opacity: 0.9; }
+.ac-im-cta:disabled { opacity: 0.5; cursor: not-allowed; }
+.ac-im-cta-secondary {
+  align-self: flex-start;
+  background: transparent;
+  color: var(--ink-soft);
+  border: 1px solid var(--border-strong);
+  border-radius: 10px;
+  padding: 9px 16px;
+  font-weight: 500; font-size: 14px;
+  cursor: pointer;
+}
+.ac-im-cta-secondary:hover { background: var(--surface-alt); color: var(--ink); }
+.ac-im-cta-danger {
+  background: var(--warn);
+  color: #fff;
+}
+.ac-im-cta-danger:hover { opacity: 0.9; }
+
+.ac-im-error {
+  background: var(--warn-soft, #fdecd9);
+  color: var(--warn);
+  border: 1px solid var(--warn);
+  border-radius: 10px;
+  padding: 12px 14px;
+  font-size: 13px;
+  line-height: 1.45;
+}
+
+.ac-im-preview {
+  background: var(--surface-alt);
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  padding: 16px;
+}
+.ac-im-preview-head { display: flex; flex-direction: column; gap: 4px; margin-bottom: 10px; }
+.ac-im-preview-name {
+  font-family: var(--font-display);
+  font-size: 17px;
+  color: var(--ink);
+}
+.ac-im-preview-meta {
+  display: flex; align-items: center; gap: 6px; flex-wrap: wrap;
+  font-size: 12px; color: var(--ink-muted);
+}
+.ac-im-badge {
+  background: var(--surface);
+  border: 1px solid var(--border-strong);
+  border-radius: 999px;
+  padding: 1px 8px;
+  font-size: 11px;
+  color: var(--ink-soft);
+}
+.ac-im-dot { color: var(--ink-muted); }
+.ac-im-preview-list {
+  margin: 8px 0 0;
+  font-size: 12px;
+  display: grid; gap: 4px;
+}
+.ac-im-preview-list > div { display: flex; gap: 8px; }
+.ac-im-preview-list dt { color: var(--ink-muted); min-width: 88px; }
+.ac-im-preview-list dd { margin: 0; color: var(--ink-soft); }
+.ac-im-warn {
+  margin-top: 10px;
+  font-size: 12px;
+  color: var(--warn);
+  background: var(--warn-soft, #fdecd9);
+  border-radius: 8px;
+  padding: 8px 10px;
+}
+
+.ac-im-modes {
+  border: none; padding: 0; margin: 0;
+  display: flex; flex-direction: column; gap: 8px;
+}
+.ac-im-modes-legend {
+  font-size: 12px; color: var(--ink-muted); margin-bottom: 4px;
+  text-transform: uppercase; letter-spacing: 0.06em;
+}
+.ac-im-mode {
+  display: flex; gap: 12px; align-items: flex-start;
+  padding: 12px 14px;
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  cursor: pointer;
+  background: var(--surface);
+}
+.ac-im-mode:hover { border-color: var(--border-strong); }
+.ac-im-mode-on { border-color: var(--accent); background: var(--accent-soft); }
+.ac-im-mode input { margin-top: 3px; }
+.ac-im-mode-name { font-weight: 600; font-size: 14px; color: var(--ink); }
+.ac-im-mode-sub { font-size: 12px; color: var(--ink-muted); margin-top: 2px; }
+
+.ac-im-actions {
+  display: flex; justify-content: flex-end; gap: 10px;
+  margin-top: 4px;
+}
+
+.ac-im-danger-panel {
+  border: 1.5px solid var(--warn);
+  background: var(--warn-soft, #fdecd9);
+  border-radius: 12px;
+  padding: 16px;
+  color: var(--ink);
+}
+.ac-im-danger-title {
+  font-family: var(--font-display);
+  font-size: 16px;
+  color: var(--warn);
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  margin-bottom: 8px;
+}
+.ac-im-danger-panel p { margin: 0 0 12px; font-size: 13px; line-height: 1.5; }
+.ac-im-danger-ack {
+  display: flex; align-items: flex-start; gap: 8px;
+  font-size: 13px; color: var(--ink);
+  cursor: pointer;
+}
+.ac-im-danger-ack input { margin-top: 3px; }
+
+.ac-tm-empty-import {
+  margin-top: 14px;
+  background: transparent;
+  border: 1px solid var(--border-strong);
+  color: var(--ink-soft);
+  padding: 8px 14px;
+  border-radius: 999px;
+  font-size: 13px;
+  cursor: pointer;
+}
+.ac-tm-empty-import:hover { background: var(--surface-alt); color: var(--ink); }
+
+@media (max-width: 720px) {
+  .ac-im-scrim { align-items: flex-end; padding: 0; }
+  .ac-im-modal {
+    width: 100%;
+    max-height: 92vh;
+    border-radius: 18px 18px 0 0;
+  }
+}

--- a/src/lib/saveFileImport.test.ts
+++ b/src/lib/saveFileImport.test.ts
@@ -1,0 +1,204 @@
+import { describe, it, expect } from 'vitest';
+import { parseSaveFile, formatParseError } from './saveFileImport';
+import {
+  buildSaveFile,
+  serializeSaveFile,
+  type BuildSaveFileArgs,
+} from './saveFile';
+import type { AllData } from './viewTypes';
+import type { GameId } from './types';
+import type { Hemisphere } from './store';
+
+function sampleData(): AllData {
+  return {
+    fish: [
+      { id: 'sea-bass', name: 'Sea Bass' } as AllData['fish'][number],
+      { id: 'koi', name: 'Koi' } as AllData['fish'][number],
+    ],
+    bugs: [{ id: 'tarantula', name: 'Tarantula' } as AllData['bugs'][number]],
+    fossils: [
+      { id: 'trex_skull', name: 'T. Rex Skull' } as AllData['fossils'][number],
+    ],
+    art: [
+      { id: 'mona-lisa', name: 'Famous Painting' } as AllData['art'][number],
+    ],
+    sea_creatures: [],
+  };
+}
+
+function buildJson(overrides: Partial<BuildSaveFileArgs> = {}): string {
+  const base: BuildSaveFileArgs = {
+    data: sampleData(),
+    donatedMap: { 'sea-bass': true, tarantula: true },
+    donatedAtMap: {
+      'sea-bass': '2026-04-15T18:42:11.000Z',
+      tarantula: '2026-04-16T02:11:08.000Z',
+    },
+    town: {
+      name: 'Pelican Town',
+      gameId: 'ACNH' as GameId,
+      hemisphere: 'NH' as Hemisphere,
+      createdAt: '2026-04-01T12:00:00.000Z',
+    },
+    appVersion: '0.9.3-beta',
+    now: new Date('2026-05-06T18:42:11.000Z'),
+    ...overrides,
+  };
+  return serializeSaveFile(buildSaveFile(base));
+}
+
+describe('parseSaveFile — happy path', () => {
+  it('round-trips a file produced by buildSaveFile (ACNH)', () => {
+    const json = buildJson();
+    const result = parseSaveFile(json);
+    if (!result.ok) throw new Error(formatParseError(result.error));
+    expect(result.file.app).toBe('ac-web');
+    expect(result.file.schemaVersion).toBe(1);
+    expect(result.file.town.name).toBe('Pelican Town');
+    expect(result.file.town.gameId).toBe('ACNH');
+    expect(result.file.town.hemisphere).toBe('NH');
+    expect(result.file.donations).toHaveLength(2);
+    expect(result.warnings.droppedMalformedRows).toBe(0);
+  });
+
+  it('round-trips for ACGCN (no hemisphere)', () => {
+    const json = buildJson({
+      town: {
+        name: 'Marigold',
+        gameId: 'ACGCN',
+        hemisphere: 'NH',
+        createdAt: '2026-04-01T00:00:00.000Z',
+      },
+    });
+    const result = parseSaveFile(json);
+    if (!result.ok) throw new Error(formatParseError(result.error));
+    expect(result.file.town.gameId).toBe('ACGCN');
+    expect(result.file.town.hemisphere).toBeUndefined();
+  });
+
+  it('accepts an empty donations array', () => {
+    const json = buildJson({ donatedMap: {}, donatedAtMap: {} });
+    const result = parseSaveFile(json);
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.file.donations).toHaveLength(0);
+    }
+  });
+});
+
+describe('parseSaveFile — hard rejects', () => {
+  it('rejects invalid JSON', () => {
+    const result = parseSaveFile('{not json');
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error.kind).toBe('invalid_json');
+  });
+
+  it('rejects schemaVersion ≠ 1', () => {
+    const obj = JSON.parse(buildJson());
+    obj.schemaVersion = 2;
+    const result = parseSaveFile(JSON.stringify(obj));
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error.kind).toBe('unsupported_version');
+  });
+
+  it('rejects wrong app field', () => {
+    const obj = JSON.parse(buildJson());
+    obj.app = 'something-else';
+    const result = parseSaveFile(JSON.stringify(obj));
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error.kind).toBe('wrong_app');
+  });
+
+  it('rejects missing town', () => {
+    const obj = JSON.parse(buildJson());
+    delete obj.town;
+    const result = parseSaveFile(JSON.stringify(obj));
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error.kind).toBe('malformed_shape');
+  });
+
+  it('rejects unknown gameId', () => {
+    const obj = JSON.parse(buildJson());
+    obj.town.gameId = 'ACPC';
+    const result = parseSaveFile(JSON.stringify(obj));
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error.kind).toBe('unknown_game');
+  });
+
+  it('rejects ACNH save with no hemisphere', () => {
+    const obj = JSON.parse(buildJson());
+    delete obj.town.hemisphere;
+    const result = parseSaveFile(JSON.stringify(obj));
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error.kind).toBe('missing_hemisphere');
+  });
+
+  it('rejects malformed exportedAt', () => {
+    const obj = JSON.parse(buildJson());
+    obj.exportedAt = 'not-a-date';
+    const result = parseSaveFile(JSON.stringify(obj));
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.kind).toBe('malformed_shape');
+      if (result.error.kind === 'malformed_shape') {
+        expect(result.error.field).toBe('exportedAt');
+      }
+    }
+  });
+
+  it('rejects donations not being an array', () => {
+    const obj = JSON.parse(buildJson());
+    obj.donations = 'oops';
+    const result = parseSaveFile(JSON.stringify(obj));
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error.kind).toBe('malformed_shape');
+  });
+});
+
+describe('parseSaveFile — donation row tolerance', () => {
+  it('drops malformed rows and reports a warning count', () => {
+    const obj = JSON.parse(buildJson());
+    obj.donations.push({ itemId: '', category: 'fish', donatedAt: '' }); // empty itemId
+    obj.donations.push({ itemId: 'x', category: 'monsters', donatedAt: '' }); // bad category
+    obj.donations.push({
+      itemId: 'y',
+      category: 'fish',
+      donatedAt: 'totally not a date',
+    });
+    obj.donations.push('not-an-object');
+    const result = parseSaveFile(JSON.stringify(obj));
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.warnings.droppedMalformedRows).toBe(4);
+      expect(result.file.donations).toHaveLength(2);
+    }
+  });
+
+  it('accepts donation rows with empty donatedAt strings', () => {
+    const obj = JSON.parse(buildJson());
+    obj.donations.push({
+      itemId: 'koi',
+      category: 'fish',
+      donatedAt: '',
+    });
+    const result = parseSaveFile(JSON.stringify(obj));
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.file.donations).toHaveLength(3);
+      expect(result.warnings.droppedMalformedRows).toBe(0);
+    }
+  });
+});
+
+describe('parseSaveFile — strays', () => {
+  it('drops a stray hemisphere field on a non-ACNH save without failing', () => {
+    const obj = JSON.parse(buildJson());
+    obj.town.gameId = 'ACGCN';
+    obj.town.hemisphere = 'SH';
+    const result = parseSaveFile(JSON.stringify(obj));
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.file.town.hemisphere).toBeUndefined();
+    }
+  });
+});

--- a/src/lib/saveFileImport.ts
+++ b/src/lib/saveFileImport.ts
@@ -1,0 +1,240 @@
+/**
+ * JSON save-file import — parser and validator.
+ *
+ * Consumes the artifact produced by saveFile.ts (PR #106). Schema is documented
+ * in docs/v0.9.3-csv-import-plan.md §4. Hard-rejects on shape/version/app
+ * violations; tolerates malformed individual donation rows by dropping them
+ * with a count surfaced as a warning.
+ */
+
+import type { CategoryId, GameId } from './types';
+import { GAMES } from './types';
+import type { Hemisphere } from './store';
+import {
+  SAVE_FILE_APP,
+  SAVE_FILE_SCHEMA_VERSION,
+  type SaveDonationV1,
+  type SaveFileV1,
+  type SaveTownV1,
+} from './saveFile';
+
+const KNOWN_CATEGORIES: ReadonlySet<CategoryId> = new Set([
+  'fish',
+  'bugs',
+  'fossils',
+  'art',
+  'sea_creatures',
+]);
+
+export type ParseError =
+  | { kind: 'invalid_json'; message: string }
+  | { kind: 'unsupported_version'; received: unknown }
+  | { kind: 'wrong_app'; received: unknown }
+  | { kind: 'malformed_shape'; field: string; message: string }
+  | { kind: 'unknown_game'; received: unknown }
+  | { kind: 'missing_hemisphere' };
+
+export interface ParseWarnings {
+  /** Donation rows whose shape was malformed and silently dropped. */
+  droppedMalformedRows: number;
+}
+
+export type ParseResult =
+  | { ok: true; file: SaveFileV1; warnings: ParseWarnings }
+  | { ok: false; error: ParseError };
+
+function isRecord(v: unknown): v is Record<string, unknown> {
+  return typeof v === 'object' && v !== null && !Array.isArray(v);
+}
+
+function isValidIsoDate(s: unknown): s is string {
+  if (typeof s !== 'string' || s.length === 0) return false;
+  const t = Date.parse(s);
+  return Number.isFinite(t);
+}
+
+function isValidGameId(v: unknown): v is GameId {
+  return typeof v === 'string' && v in GAMES;
+}
+
+function parseDonation(row: unknown): SaveDonationV1 | null {
+  if (!isRecord(row)) return null;
+  const { itemId, category, donatedAt } = row;
+  if (typeof itemId !== 'string' || itemId.length === 0) return null;
+  if (
+    typeof category !== 'string' ||
+    !KNOWN_CATEGORIES.has(category as CategoryId)
+  ) {
+    return null;
+  }
+  if (typeof donatedAt !== 'string') return null;
+  // Empty donatedAt is permitted by the producer (sea_bass with no timestamp
+  // sinks to the end). Non-empty strings must parse as a Date.
+  if (donatedAt.length > 0 && !isValidIsoDate(donatedAt)) return null;
+  return {
+    itemId,
+    category: category as CategoryId,
+    donatedAt,
+  };
+}
+
+export function parseSaveFile(text: string): ParseResult {
+  let raw: unknown;
+  try {
+    raw = JSON.parse(text);
+  } catch (e) {
+    const message = e instanceof Error ? e.message : 'Could not parse JSON.';
+    return { ok: false, error: { kind: 'invalid_json', message } };
+  }
+
+  if (!isRecord(raw)) {
+    return {
+      ok: false,
+      error: {
+        kind: 'malformed_shape',
+        field: '<root>',
+        message: 'Expected a JSON object at the top level.',
+      },
+    };
+  }
+
+  // schemaVersion gate first — a future version's shape might otherwise fail
+  // confusingly downstream.
+  if (raw.schemaVersion !== SAVE_FILE_SCHEMA_VERSION) {
+    return {
+      ok: false,
+      error: { kind: 'unsupported_version', received: raw.schemaVersion },
+    };
+  }
+
+  if (raw.app !== SAVE_FILE_APP) {
+    return { ok: false, error: { kind: 'wrong_app', received: raw.app } };
+  }
+
+  if (typeof raw.appVersion !== 'string') {
+    return {
+      ok: false,
+      error: {
+        kind: 'malformed_shape',
+        field: 'appVersion',
+        message: 'Expected a string.',
+      },
+    };
+  }
+
+  if (!isValidIsoDate(raw.exportedAt)) {
+    return {
+      ok: false,
+      error: {
+        kind: 'malformed_shape',
+        field: 'exportedAt',
+        message: 'Expected an ISO date string.',
+      },
+    };
+  }
+
+  if (!isRecord(raw.town)) {
+    return {
+      ok: false,
+      error: {
+        kind: 'malformed_shape',
+        field: 'town',
+        message: 'Expected an object.',
+      },
+    };
+  }
+
+  const town = raw.town;
+  if (typeof town.name !== 'string' || town.name.length === 0) {
+    return {
+      ok: false,
+      error: {
+        kind: 'malformed_shape',
+        field: 'town.name',
+        message: 'Expected a non-empty string.',
+      },
+    };
+  }
+  if (!isValidGameId(town.gameId)) {
+    return {
+      ok: false,
+      error: { kind: 'unknown_game', received: town.gameId },
+    };
+  }
+  if (!isValidIsoDate(town.createdAt)) {
+    return {
+      ok: false,
+      error: {
+        kind: 'malformed_shape',
+        field: 'town.createdAt',
+        message: 'Expected an ISO date string.',
+      },
+    };
+  }
+
+  let hemisphere: Hemisphere | undefined;
+  if (town.gameId === 'ACNH') {
+    if (town.hemisphere !== 'NH' && town.hemisphere !== 'SH') {
+      return { ok: false, error: { kind: 'missing_hemisphere' } };
+    }
+    hemisphere = town.hemisphere;
+  } else if (town.hemisphere !== undefined) {
+    // Tolerate stray hemisphere on non-ACNH files — drop it silently.
+    hemisphere = undefined;
+  }
+
+  const saveTown: SaveTownV1 = {
+    name: town.name,
+    gameId: town.gameId,
+    createdAt: town.createdAt,
+  };
+  if (hemisphere) saveTown.hemisphere = hemisphere;
+
+  if (!Array.isArray(raw.donations)) {
+    return {
+      ok: false,
+      error: {
+        kind: 'malformed_shape',
+        field: 'donations',
+        message: 'Expected an array.',
+      },
+    };
+  }
+
+  const donations: SaveDonationV1[] = [];
+  let droppedMalformedRows = 0;
+  for (const row of raw.donations) {
+    const parsed = parseDonation(row);
+    if (parsed) donations.push(parsed);
+    else droppedMalformedRows += 1;
+  }
+
+  const file: SaveFileV1 = {
+    schemaVersion: SAVE_FILE_SCHEMA_VERSION,
+    app: SAVE_FILE_APP,
+    appVersion: raw.appVersion,
+    exportedAt: raw.exportedAt,
+    town: saveTown,
+    donations,
+  };
+
+  return { ok: true, file, warnings: { droppedMalformedRows } };
+}
+
+/** Human-readable error string for the modal UI. */
+export function formatParseError(error: ParseError): string {
+  switch (error.kind) {
+    case 'invalid_json':
+      return `That file isn't valid JSON. (${error.message})`;
+    case 'unsupported_version':
+      return `Unsupported save-file version: ${String(error.received)}. This file may have been exported by a newer version of the app.`;
+    case 'wrong_app':
+      return `This file isn't an Animal Crossing Museum Tracker save (app field was "${String(error.received)}").`;
+    case 'unknown_game':
+      return `Unknown game: "${String(error.received)}".`;
+    case 'missing_hemisphere':
+      return 'ACNH save files require a hemisphere ("NH" or "SH"), but none was found.';
+    case 'malformed_shape':
+      return `Malformed save file at "${error.field}": ${error.message}`;
+  }
+}

--- a/src/lib/saveFileReconcile.test.ts
+++ b/src/lib/saveFileReconcile.test.ts
@@ -1,0 +1,216 @@
+import { describe, it, expect } from 'vitest';
+import { buildImportPlan, findCandidateMatch } from './saveFileReconcile';
+import { buildSaveFile, serializeSaveFile } from './saveFile';
+import { parseSaveFile } from './saveFileImport';
+import type { Town } from './store';
+import type { AllData } from './viewTypes';
+
+function sampleData(): AllData {
+  return {
+    fish: [
+      { id: 'sea-bass', name: 'Sea Bass' } as AllData['fish'][number],
+      { id: 'koi', name: 'Koi' } as AllData['fish'][number],
+    ],
+    bugs: [{ id: 'tarantula', name: 'Tarantula' } as AllData['bugs'][number]],
+    fossils: [],
+    art: [],
+    sea_creatures: [],
+  };
+}
+
+function knownIds(): Set<string> {
+  return new Set(['sea-bass', 'koi', 'tarantula']);
+}
+
+function buildAndParse(town: Town, donatedAt: Record<string, string>) {
+  const donatedMap: Record<string, boolean> = {};
+  for (const k of Object.keys(donatedAt)) donatedMap[k] = true;
+  const json = serializeSaveFile(
+    buildSaveFile({
+      data: sampleData(),
+      donatedMap,
+      donatedAtMap: donatedAt,
+      town: {
+        name: town.name,
+        gameId: town.gameId,
+        hemisphere: town.hemisphere,
+        createdAt: town.createdAt,
+      },
+      appVersion: '0.9.3-beta',
+      now: new Date('2026-05-06T18:42:11.000Z'),
+    })
+  );
+  const parsed = parseSaveFile(json);
+  if (!parsed.ok) throw new Error(`parse failed: ${parsed.error.kind}`);
+  return parsed.file;
+}
+
+const townA: Town = {
+  id: 'town-A',
+  name: 'Pelican Town',
+  gameId: 'ACNH',
+  hemisphere: 'NH',
+  createdAt: '2026-04-01T12:00:00.000Z',
+};
+
+describe('findCandidateMatch', () => {
+  it('matches on (name, gameId)', () => {
+    const file = buildAndParse(townA, {});
+    expect(findCandidateMatch([townA], file)).toBe(townA);
+  });
+
+  it('does not match if name differs', () => {
+    const file = buildAndParse({ ...townA, name: 'Aroma Park' }, {});
+    expect(findCandidateMatch([townA], file)).toBeNull();
+  });
+
+  it('does not match if gameId differs', () => {
+    const file = buildAndParse({ ...townA, gameId: 'ACGCN' }, {});
+    expect(findCandidateMatch([townA], file)).toBeNull();
+  });
+});
+
+describe('buildImportPlan — create', () => {
+  it('produces a create plan when there is no matched town', () => {
+    const file = buildAndParse(townA, {
+      'sea-bass': '2026-04-15T00:00:00.000Z',
+      tarantula: '2026-04-16T00:00:00.000Z',
+    });
+    const plan = buildImportPlan({
+      file,
+      mode: 'create',
+      existing: null,
+      existingDonatedAt: {},
+      knownItemIds: knownIds(),
+    });
+    expect(plan.kind).toBe('create');
+    if (plan.kind === 'create') {
+      expect(plan.newTown.name).toBe('Pelican Town');
+      expect(plan.newTown.gameId).toBe('ACNH');
+      expect(plan.newTown.hemisphere).toBe('NH');
+      expect(plan.donations).toHaveLength(2);
+      expect(plan.droppedUnknownIds).toBe(0);
+    }
+  });
+
+  it('drops donations whose itemId is not in knownItemIds', () => {
+    const file = buildAndParse(townA, {
+      'sea-bass': '2026-04-15T00:00:00.000Z',
+      tarantula: '2026-04-16T00:00:00.000Z',
+    });
+    const plan = buildImportPlan({
+      file,
+      mode: 'create',
+      existing: null,
+      existingDonatedAt: {},
+      knownItemIds: new Set(['sea-bass']),
+    });
+    if (plan.kind !== 'create') throw new Error('wrong kind');
+    expect(plan.donations).toHaveLength(1);
+    expect(plan.droppedUnknownIds).toBe(1);
+  });
+});
+
+describe('buildImportPlan — replace', () => {
+  it('replaces the existing town and reports previousCount', () => {
+    const file = buildAndParse(townA, {
+      'sea-bass': '2026-04-15T00:00:00.000Z',
+    });
+    const plan = buildImportPlan({
+      file,
+      mode: 'replace',
+      existing: townA,
+      existingDonatedAt: {
+        koi: '2026-03-01T00:00:00.000Z',
+        tarantula: '2026-03-02T00:00:00.000Z',
+      },
+      knownItemIds: knownIds(),
+    });
+    if (plan.kind !== 'replace') throw new Error('wrong kind');
+    expect(plan.townId).toBe(townA.id);
+    expect(plan.previousCount).toBe(2);
+    expect(plan.donations).toHaveLength(1);
+    expect(plan.donations[0].itemId).toBe('sea-bass');
+    expect(plan.townPatch.name).toBe('Pelican Town');
+    expect(plan.townPatch.hemisphere).toBe('NH');
+  });
+});
+
+describe('buildImportPlan — merge', () => {
+  it('unions rows and reports newRows + conflicts', () => {
+    const file = buildAndParse(townA, {
+      'sea-bass': '2026-04-15T00:00:00.000Z', // conflict
+      tarantula: '2026-04-16T00:00:00.000Z', // new
+    });
+    const plan = buildImportPlan({
+      file,
+      mode: 'merge',
+      existing: townA,
+      existingDonatedAt: {
+        'sea-bass': '2026-05-01T00:00:00.000Z',
+        koi: '2026-04-10T00:00:00.000Z',
+      },
+      knownItemIds: knownIds(),
+    });
+    if (plan.kind !== 'merge') throw new Error('wrong kind');
+    expect(plan.newRows).toBe(1);
+    expect(plan.conflicts).toBe(1);
+    // merged set: sea-bass + koi + tarantula
+    expect(plan.donations).toHaveLength(3);
+  });
+
+  it('keeps the earlier donatedAt on conflict', () => {
+    const file = buildAndParse(townA, {
+      'sea-bass': '2026-03-15T00:00:00.000Z', // earlier than existing
+    });
+    const plan = buildImportPlan({
+      file,
+      mode: 'merge',
+      existing: townA,
+      existingDonatedAt: {
+        'sea-bass': '2026-05-01T00:00:00.000Z',
+      },
+      knownItemIds: knownIds(),
+    });
+    if (plan.kind !== 'merge') throw new Error('wrong kind');
+    const seaBass = plan.donations.find(d => d.itemId === 'sea-bass');
+    expect(seaBass?.donatedAt).toBe('2026-03-15T00:00:00.000Z');
+  });
+
+  it('keeps the earlier existing donatedAt when import is later', () => {
+    const file = buildAndParse(townA, {
+      'sea-bass': '2026-06-01T00:00:00.000Z',
+    });
+    const plan = buildImportPlan({
+      file,
+      mode: 'merge',
+      existing: townA,
+      existingDonatedAt: {
+        'sea-bass': '2026-04-01T00:00:00.000Z',
+      },
+      knownItemIds: knownIds(),
+    });
+    if (plan.kind !== 'merge') throw new Error('wrong kind');
+    const seaBass = plan.donations.find(d => d.itemId === 'sea-bass');
+    expect(seaBass?.donatedAt).toBe('2026-04-01T00:00:00.000Z');
+  });
+});
+
+describe('round-trip', () => {
+  it('parse → reconcile (create) preserves donation set', () => {
+    const file = buildAndParse(townA, {
+      'sea-bass': '2026-04-15T00:00:00.000Z',
+      tarantula: '2026-04-16T00:00:00.000Z',
+    });
+    const plan = buildImportPlan({
+      file,
+      mode: 'create',
+      existing: null,
+      existingDonatedAt: {},
+      knownItemIds: knownIds(),
+    });
+    if (plan.kind !== 'create') throw new Error('wrong kind');
+    const ids = plan.donations.map(d => d.itemId).sort();
+    expect(ids).toEqual(['sea-bass', 'tarantula']);
+  });
+});

--- a/src/lib/saveFileReconcile.ts
+++ b/src/lib/saveFileReconcile.ts
@@ -1,0 +1,183 @@
+/**
+ * Reconcile a parsed SaveFileV1 against the current store, producing an
+ * ImportPlan that the store can apply atomically. Pure — no React, no
+ * persistence side-effects.
+ */
+
+import type { Town, TownPatch, Hemisphere } from './store';
+import type { GameId } from './types';
+import type { SaveFileV1, SaveDonationV1 } from './saveFile';
+
+export type ReconcileMode = 'replace' | 'merge' | 'create';
+
+export interface DonationRow {
+  itemId: string;
+  donatedAt: string;
+}
+
+export interface ImportPlanCreate {
+  kind: 'create';
+  newTown: {
+    name: string;
+    gameId: GameId;
+    hemisphere: Hemisphere;
+    createdAt: string;
+  };
+  donations: DonationRow[];
+  /** Donations dropped because their itemId is not in the loaded data files. */
+  droppedUnknownIds: number;
+}
+
+export interface ImportPlanReplace {
+  kind: 'replace';
+  townId: string;
+  /** Patch to the existing town record (name + hemisphere from the file). */
+  townPatch: TownPatch;
+  gameId: GameId;
+  donations: DonationRow[];
+  /** Number of existing donations that will be wiped (for warning copy). */
+  previousCount: number;
+  droppedUnknownIds: number;
+}
+
+export interface ImportPlanMerge {
+  kind: 'merge';
+  townId: string;
+  gameId: GameId;
+  /** Final donations (existing ∪ imported, earlier donatedAt wins on conflict). */
+  donations: DonationRow[];
+  /** New rows that were not previously donated. */
+  newRows: number;
+  /** Rows that were donated in both — earlier timestamp kept. */
+  conflicts: number;
+  droppedUnknownIds: number;
+}
+
+export type ImportPlan = ImportPlanCreate | ImportPlanReplace | ImportPlanMerge;
+
+/** Match by (name, gameId). Returns the first matching town, or null. */
+export function findCandidateMatch(
+  towns: Town[],
+  file: SaveFileV1
+): Town | null {
+  return (
+    towns.find(
+      t => t.name === file.town.name && t.gameId === file.town.gameId
+    ) ?? null
+  );
+}
+
+function filterKnown(
+  donations: SaveDonationV1[],
+  knownItemIds: ReadonlySet<string>
+): { rows: DonationRow[]; dropped: number } {
+  const rows: DonationRow[] = [];
+  let dropped = 0;
+  for (const d of donations) {
+    if (!knownItemIds.has(d.itemId)) {
+      dropped += 1;
+      continue;
+    }
+    rows.push({ itemId: d.itemId, donatedAt: d.donatedAt });
+  }
+  return { rows, dropped };
+}
+
+function compareIso(a: string, b: string): number {
+  // Empty strings sort last; otherwise lexicographic on ISO is chronological.
+  if (!a && !b) return 0;
+  if (!a) return 1;
+  if (!b) return -1;
+  return a.localeCompare(b);
+}
+
+interface BuildPlanArgs {
+  file: SaveFileV1;
+  mode: ReconcileMode;
+  /** Existing matched town. Required for replace/merge; ignored for create. */
+  existing: Town | null;
+  /** Existing donatedAt map for the matched town's gameId (id → ISO string). */
+  existingDonatedAt: Record<string, string>;
+  /** All known itemIds for the file's gameId, loaded from data files. */
+  knownItemIds: ReadonlySet<string>;
+}
+
+export function buildImportPlan(args: BuildPlanArgs): ImportPlan {
+  const { file, mode, existing, existingDonatedAt, knownItemIds } = args;
+  const { rows: importedRows, dropped } = filterKnown(
+    file.donations,
+    knownItemIds
+  );
+
+  if (mode === 'create' || existing === null) {
+    const hemisphere: Hemisphere =
+      file.town.gameId === 'ACNH' ? (file.town.hemisphere ?? 'NH') : 'NH';
+    return {
+      kind: 'create',
+      newTown: {
+        name: file.town.name,
+        gameId: file.town.gameId,
+        hemisphere,
+        createdAt: file.town.createdAt,
+      },
+      donations: importedRows,
+      droppedUnknownIds: dropped,
+    };
+  }
+
+  // Replace + merge both target the matched existing town.
+  const townPatch: TownPatch = { name: file.town.name };
+  if (file.town.gameId === 'ACNH' && file.town.hemisphere) {
+    townPatch.hemisphere = file.town.hemisphere;
+  }
+
+  if (mode === 'replace') {
+    return {
+      kind: 'replace',
+      townId: existing.id,
+      townPatch,
+      gameId: existing.gameId,
+      donations: importedRows,
+      previousCount: Object.keys(existingDonatedAt).length,
+      droppedUnknownIds: dropped,
+    };
+  }
+
+  // merge — union; earlier donatedAt wins on conflict.
+  const merged = new Map<string, string>();
+  for (const [itemId, donatedAt] of Object.entries(existingDonatedAt)) {
+    merged.set(itemId, donatedAt ?? '');
+  }
+  let conflicts = 0;
+  let newRows = 0;
+  for (const row of importedRows) {
+    const prior = merged.get(row.itemId);
+    if (prior === undefined) {
+      merged.set(row.itemId, row.donatedAt);
+      newRows += 1;
+    } else {
+      conflicts += 1;
+      if (compareIso(row.donatedAt, prior) < 0) {
+        merged.set(row.itemId, row.donatedAt);
+      }
+    }
+  }
+
+  const donations: DonationRow[] = Array.from(
+    merged,
+    ([itemId, donatedAt]) => ({
+      itemId,
+      donatedAt,
+    })
+  );
+
+  return {
+    kind: 'merge',
+    townId: existing.id,
+    gameId: existing.gameId,
+    donations,
+    newRows,
+    conflicts,
+    droppedUnknownIds: dropped,
+  };
+}

--- a/src/lib/store.ts
+++ b/src/lib/store.ts
@@ -2,6 +2,7 @@ import { create } from 'zustand';
 import { persist } from 'zustand/middleware';
 import type { GameId } from './types';
 import { migrateStore } from './storeMigrations';
+import type { ImportPlan } from './saveFileReconcile';
 
 export type Hemisphere = 'NH' | 'SH';
 
@@ -37,6 +38,8 @@ interface AppState {
   getActiveTown: () => Town | undefined;
   resetActiveTownDonations: () => void;
   resetAll: () => void;
+  /** Apply a parsed save-file ImportPlan atomically. Returns the affected townId. */
+  applyImportedSave: (plan: ImportPlan) => string;
 }
 
 function generateId(): string {
@@ -165,6 +168,104 @@ export const useAppStore = create<AppState>()(
           delete donatedAt[activeTownId];
           return { donated, donatedAt };
         }),
+
+      applyImportedSave: plan => {
+        let resultTownId = '';
+        set(state => {
+          if (plan.kind === 'create') {
+            const id = generateId();
+            const newTown: Town = {
+              id,
+              name: plan.newTown.name,
+              gameId: plan.newTown.gameId,
+              hemisphere: plan.newTown.hemisphere,
+              createdAt: plan.newTown.createdAt,
+            };
+            const itemMap: Record<string, boolean> = {};
+            const atMap: Record<string, string> = {};
+            for (const r of plan.donations) {
+              itemMap[r.itemId] = true;
+              if (r.donatedAt) atMap[r.itemId] = r.donatedAt;
+            }
+            resultTownId = id;
+            return {
+              towns: [...state.towns, newTown],
+              activeTownId: id,
+              donated: {
+                ...state.donated,
+                [id]: { [newTown.gameId]: itemMap },
+              },
+              donatedAt: {
+                ...state.donatedAt,
+                [id]: { [newTown.gameId]: atMap },
+              },
+            };
+          }
+
+          if (plan.kind === 'replace') {
+            const towns = state.towns.map(t => {
+              if (t.id !== plan.townId) return t;
+              const next: Town = { ...t };
+              if (plan.townPatch.name !== undefined)
+                next.name = plan.townPatch.name;
+              if (
+                plan.townPatch.hemisphere !== undefined &&
+                plan.townPatch.hemisphere !== null
+              ) {
+                next.hemisphere = plan.townPatch.hemisphere;
+              }
+              return next;
+            });
+            const itemMap: Record<string, boolean> = {};
+            const atMap: Record<string, string> = {};
+            for (const r of plan.donations) {
+              itemMap[r.itemId] = true;
+              if (r.donatedAt) atMap[r.itemId] = r.donatedAt;
+            }
+            const donated = {
+              ...state.donated,
+              [plan.townId]: {
+                ...(state.donated[plan.townId] ?? {}),
+                [plan.gameId]: itemMap,
+              },
+            };
+            const donatedAt = {
+              ...state.donatedAt,
+              [plan.townId]: {
+                ...(state.donatedAt[plan.townId] ?? {}),
+                [plan.gameId]: atMap,
+              },
+            };
+            resultTownId = plan.townId;
+            return { towns, donated, donatedAt, activeTownId: plan.townId };
+          }
+
+          // merge
+          const itemMap: Record<string, boolean> = {};
+          const atMap: Record<string, string> = {};
+          for (const r of plan.donations) {
+            itemMap[r.itemId] = true;
+            if (r.donatedAt) atMap[r.itemId] = r.donatedAt;
+          }
+          const donated = {
+            ...state.donated,
+            [plan.townId]: {
+              ...(state.donated[plan.townId] ?? {}),
+              [plan.gameId]: itemMap,
+            },
+          };
+          const donatedAt = {
+            ...state.donatedAt,
+            [plan.townId]: {
+              ...(state.donatedAt[plan.townId] ?? {}),
+              [plan.gameId]: atMap,
+            },
+          };
+          resultTownId = plan.townId;
+          return { donated, donatedAt, activeTownId: plan.townId };
+        });
+        return resultTownId;
+      },
 
       resetAll: () => {
         try {

--- a/src/lib/uiStore.ts
+++ b/src/lib/uiStore.ts
@@ -6,6 +6,9 @@ interface UIState {
   townManagerForceCreate: boolean;
   openTownManager: (forceCreate?: boolean) => void;
   closeTownManager: () => void;
+  importSaveOpen: boolean;
+  openImportSave: () => void;
+  closeImportSave: () => void;
 }
 
 export const useUIStore = create<UIState>(set => ({
@@ -15,4 +18,7 @@ export const useUIStore = create<UIState>(set => ({
     set({ townManagerOpen: true, townManagerForceCreate: forceCreate }),
   closeTownManager: () =>
     set({ townManagerOpen: false, townManagerForceCreate: false }),
+  importSaveOpen: false,
+  openImportSave: () => set({ importSaveOpen: true }),
+  closeImportSave: () => set({ importSaveOpen: false }),
 }));


### PR DESCRIPTION
## Summary
Round-trip companion to PR #106 — imports the JSON save file PR 1 produces. Parser, reconciler, modal UI, and two entry points (sidebar footer + empty-state TownManager).

- \`src/lib/saveFileImport.ts\` — JSON parser + structured validator. Hard-rejects non-\`schemaVersion=1\`, wrong-\`app\`, missing/malformed required fields, unknown \`gameId\`, ACNH-without-hemisphere. Tolerates malformed donation rows by dropping them with a count.
- \`src/lib/saveFileReconcile.ts\` — pure reconciliation. \`findCandidateMatch\` matches on \`(name, gameId)\`. \`buildImportPlan\` returns one of three plans: \`create\` / \`replace\` / \`merge\`. Unknown itemIds (relative to currently-loaded data files) dropped + counted.
- \`src/lib/store.ts\` — atomic \`applyImportedSave(plan)\` action; touches towns/donated/donatedAt/activeTownId in a single \`set\`.
- \`src/components/ImportSaveModal.tsx\` — modal with file picker → preview → mode selector → (heavy two-step confirm for destructive Replace) → apply. Mounts at App layout level alongside \`<TownManager />\`.
- Entry points: \`Import save\` button in \`Sidebar.tsx\` footer; \`Import save instead\` button in \`TownManager.tsx\` empty state. App-level effect that auto-opens TownManager when \`towns.length === 0\` is gated on \`!importSaveOpen\` so the two modals don't stack.

## Decisions
- Followed scoping doc §6 on Merge tiebreak — **earlier \`donatedAt\` wins on conflict** (preserves the user's actual first-donation timestamp). Locked answer in the plan; matches the round-trip behaviour we want.
- Replace destructive UX (locked Q5): two-step gate ONLY when the matched town has at-risk data. Replace into an empty town shows a single light confirm. No undo / no sessionStorage snapshot.
- Single-town import only (locked Q3); multi-town deferred.
- Import modal mounted at App layout (matches TownManager pattern), so the same modal works from \`/\`, \`/town/:id/...\`, \`/settings\`, and \`/credits\`.
- Drop unknown \`itemId\`s silently and surface count (per scoping doc §6); whole import never fails on these.
- Modal fetches data files for the imported \`gameId\` via \`useMuseumData\` directly — necessary because the imported file's gameId may differ from the active town's gameId.

## Test plan
- 24 new unit tests across \`saveFileImport.test.ts\` (14) and \`saveFileReconcile.test.ts\` (10), plus PR #106's existing 18 stay green.
- Round-trip: \`buildSaveFile\` → JSON → \`parseSaveFile\` → \`buildImportPlan\` (create) preserves donation set.
- Parser rejects: invalid JSON, schemaVersion ≠ 1, wrong app, missing town, unknown gameId, ACNH without hemisphere, malformed exportedAt, donations not an array.
- Parser tolerates: empty itemId, unknown category, unparseable donatedAt, non-object rows — drops + counts.
- Reconcile: replace reports \`previousCount\` and patches town name/hemisphere; merge unions rows, reports \`newRows\`/\`conflicts\`, keeps earlier date; create generates a fresh town record; unknown itemIds dropped + counted.
- \`npm run lint\`, \`npm run build\`, \`npm test\` all clean (121 tests passing).

Refs: PR #106 (the export half), \`docs/v0.9.3-csv-import-plan.md\` (locked scoping).