### PR TITLE
docs: roadmap update to v0.9.3 shipped state + v0.9.4 plan

### DIFF
--- a/docs/roadmap-to-v1.md
+++ b/docs/roadmap-to-v1.md
@@ -2,11 +2,11 @@
 
 This document is the canonical roadmap. It supersedes any earlier scattered planning notes.
 
-Last updated: **2026-05-04** (immediately after v0.9.1-beta shipped).
+Last updated: **2026-05-07** (after v0.9.3-beta shipped; v0.9.4 in progress).
 
 ## Where the project sits
 
-- **Current public release:** v0.9.1-beta — ACGCN item icons, `<ItemIcon>` component, `/credits` route, MIT LICENSE, CC BY-SA 3.0 NOTICE for redistributed wiki assets.
+- **Current public release:** v0.9.3-beta — JSON save-file round-trip (export + import), onboarding empty-state fixes, first hand-drawn bug (ant).
 - **Cadence:** roughly one focused beta every 2-4 days since v0.6 (April 2026). The path to v1.0 holds that pace.
 - **Principle:** one focused track per beta. Polish bundles ship as their own betas, not bundled with feature work.
 
@@ -15,42 +15,61 @@ Last updated: **2026-05-04** (immediately after v0.9.1-beta shipped).
 | Version | Track | Status |
 |---|---|---|
 | v0.9.1-beta | ACGCN item icons + UI wiring + credits/license | Shipped 2026-05-04 |
-| v0.9.2-beta | Cross-game icon routing + per-game gap audit | Next |
-| v0.9.3-beta | CSV import (save file / digital cartridge) | Planned |
-| v0.9.4-beta | ACWW icon gap-fill | Planned |
-| v0.9.5-beta | ACCF icon gap-fill (likely a no-op release after cross-game routing) | Planned |
-| v0.9.6-beta | ACNL icon gap-fill | Planned |
-| v0.9.7-beta | ACNH icon gap-fill | Planned |
-| v0.9.8-beta | SEO basics (OG tags, sitemap, meta, social cards per game) | Planned |
-| v0.9.9-beta | Light monetization footer + polish bug sweep | Planned |
-| v1.0.0 | Final polish + public ship | Target |
+| v0.9.2-beta | Cross-game icon routing + per-game gap audit | Shipped 2026-05-05 |
+| v0.9.3-beta | JSON save-file round-trip (export + import) + first hand-drawn bug (ant) | Shipped 2026-05-06 |
+| v0.9.4-beta | Silhouette rendering for un-donated items + ACWW icon gap-fill + higher-res hand-drawn icons | In progress |
+| v0.9.5-beta | ACNL icon gap-fill (53 items) | Planned |
+| v0.9.6-beta | ACNH icon gap-fill (106 items) | Planned |
+| v0.9.7-beta | SEO basics (OG tags, sitemap, meta, social cards per game) | Planned |
+| v0.9.8-beta | Light monetization footer + polish bug sweep | Planned |
+| v1.0.0 | Final polish + public ship + all hand-drawn icons | Target |
 
 ## Track notes
 
 ### v0.9.2-beta — cross-game icon routing
-Reverse-index the per-game manifests so an item drawn (or scraped) for one game routes to every other game that has it. Generates a per-game audit of what's still missing. The catalog analysis showed 56% of naive-per-game scrape work is redundant — cross-game routing recovers that effort and makes the gap-fill betas dramatically smaller.
+Shipped 2026-05-05. Reverse-indexed the per-game manifests so an item drawn (or scraped) for one game routes to every other game that has it. Generated a per-game audit of what's still missing. The catalog analysis showed 56% of naive-per-game scrape work is redundant — cross-game routing recovers that effort and makes the gap-fill betas dramatically smaller.
 
