### PR TITLE
Silhouette rendering for un-donated items

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to this project are documented here.
 
+## [Unreleased]
+
+### Added
+- Silhouette rendering for un-donated items (Closes #116) — un-donated species now render as black silhouettes that fade to full color on donation, matching the canonical Animal Crossing museum experience. Implemented as a CSS `filter: brightness(0)` on the existing PNGs (no new assets) with a 300ms reveal transition; honors `prefers-reduced-motion`. New "Museum display" section in Settings with a single global toggle (`museumDisplay.silhouettesEnabled` in the persisted store, default ON). `ItemIcon` accepts a new optional `donated` prop and conveys donation state via `alt` text for screen readers ("Coelacanth, not yet donated" / ", donated"). Applies across category rows, expand panels, Home shelves, search results, and the recent-activity feed
+
 ## [0.9.3-beta] — 2026-05-06
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -306,8 +306,11 @@ Do not add new top-level tabs without updating the tab switch in ACCanvas, the n
 - PR #109 — Onboarding: secondary "or import an existing save" link below NewTownForm in TownManager during forced-create flow
 - PR #110 — Hide canvas empty-state while TownManager is open (closes Issue #107)
 
-### v0.9.4-beta — Per-game icon gap fills (next milestone)
-- Icon scrape + manifest for ACWW (smallest catalog, ~56 fish / ~56 bugs)
+### v0.9.4-beta — Silhouettes + ACWW icon gap-fill (in progress)
+- Silhouette rendering for un-donated items (Closes #116). CSS `filter: brightness(0)` on existing PNGs (no new assets) with a 300ms fade reveal on donation. Respects `prefers-reduced-motion`. Persisted setting `museumDisplay.silhouettesEnabled` on the app store (default ON, AC-canonical) with one global toggle in a new "Museum display" Settings section. `ItemIcon` accepts a `donated?: boolean` prop and conveys donation state via `alt` text for screen readers
+- ACWW icon scrape + manifest entries for items unique to Wild World after cross-game routing
+
+### v0.9.5-beta — Per-game icon gap fills (next milestone)
 - Icon scrape + manifest for ACCF (~40 fish / ~40 bugs)
 - Icon scrape + manifest for ACNL
 - Icon scrape + manifest for ACNH (largest catalog — sequenced last)

--- a/src/components/CollectibleRow.tsx
+++ b/src/components/CollectibleRow.tsx
@@ -132,6 +132,7 @@ export function CollectibleRow({
             size={48}
             className="ac-row-icon"
             alt=""
+            donated={checked}
           />
         ) : (
           <Glyph name={name} category={category} donated={checked} />

--- a/src/components/HomeTab.tsx
+++ b/src/components/HomeTab.tsx
@@ -324,6 +324,7 @@ export default function HomeTab({
                     size={32}
                     className="ac-recent-icon"
                     alt=""
+                    donated={true}
                   />
                 ) : (
                   <span
@@ -378,6 +379,7 @@ function ShelfGrid({
                 size={32}
                 className="ac-shelf-icon"
                 alt=""
+                donated={false}
               />
             ) : (
               <span

--- a/src/components/ItemExpandPanel.tsx
+++ b/src/components/ItemExpandPanel.tsx
@@ -56,6 +56,7 @@ export function ItemExpandPanel({
             id={item.id}
             size={192}
             alt=""
+            donated={checked}
           />
         </div>
       )}

--- a/src/components/ItemIcon.tsx
+++ b/src/components/ItemIcon.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useState } from 'react';
 import type { CategoryId, GameId } from '../lib/types';
+import { useAppStore } from '../lib/store';
 import { resolveIconUrl, useManifestState } from './itemIconUtils';
 
 function humanize(id: string): string {
@@ -30,6 +31,7 @@ export function ItemIcon({
   size,
   className,
   alt,
+  donated,
 }: {
   gameId?: GameId;
   category: CategoryId;
@@ -37,8 +39,13 @@ export function ItemIcon({
   size: number;
   className?: string;
   alt?: string;
+  /** Donation state for this item. Pass `false` for un-donated items to allow silhouette rendering. Omit/`true` for donated. */
+  donated?: boolean;
 }) {
   const state = useManifestState();
+  const silhouettesEnabled = useAppStore(
+    s => s.museumDisplay.silhouettesEnabled
+  );
   const [errored, setErrored] = useState(false);
 
   useEffect(() => {
@@ -50,7 +57,16 @@ export function ItemIcon({
       ? resolveIconUrl(state.manifest, category, id)
       : null;
 
-  const altText = alt ?? `${humanize(id)} icon`;
+  const isSilhouette = donated === false && silhouettesEnabled;
+  const baseAlt = alt ?? `${humanize(id)} icon`;
+  const altText =
+    alt === ''
+      ? ''
+      : donated === false
+        ? `${humanize(id)}, not yet donated`
+        : donated === true
+          ? `${humanize(id)}, donated`
+          : baseAlt;
 
   const wrapperStyle: React.CSSProperties = {
     width: size,
@@ -62,9 +78,17 @@ export function ItemIcon({
 
   const showPlaceholder = !src || errored;
 
+  const wrapperClass = [
+    'ac-item-icon',
+    isSilhouette ? 'ac-item-icon-silhouette' : '',
+    className ?? '',
+  ]
+    .filter(Boolean)
+    .join(' ');
+
   return (
     <span
-      className={`ac-item-icon${className ? ` ${className}` : ''}`}
+      className={wrapperClass}
       style={wrapperStyle}
       aria-hidden={alt === '' ? true : undefined}
     >

--- a/src/components/SettingsPage.tsx
+++ b/src/components/SettingsPage.tsx
@@ -9,6 +9,10 @@ export function SettingsPage() {
   const activeTownId = useAppStore(s => s.activeTownId);
   const resetActiveTownDonations = useAppStore(s => s.resetActiveTownDonations);
   const resetAll = useAppStore(s => s.resetAll);
+  const silhouettesEnabled = useAppStore(
+    s => s.museumDisplay.silhouettesEnabled
+  );
+  const setSilhouettesEnabled = useAppStore(s => s.setSilhouettesEnabled);
 
   const totalDonations = useMemo(() => {
     let n = 0;
@@ -122,6 +126,37 @@ export function SettingsPage() {
               </dd>
             </div>
           </dl>
+        </div>
+      </section>
+
+      <section className="ac-settings-section">
+        <div className="ac-settings-section-head">
+          <h2 className="ac-settings-section-title">Museum display</h2>
+          <p className="ac-settings-section-sub">
+            Tweak how the museum looks while you collect.
+          </p>
+        </div>
+        <div className="ac-settings-card">
+          <div className="ac-toggle-row">
+            <div className="ac-toggle-text">
+              <div className="ac-toggle-name">
+                Silhouettes for un-donated items
+              </div>
+              <div className="ac-toggle-sub">
+                Hide species art behind a black silhouette until you donate
+                them. Faithful to the in-game museum.
+              </div>
+            </div>
+            <label className="ac-toggle">
+              <input
+                type="checkbox"
+                checked={silhouettesEnabled}
+                onChange={e => setSilhouettesEnabled(e.target.checked)}
+                aria-label="Show silhouettes for un-donated items"
+              />
+              <span className="ac-toggle-slider" aria-hidden="true" />
+            </label>
+          </div>
         </div>
       </section>
 

--- a/src/components/search/GlobalSearchDropdown.tsx
+++ b/src/components/search/GlobalSearchDropdown.tsx
@@ -352,6 +352,7 @@ export function GlobalSearchDropdown({
                               size={32}
                               className="ac-gs-row-icon"
                               alt=""
+                              donated={isDonated}
                             />
                           ) : (
                             <div

--- a/src/components/views/ActivityFeed.tsx
+++ b/src/components/views/ActivityFeed.tsx
@@ -86,6 +86,7 @@ export function ActivityFeed({
                     id={entry.itemId}
                     size={32}
                     alt=""
+                    donated={true}
                   />
                   <div className="min-w-0 flex-1">
                     <div

--- a/src/index.css
+++ b/src/index.css
@@ -547,6 +547,62 @@ body {
   text-underline-offset: 3px;
 }
 
+.ac-toggle-row {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 24px;
+}
+.ac-toggle-text { min-width: 0; }
+.ac-toggle-name {
+  font-weight: 500;
+  color: var(--ink);
+  font-size: 14px;
+}
+.ac-toggle-sub {
+  font-size: 13px;
+  color: var(--ink-muted);
+  margin-top: 2px;
+}
+.ac-toggle {
+  position: relative;
+  display: inline-block;
+  flex-shrink: 0;
+  width: 44px;
+  height: 26px;
+}
+.ac-toggle input {
+  opacity: 0;
+  width: 0;
+  height: 0;
+}
+.ac-toggle-slider {
+  position: absolute;
+  cursor: pointer;
+  inset: 0;
+  background: var(--border-strong);
+  border-radius: 999px;
+  transition: background 180ms ease-out;
+}
+.ac-toggle-slider::before {
+  content: '';
+  position: absolute;
+  height: 20px;
+  width: 20px;
+  left: 3px;
+  top: 3px;
+  background: var(--surface);
+  border-radius: 50%;
+  transition: transform 180ms ease-out;
+  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.18);
+}
+.ac-toggle input:checked + .ac-toggle-slider { background: var(--accent); }
+.ac-toggle input:checked + .ac-toggle-slider::before { transform: translateX(18px); }
+.ac-toggle input:focus-visible + .ac-toggle-slider {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+}
+
 .ac-settings-danger {
   border-color: oklch(0.62 0.12 25 / 0.35);
   background: color-mix(in oklch, oklch(0.62 0.12 25) 4%, var(--surface));
@@ -815,6 +871,12 @@ body {
 
 .ac-row { border-bottom: 1px solid var(--border); }
 .ac-row:last-child { border-bottom: none; }
+
+.ac-item-icon img { transition: filter 300ms ease-out; }
+.ac-item-icon-silhouette img { filter: brightness(0); }
+@media (prefers-reduced-motion: reduce) {
+  .ac-item-icon img { transition: none; }
+}
 
 .ac-row-pulse > .ac-row-main { animation: ac-row-pulse 1.4s ease-out; }
 @keyframes ac-row-pulse {

--- a/src/lib/store.ts
+++ b/src/lib/store.ts
@@ -19,6 +19,11 @@ export interface TownPatch {
   hemisphere?: Hemisphere | null;
 }
 
+export interface MuseumDisplaySettings {
+  /** Render un-donated items as black silhouettes; default true (AC-canonical). */
+  silhouettesEnabled: boolean;
+}
+
 interface AppState {
   towns: Town[];
   activeTownId: string | null;
@@ -26,6 +31,8 @@ interface AppState {
   donated: Record<string, Record<string, Record<string, boolean>>>;
   // donatedAt[townId][gameId][itemId] = ISO string
   donatedAt: Record<string, Record<string, Record<string, string>>>;
+  museumDisplay: MuseumDisplaySettings;
+  setSilhouettesEnabled: (enabled: boolean) => void;
 
   createTown: (name: string, gameId: GameId, hemisphere?: Hemisphere) => Town;
   updateTown: (id: string, patch: TownPatch) => void;
@@ -53,6 +60,15 @@ export const useAppStore = create<AppState>()(
       activeTownId: null,
       donated: {},
       donatedAt: {},
+      museumDisplay: { silhouettesEnabled: true },
+
+      setSilhouettesEnabled: enabled =>
+        set(state => ({
+          museumDisplay: {
+            ...state.museumDisplay,
+            silhouettesEnabled: enabled,
+          },
+        })),
 
       createTown: (name, gameId, hemisphere = 'NH') => {
         const town: Town = {


### PR DESCRIPTION
Closes #116.

## Summary

Un-donated species now render as black silhouettes that fade to full color the moment they're donated — faithful to the canonical Animal Crossing museum experience.

- **CSS filter approach.** A `filter: brightness(0)` on the existing PNGs preserves alpha and needs no new assets. The reveal is a 300ms transition on the same filter property; `prefers-reduced-motion` removes the animation.
- **One global setting.** New `museumDisplay.silhouettesEnabled` field on the persisted app store, default ON (AC-canonical). Toggle lives in a new "Museum display" section in Settings — no per-category granularity, per the locked spec.
- **Detail info still flows.** Silhouettes gate the icon only. Names, locations, hours, sell price, etc. remain visible in rows and expand panels regardless of donation state.
- **Accessibility.** `ItemIcon` now accepts `donated?: boolean` and conveys donation state via `alt` text — "Coelacanth, not yet donated" / "…, donated" — for screen readers.
- **Surfaces wired.** Category rows, expand panels, Home shelves (leaving / just-arrived), global search dropdown, and the latest-donations feed all pass `donated` through to `ItemIcon`.

## Decisions

- **CSS filter over swapping silhouette assets.** Half the asset weight, no manifest churn, animates for free. Trade-off: relies on the original PNG's alpha being clean — the existing hand-drawn + scraped icons all are.
- **One toggle, not per-category.** The spec explicitly rejects per-category granularity. Kept the Settings UI to a single switch to avoid any drift.
- **Default ON.** AC-canonical and the more interesting visual default; users who want the old "always full art" view flip it off once.
- **Did NOT name-censor un-donated items.** The spec defers `????` style name hiding to a future Challenge Mode. This PR is icon-only.
- **No store migration bump.** New field has a default; Zustand persist's shallow merge fills it for existing users without needing a `version` increment.

## Test plan

- [x] `npm run build` clean
- [x] `npm test` — 129/129 passing
- [ ] Vercel preview manual checks: silhouettes render in all four categories (fish, bugs, fossils, art), 300ms fade plays on donation, toggle in Settings flips state immediately, screen reader announces species + state, reduced-motion users skip the fade