### PR TITLE
fix(import): show import-save affordance during forced-create onboarding flow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ All notable changes to this project are documented here.
 - The sidebar's single "Export CSV" control is now two distinct buttons — `Export save` (the new JSON save file) and `Download report` (the existing human-readable CSV, unchanged). The CSV remains for users pasting into spreadsheets; the JSON file is the new round-trip artifact
 - The empty-state TownManager (no towns yet) gained an "Import save instead" affordance, so a fresh-device user can restore from a save file without first creating a placeholder town
 
+### Fixed
+- Import-save affordance now visible during first-load onboarding. Previously, `App.tsx` calling `openTownManager(forceCreate=true)` immediately set `creating=true`, collapsing `showEmptyState` to `false` before first paint and hiding the import button entirely. An "or import an existing save" secondary link is now rendered below the `NewTownForm` whenever `creating && towns.length === 0`
+
 ## [v0.9.2-beta] — 2026-05-05
 
 ### Added

--- a/src/components/TownManager.test.tsx
+++ b/src/components/TownManager.test.tsx
@@ -1,0 +1,125 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { TownManager } from './TownManager';
+import { useUIStore } from '../lib/uiStore';
+import { useAppStore } from '../lib/store';
+
+vi.mock('../lib/store', () => ({
+  useAppStore: vi.fn(),
+}));
+
+vi.mock('../lib/uiStore', () => ({
+  useUIStore: vi.fn(),
+}));
+
+function makeUIStore(overrides = {}) {
+  return {
+    townManagerOpen: true,
+    townManagerForceCreate: true,
+    closeTownManager: vi.fn(),
+    openImportSave: vi.fn(),
+    importSaveOpen: false,
+    closeImportSave: vi.fn(),
+    ...overrides,
+  };
+}
+
+function makeAppStore(towns: unknown[] = []) {
+  return {
+    towns,
+    activeTownId: null,
+    donated: {},
+    setActiveTown: vi.fn(),
+    updateTown: vi.fn(),
+    createTown: vi.fn(),
+    deleteTown: vi.fn(),
+  };
+}
+
+function renderTownManager() {
+  return render(
+    <MemoryRouter>
+      <TownManager />
+    </MemoryRouter>
+  );
+}
+
+describe('TownManager — onboarding import link', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('renders import link when forceCreate=true and towns=[]', () => {
+    (useUIStore as unknown as ReturnType<typeof vi.fn>).mockImplementation(
+      (sel: (s: ReturnType<typeof makeUIStore>) => unknown) =>
+        sel(makeUIStore())
+    );
+    (useAppStore as unknown as ReturnType<typeof vi.fn>).mockImplementation(
+      (sel: (s: ReturnType<typeof makeAppStore>) => unknown) =>
+        sel(makeAppStore([]))
+    );
+
+    renderTownManager();
+    expect(
+      screen.getByRole('button', { name: /or import an existing save/i })
+    ).toBeTruthy();
+  });
+
+  it('does NOT render import link when towns already exist', () => {
+    const existingTown = {
+      id: 't1',
+      name: 'Marigold',
+      gameId: 'ACNH',
+      hemisphere: 'NH',
+      createdAt: new Date().toISOString(),
+    };
+    (useUIStore as unknown as ReturnType<typeof vi.fn>).mockImplementation(
+      (sel: (s: ReturnType<typeof makeUIStore>) => unknown) =>
+        sel(makeUIStore())
+    );
+    (useAppStore as unknown as ReturnType<typeof vi.fn>).mockImplementation(
+      (sel: (s: ReturnType<typeof makeAppStore>) => unknown) =>
+        sel(makeAppStore([existingTown]))
+    );
+
+    renderTownManager();
+    expect(
+      screen.queryByRole('button', { name: /or import an existing save/i })
+    ).toBeNull();
+  });
+
+  it('clicking import link calls close() and openImportSave()', () => {
+    const uiState = makeUIStore();
+    (useUIStore as unknown as ReturnType<typeof vi.fn>).mockImplementation(
+      (sel: (s: ReturnType<typeof makeUIStore>) => unknown) => sel(uiState)
+    );
+    (useAppStore as unknown as ReturnType<typeof vi.fn>).mockImplementation(
+      (sel: (s: ReturnType<typeof makeAppStore>) => unknown) =>
+        sel(makeAppStore([]))
+    );
+
+    renderTownManager();
+    fireEvent.click(
+      screen.getByRole('button', { name: /or import an existing save/i })
+    );
+    expect(uiState.closeTownManager).toHaveBeenCalled();
+    expect(uiState.openImportSave).toHaveBeenCalled();
+  });
+
+  it('empty-state import button still renders when forceCreate=false and towns=[]', () => {
+    (useUIStore as unknown as ReturnType<typeof vi.fn>).mockImplementation(
+      (sel: (s: ReturnType<typeof makeUIStore>) => unknown) =>
+        sel(makeUIStore({ townManagerForceCreate: false }))
+    );
+    (useAppStore as unknown as ReturnType<typeof vi.fn>).mockImplementation(
+      (sel: (s: ReturnType<typeof makeAppStore>) => unknown) =>
+        sel(makeAppStore([]))
+    );
+
+    renderTownManager();
+    expect(
+      screen.queryByRole('button', { name: /import save instead/i })
+    ).not.toBeNull();
+  });
+});