-### v0.9.3-beta — CSV import
-Adds CSV import as the round-trip half of the existing CSV export — a portable save-file / digital-cartridge surface. Pulls testing leverage forward: every release after this is faster to validate because re-creating a fully-completed museum becomes a one-second hydrate. See [issue #88](https://github.com/jacuzzicoding/animalcrossingwebapp/issues/88) for the schema audit and acceptance criteria.
+### v0.9.3-beta — JSON save-file round-trip
+Shipped 2026-05-06. The original scoping targeted CSV import as the round-trip complement to CSV export; during scoping it became clear that JSON fit the schema needs better — versioned, lossless round-trip, structured per-game donation records. The shipped feature exports a full save file (`ac-save-<town>-<date>.json`) and imports it via a modal with three reconciliation modes: Replace, Merge, and Import as new town. Two-step destructive confirmation guards Replace when the target town has existing data.
 
-### v0.9.4 → v0.9.7-beta — per-game icon gap fills
-After cross-game routing, each remaining game's scrape is much smaller than v0.9.1's was. The per-game catalog audit established the gap sizes:
+v0.9.3 also delivered the first hand-drawn bug: ant. The ACGCN ant joins koi, sea-bass, and coelacanth (fish) as the first four hand-drawn pieces in the library.
 
-- ACWW: 9 unique items
-- ACCF: 0 unique items (release may collapse to a no-op or be skipped)
+### v0.9.4-beta — silhouette rendering + ACWW gap-fill + higher-res hand-drawn icons
+Bundles three related tracks:
+
+**Silhouette rendering (headline feature, issue #116).** CSS-filter-based silhouette rendering for un-donated items across all four categories. A new "Museum display" section in Settings exposes a toggle (default ON). Un-donated items render as a dark silhouette; donating an item triggers a 300ms reveal animation. Faithful to the canonical Animal Crossing museum experience of seeing silhouettes until a piece is donated.
+
+**ACWW icon gap-fill.** 9 unique items scraped from the wiki via the established algorithmic-resolver-plus-OVERRIDES pattern. Smallest of the remaining gap-fill releases, sequenced first so the silhouette feature has icon coverage in a second game at launch.
+
+**Higher-resolution hand-drawn icons.** The icon export pipeline's TARGET_SIZE was bumped from 512 → 768 (PR #115), preserving painterly detail at larger display sizes. Coelacanth shipped as the first new hand-drawn fish under this pipeline (PR #114). These asset changes merged into `development` after the v0.9.3-beta tag, so they ship as part of v0.9.4.
+
+One-track-per-beta is preserved in spirit: silhouette is the headline feature. The icon work is supporting asset/data changes, not a parallel feature.
+
+### v0.9.5 / v0.9.6-beta — per-game icon gap fills
+After cross-game routing, each remaining game's scrape is much smaller than v0.9.1's was. The per-game catalog audit established the remaining gap sizes:
+
 - ACNL: 53 unique items
 - ACNH: 106 unique items (largest catalog, save for last)
 
+ACCF has 0 unique items after cross-game routing — no release needed for that game.
+
 Each release uses the same algorithmic-resolver-plus-OVERRIDES pattern documented in [docs/wiki-scraping-pattern.md](./wiki-scraping-pattern.md).
 
-### v0.9.8-beta — SEO basics
+### v0.9.7-beta — SEO basics
 Open Graph tags, sitemap, meta descriptions, social cards per game. One-shot pass to make share links render well and the site discoverable.
 
-### v0.9.9-beta — Light monetization + polish bug sweep
+### v0.9.8-beta — Light monetization + polish bug sweep
 Ko-fi or GH Sponsors footer link. Sweeps remaining polish bugs (currently tracked: #85 mobile category clipping, #92 v0.9.1 post-release polish bundle, anything new from beta use).
 
 ### v1.0.0 — Final polish + public ship
-The moment the project is ready to share publicly. Reddit launch, portfolio link goes live.
+The moment the project is ready to share publicly. Reddit launch, portfolio link goes live. All 255 hand-drawn icons complete (94 fish + 116 bugs + 45 sea creatures).
+
+## Post-v1.0 ideas
+
+Not scoped for the v1.0 release, but worth preserving for future planning:
+
+- **Challenge Mode.** A more aggressive spoiler/discovery layer building on the v1.0 silhouette feature. Un-donated item names are hidden ("????") and the donation interaction shifts toward typing the species name. Requires UI rework: name-input flow, fuzzy matching, anti-frustration patterns. Spun off the silhouette brainstorm 2026-05-07.
+- **Art real-vs-fake mechanic.** ACNL/ACNH-only feature surfacing a "real vs fake" identification flow during art donations. Requires sourcing reference data not in the current scrape pipelines.
 
 ## Hand-drawn icon plan
 
@@ -72,9 +91,17 @@ Per-game new items (the workload added by each release):
 | ACNH | 10 | 21 | 10 | 41 |
 | **Total** | **94** | **116** | **45** | **255** |
 
-Hand-drawn pieces target v1.0; if the count proves unsustainable, the polish track moves to post-v1.0.
+**Progress as of 2026-05-07:** 4 of 255 complete — ant (bug), koi (fish), sea-bass (fish), coelacanth (fish).
 
-Procreate canvas: 512×512 px, transparent background, sRGB, exported as PNG. Filename matches the canonical kebab-case item id (e.g. `sea-bass.png`, `tiger-swallowtail-butterfly.png`).
+**Procreate canvas:** 2048×2048 px, transparent background, sRGB, exported as PNG. The production pipeline (sharp + pngquant) re-exports to 768×768 for deployment via `npm run icons:export`. Filename matches the canonical kebab-case item id (e.g. `sea-bass.png`, `tiger-swallowtail-butterfly.png`). Originals committed to `icon-sources/` for archival and reproduction.
+
+The process of reusing fish bodies/silhouettes and editing variants reduces per-icon time significantly for closely-related species. Hand-drawn pieces target v1.0; if the count proves unsustainable before ship, the remaining pieces shift to a post-v1.0 polish track.
+
+## Cloud-hosted full-resolution gallery (opportunistic)
+
+Each hand-drawn piece is painted at 2048×2048 — there's value in surfacing the full-resolution work somewhere beyond the 768px production export. A "view full art" link on item detail panels, or a dedicated `/gallery` route, could surface the 2048 sources. Hosting options include Cloudinary, Vercel Blob, Cloudflare Images, and GitHub LFS — each has cost, CDN, and on-the-fly transformation tradeoffs.
+
+**Status: opportunistic — explore if easy, not a release blocker for v1.0.**
 
 ## Process invariants
 


### PR DESCRIPTION
## Summary

- Bumps last-updated date to 2026-05-07
- Marks v0.9.2-beta (2026-05-05) and v0.9.3-beta (2026-05-06) as shipped in the sequence table
- Rewrites the v0.9.3 track note from \"CSV import\" to the JSON save-file round-trip that actually shipped
- Adds a v0.9.4 track note covering silhouette rendering (headline feature, issue #116), ACWW icon gap-fill (9 items), and the 768px export pipeline bump
- Drops the ACCF gap-fill row (0 unique items post cross-game routing); renumbers v0.9.5 → ACNL, v0.9.6 → ACNH, v0.9.7 → SEO, v0.9.8 → monetization
- Corrects the hand-drawn canvas size from 512×512 to 2048×2048 (the actual Procreate canvas); adds progress count (4/255: ant, koi, sea-bass, coelacanth)
- Adds a \"Post-v1.0 ideas\" section with Challenge Mode and art real-vs-fake mechanic
- Adds a \"Cloud-hosted full-resolution gallery\" section (opportunistic, not a v1.0 blocker)

## Test plan

- Docs-only change — no build, no tests needed
- Reviewed doc for house style consistency and single-author voice