### PR TITLE
docs(claude.md): mark prior betas shipped + add v0.9.4 next milestone

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -276,8 +276,7 @@ Do not add new top-level tabs without updating the tab switch in ACCanvas, the n
   - Art tab persistent label fix — `setSelected(null)` on tab change (PR #57, Closes #26)
   - Branch-label footer suffix for non-main/development/release builds
 
-### v0.9.0-beta — UI revamp (in progress on `development`)
-Phases shipped to `development`:
+### v0.9.0-beta — UI revamp — **shipped 2026-05-03**
 - Phase 1 — Meadow tokens + Fraunces/Inter; Varela Round retired (PR #63)
 - Phase 2 — Sidebar shell; MuseumHeader/TabBar/TownSwitcher retired (PR #65)
 - Phase 3 — Settings page (About + Danger zone) (PR #66)
@@ -287,15 +286,13 @@ Phases shipped to `development`:
 - Phase 7 — CategoryTab sectioning (Leaving / Available / Out of season / Already donated) (PR #73)
 - Phase 8 — GlobalSearchDropdown; GlobalSearchBar/Results/HistoryPopover/`useSearch` retired; a11y polish tracked in Issue #76 (PR #75)
 - Phase 9 — StatsTab rebuild; AnalyticsView + SectionCard retired (PR #77)
-
-Pending:
 - Phase 10 — Mobile responsive verification pass
 - ACWW + ACCF art data (PR #78, closes Issue #74)
 
-### v0.9.1-beta — Item icons (in progress)
-- PR (a) — Fandom scraper, `OVERRIDES` map, full ACGCN icon set committed under `public/icons/acgcn/` with per-game `manifest.json` (PR #86, shipped)
-- PR (b) — `<ItemIcon>` component + UI wiring in CollectibleRow / ItemExpandPanel / GlobalSearchDropdown / HomeTab; `scripts/generate-icon-manifest.ts` standalone re-emitter; `GAMES_WITH_ICONS` gate scoped to ACGCN until other games' icon scrapes ship (this PR)
-- PR (c) — `NOTICE` at the repo root + in-app `/credits` route + release prep (pending)
+### v0.9.1-beta — Item icons — **shipped 2026-05-04**
+- PR (a) — Fandom scraper, `OVERRIDES` map, full ACGCN icon set committed under `public/icons/acgcn/` with per-game `manifest.json` (PR #86)
+- PR (b) — `<ItemIcon>` component + UI wiring in CollectibleRow / ItemExpandPanel / GlobalSearchDropdown / HomeTab; `scripts/generate-icon-manifest.ts` standalone re-emitter; `GAMES_WITH_ICONS` gate scoped to ACGCN until other games' icon scrapes ship
+- PR (c) — `NOTICE` at the repo root + in-app `/credits` route + release prep
 
 ### v0.9.2-beta — Hand-drawn icons — **shipped 2026-05-05**
 - PR #94 — flat icon hierarchy + cross-game routing simplification + first two hand-drawn icons (fish/sea-bass, fish/koi) optimized 2048→512 with sharp + pngquant
@@ -308,6 +305,13 @@ Pending:
 - PR #108 — JSON save-file import. Parser + reconciler as pure modules. Modal mounted at App layout. Replace / Merge / Import-as-new modes with `(name, gameId)` matching. Two-step destructive Replace confirmation gated on existing-town-has-data. No undo by design
 - PR #109 — Onboarding: secondary "or import an existing save" link below NewTownForm in TownManager during forced-create flow
 - PR #110 — Hide canvas empty-state while TownManager is open (closes Issue #107)
+
+### v0.9.4-beta — Per-game icon gap fills (next milestone)
+- Icon scrape + manifest for ACWW (smallest catalog, ~56 fish / ~56 bugs)
+- Icon scrape + manifest for ACCF (~40 fish / ~40 bugs)
+- Icon scrape + manifest for ACNL
+- Icon scrape + manifest for ACNH (largest catalog — sequenced last)
+- `GAMES_WITH_ICONS` gate in `itemIconUtils.ts` expands automatically as each game's `manifest.json` lands; no component-level code change required
 
 ### v1.0 — Launch ready
 - Branding, SEO, accessibility, performance audit


### PR DESCRIPTION
## Summary

Currency sweep against the v0.9.3-beta release. Three surgical fixes to the Roadmap section of `CLAUDE.md`:

1. **v0.9.0-beta**: removed the "in progress on `development`" label and stale "Pending" sub-block (Phase 10 and PR #78 shipped in v0.9.0 and v0.9.1 respectively). Marked shipped 2026-05-03.
2. **v0.9.1-beta**: removed "in progress" label and dropped the `(pending)` marker from PR (c) — `NOTICE` file and `/credits` route (`CreditsPage.tsx`) are confirmed present in tree. Marked shipped 2026-05-04.
3. **v0.9.4-beta**: added next-milestone entry covering per-game icon gap fills, sequenced ACWW → ACCF → ACNL → ACNH (smallest catalog first, largest last), noting that the `GAMES_WITH_ICONS` gate expands automatically as each manifest lands.

No user-visible changes; CHANGELOG entry skipped per doc-only PR convention.

## Test plan
- `npm run build` — ✓ clean
- `npm test` — ✓ 129 tests passing