--- a/src/components/TownManager.test.tsx
+++ b/src/components/TownManager.test.tsx
@@ -76,7 +76,7 @@ describe('TownManager — onboarding import link', () => {
     };
     (useUIStore as unknown as ReturnType<typeof vi.fn>).mockImplementation(
       (sel: (s: ReturnType<typeof makeUIStore>) => unknown) =>
-        sel(makeUIStore())
+        sel(makeUIStore({ townManagerForceCreate: false }))
     );
     (useAppStore as unknown as ReturnType<typeof vi.fn>).mockImplementation(
       (sel: (s: ReturnType<typeof makeAppStore>) => unknown) =>

--- a/src/components/TownManager.tsx
+++ b/src/components/TownManager.tsx
@@ -24,6 +24,11 @@ export function TownManager() {
   const [editingId, setEditingId] = useState<string | null>(null);
   const [creating, setCreating] = useState(false);
 
+  const handleOpenImportSave = () => {
+    close();
+    openImportSave();
+  };
+
   // Reset transient state when drawer toggles
   useEffect(() => {
     if (!open) {
@@ -132,10 +137,7 @@ export function TownManager() {
             <button
               type="button"
               className="ac-tm-empty-import"
-              onClick={() => {
-                close();
-                openImportSave();
-              }}
+              onClick={handleOpenImportSave}
             >
               Import save instead
             </button>
@@ -174,10 +176,7 @@ export function TownManager() {
                 <button
                   type="button"
                   className="ac-tm-import-link"
-                  onClick={() => {
-                    close();
-                    openImportSave();
-                  }}
+                  onClick={handleOpenImportSave}
                 >
                   or import an existing save
                 </button>

--- a/src/components/TownManager.tsx
+++ b/src/components/TownManager.tsx
@@ -162,13 +162,27 @@ export function TownManager() {
 
         <footer className="ac-tm-foot">
           {creating ? (
-            <NewTownForm
-              onCancel={() => {
-                if (!forceCreate) setCreating(false);
-              }}
-              onCreate={handleCreate}
-              cancellable={!forceCreate}
-            />
+            <>
+              <NewTownForm
+                onCancel={() => {
+                  if (!forceCreate) setCreating(false);
+                }}
+                onCreate={handleCreate}
+                cancellable={!forceCreate}
+              />
+              {towns.length === 0 && (
+                <button
+                  type="button"
+                  className="ac-tm-import-link"
+                  onClick={() => {
+                    close();
+                    openImportSave();
+                  }}
+                >
+                  or import an existing save
+                </button>
+              )}
+            </>
           ) : (
             <button className="ac-tm-cta" onClick={() => setCreating(true)}>
               <span className="ac-tm-cta-plus">+</span>

--- a/src/index.css
+++ b/src/index.css
@@ -1733,6 +1733,19 @@ body {
   cursor: pointer;
 }
 .ac-tm-empty-import:hover { background: var(--surface-alt); color: var(--ink); }
+.ac-tm-import-link {
+  display: block;
+  width: 100%;
+  margin-top: 10px;
+  background: transparent;
+  border: none;
+  color: var(--ink-muted);
+  font-size: 13px;
+  text-align: center;
+  cursor: pointer;
+  padding: 4px 0;
+}
+.ac-tm-import-link:hover { color: var(--ink-soft); text-decoration: underline; }
 
 @media (max-width: 720px) {
   .ac-im-scrim { align-items: flex-end; padding: 0; }


### PR DESCRIPTION
## Summary

- `App.tsx` calls `openTownManager(forceCreate=true)` on first load, which immediately sets `creating=true` via the `useEffect` at TownManager.tsx ~line 31–34
- This collapsed `showEmptyState` to `false` before first paint, so the empty-state import button never rendered — violating locked Q2 in `docs/v0.9.3-csv-import-plan.md` ("Import button visible during onboarding 100%")
- Adds a secondary `"or import an existing save"` link **below the `NewTownForm`**, visible when `creating && towns.length === 0`
- Reuses the same `close() + openImportSave()` handler as the existing empty-state button; that button is unchanged
- Adds `.ac-tm-import-link` CSS: muted, full-width, hover underline — secondary treatment appropriate for an alternative-path affordance

## Decisions

- Placement is below the form (not beside the submit button) — natural reading order: fill form → submit, *or* import
- The empty-state button (`.ac-tm-empty-import`) is intentionally untouched; it handles the separate flow where the user manually opens TownManager with no towns
- No new state introduced — the condition is derivable from existing `creating` + `towns.length`

## Test plan

- New `src/components/TownManager.test.tsx` with 4 cases:
  1. Link renders when `forceCreate=true` and `towns=[]`
  2. Link does NOT render when `towns` already has entries
  3. Clicking link calls `close()` and `openImportSave()`
  4. Existing empty-state import button still renders when `forceCreate=false` and `towns=[]`
- `npm run build` ✓
- `npm test` — 1819 passed ✓

Refs PR #108. Closes locked Q2 in `docs/v0.9.3-csv-import-plan.md`.