### PR TITLE
Release v0.9.4-beta

### DIFF
--- a/.claude/rules/architecture.md
+++ b/.claude/rules/architecture.md
@@ -1,4 +1,4 @@
-# Architecture Reference (v0.9.3-beta)
+# Architecture Reference (v0.9.4-beta)
 
 ## Stack
 Vite + React 19 + TypeScript + Tailwind CSS v4 + Zustand (persist + non-persisted UI store) + React Router v6. Meadow design tokens (CSS custom properties in `src/index.css` `@theme`); Fraunces (display) + Inter (UI).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,15 @@ All notable changes to this project are documented here.
 
 ## [Unreleased]
 
+## [0.9.4-beta] — 2026-05-07
+
 ### Added
-- Silhouette rendering for un-donated items (Closes #116) — un-donated species now render as black silhouettes that fade to full color on donation, matching the canonical Animal Crossing museum experience. Implemented as a CSS `filter: brightness(0)` on the existing PNGs (no new assets) with a 300ms reveal transition; honors `prefers-reduced-motion`. New "Museum display" section in Settings with a single global toggle (`museumDisplay.silhouettesEnabled` in the persisted store, default ON). `ItemIcon` accepts a new optional `donated` prop and conveys donation state via `alt` text for screen readers ("Coelacanth, not yet donated" / ", donated"). Applies across category rows, expand panels, Home shelves, search results, and the recent-activity feed
+- **Silhouette rendering for un-donated items** (PR #118, Closes #116) — un-donated species now render as black silhouettes that fade to full color on donation, matching the canonical Animal Crossing museum experience. Implemented as a CSS `filter: brightness(0)` on the existing PNGs (no new assets) with a 300ms reveal transition; honors `prefers-reduced-motion`. New "Museum display" section in Settings with a single global toggle (`museumDisplay.silhouettesEnabled` in the persisted store, default ON). `ItemIcon` accepts a new optional `donated` prop and conveys donation state via `alt` text for screen readers ("Coelacanth, not yet donated" / ", donated"). Applies across category rows, expand panels, Home shelves, search results, and the recent-activity feed
+- **ACWW icon gap-fill** (PR #119) — 84 wiki-scraped items added (21 fish + 27 bugs + 27 fossils + 9 art) via the established Fandom MediaWiki + algorithmic-resolver-plus-`OVERRIDES` pattern documented in `docs/wiki-scraping-pattern.md`. ACWW icon coverage now stands at 100%. As a side effect of cross-game ID matching, ACCF coverage rose to 95.5%, ACNL to 49.1%, and ACNH to 39.1% — partial free coverage for the upcoming v0.9.5/v0.9.6 betas
+- Hand-drawn `fish/coelacanth.png` icon (PR #114) — fourth hand-drawn piece in the library after sea-bass, koi, and ant. 2048 source committed at `icon-sources/fish/coelacanth.png`
+
+### Changed
+- **Icon export pipeline `TARGET_SIZE` bumped 512 → 768** (PR #115) — `scripts/export-icons.ts` now resizes 2048 sources to 768×768 (was 512). All four hand-drawn pieces (ant, koi, sea-bass, coelacanth) re-exported at the new resolution. Preserves painterly detail at the larger expand-panel render sizes introduced in v0.9.2 without changing the source workflow
 
 ## [0.9.3-beta] — 2026-05-06
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,7 +16,7 @@ See `docs/architecture.md` — deep architectural context (store schema, migrati
 ## Project Overview
 
 Animal Crossing multi-game companion web app. Tracks museum donations (fish, bugs, fossils, art) across multiple towns and games.
-Meadow design language (Fraunces + Inter, moss-green accent) as of v0.9. **Current release: v0.9.3-beta (2026-05-06) — JSON save-file export + import (round-trip), onboarding empty-state fixes (closes #107), third hand-drawn icon (ant). Previous: v0.9.2-beta (cross-game icon routing + first hand-drawn icons), v0.9.1-beta (ACGCN item icons), v0.9.0-beta (full UI revamp). See `docs/v0.9.3-csv-import-plan.md` for the save-file scoping doc and `CHANGELOG.md` for the full entries.**
+Meadow design language (Fraunces + Inter, moss-green accent) as of v0.9. **Current release: v0.9.4-beta (2026-05-07) — silhouette rendering for un-donated items (closes #116), ACWW icon gap-fill (100% coverage), icon pipeline bumped 512→768, fourth hand-drawn icon (coelacanth). Previous: v0.9.3-beta (JSON save-file round-trip), v0.9.2-beta (cross-game icon routing + first hand-drawn icons), v0.9.1-beta (ACGCN item icons), v0.9.0-beta (full UI revamp). See `docs/roadmap-to-v1.md` for the path to v1.0 and `CHANGELOG.md` for the full entries.**
 Live at: https://animalcrossingwebapp.vercel.app | Dev preview: https://development-animalcrossingwebapp.vercel.app
 
 ## Commands
@@ -306,15 +306,18 @@ Do not add new top-level tabs without updating the tab switch in ACCanvas, the n
 - PR #109 — Onboarding: secondary "or import an existing save" link below NewTownForm in TownManager during forced-create flow
 - PR #110 — Hide canvas empty-state while TownManager is open (closes Issue #107)
 
-### v0.9.4-beta — Silhouettes + ACWW icon gap-fill (in progress)
-- Silhouette rendering for un-donated items (Closes #116). CSS `filter: brightness(0)` on existing PNGs (no new assets) with a 300ms fade reveal on donation. Respects `prefers-reduced-motion`. Persisted setting `museumDisplay.silhouettesEnabled` on the app store (default ON, AC-canonical) with one global toggle in a new "Museum display" Settings section. `ItemIcon` accepts a `donated?: boolean` prop and conveys donation state via `alt` text for screen readers
-- ACWW icon scrape + manifest entries for items unique to Wild World after cross-game routing
+### v0.9.4-beta — Silhouettes + ACWW icon gap-fill + 768px hand-drawn pipeline — **shipped 2026-05-07**
+- PR #114 — fourth hand-drawn icon: ACGCN coelacanth (initial 512px export)
+- PR #115 — icon export `TARGET_SIZE` bumped 512 → 768; all four hand-drawn pieces (ant, koi, sea-bass, coelacanth) re-exported at the new resolution to preserve painterly detail at the larger expand-panel render sizes
+- PR #117 — roadmap doc updated to current state (sequence table, post-v1.0 ideas, cloud-gallery section)
+- PR #118 — silhouette rendering for un-donated items (Closes #116). CSS `filter: brightness(0)` on existing PNGs (no new assets) with a 300ms fade reveal on donation. Respects `prefers-reduced-motion`. Persisted setting `museumDisplay.silhouettesEnabled` on the app store (default ON, AC-canonical) with one global toggle in a new "Museum display" Settings section. `ItemIcon` accepts a `donated?: boolean` prop and conveys donation state via `alt` text for screen readers
+- PR #119 — ACWW icon gap-fill: 84 wiki-scraped items (21 fish + 27 bugs + 27 fossils + 9 art) via the established Fandom MediaWiki + algorithmic-resolver-plus-`OVERRIDES` pattern. ACWW now at 100% coverage. Cross-game ID matching also lifted ACCF to 95.5%, ACNL to 49.1%, and ACNH to 39.1%
 
-### v0.9.5-beta — Per-game icon gap fills (next milestone)
-- Icon scrape + manifest for ACCF (~40 fish / ~40 bugs)
-- Icon scrape + manifest for ACNL
-- Icon scrape + manifest for ACNH (largest catalog — sequenced last)
-- `GAMES_WITH_ICONS` gate in `itemIconUtils.ts` expands automatically as each game's `manifest.json` lands; no component-level code change required
+### v0.9.5-beta — ACNL icon gap-fill (next milestone)
+- Icon scrape + manifest for ACNL (53 unique items remain after cross-game routing)
+- ACCF needs no release after the v0.9.4 cross-game uplift (0 unique items remain)
+- ACNH (106 unique items, largest catalog) sequenced for v0.9.6
+- Icon resolution is data-driven via per-game `manifest.json` — adding a manifest lights up coverage automatically; no component-level code change required
 
 ### v1.0 — Launch ready
 - Branding, SEO, accessibility, performance audit

--- a/README.md
+++ b/README.md
@@ -66,6 +66,6 @@ Museum data lives in `public/data/<game>/`:
 
 ## Version
 
-Current release: **v0.9.3-beta** (2026-05-06) — JSON save-file export + import (round-trip), onboarding empty-state fixes, third hand-drawn icon (ant). Previous betas: **v0.9.2-beta** (cross-game icon routing + first hand-drawn icons), **v0.9.1-beta** (ACGCN item icons), **v0.9.0-beta** (full UI revamp). Last stable on `main`: **v0.8.2-alpha**. See [CHANGELOG.md](CHANGELOG.md) for history and [docs/v0.9-plan.md](docs/v0.9-plan.md) for the v0.9 plan.
+Current release: **v0.9.4-beta** (2026-05-07) — silhouette rendering for un-donated items, ACWW icon gap-fill (100% coverage), 768px hand-drawn icon pipeline, fourth hand-drawn icon (coelacanth). Previous betas: **v0.9.3-beta** (JSON save-file round-trip + onboarding fixes), **v0.9.2-beta** (cross-game icon routing + first hand-drawn icons), **v0.9.1-beta** (ACGCN item icons), **v0.9.0-beta** (full UI revamp). Last stable on `main`: **v0.8.2-alpha**. See [CHANGELOG.md](CHANGELOG.md) for history and [docs/roadmap-to-v1.md](docs/roadmap-to-v1.md) for the path to v1.0.
 
 Significant design decisions are logged in [docs/decisions.md](docs/decisions.md).

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,4 +1,4 @@
-# Architecture Reference (v0.9.3-beta)
+# Architecture Reference (v0.9.4-beta)
 
 This document mirrors `.claude/rules/architecture.md` — the canonical copy that Claude Code sessions auto-load. They are kept in lockstep; if they diverge, the `.claude/rules/` copy wins. Update both together.
 

--- a/docs/roadmap-to-v1.md
+++ b/docs/roadmap-to-v1.md
@@ -2,11 +2,11 @@
 
 This document is the canonical roadmap. It supersedes any earlier scattered planning notes.
 
-Last updated: **2026-05-07** (after v0.9.3-beta shipped; v0.9.4 in progress).
+Last updated: **2026-05-07** (after v0.9.4-beta shipped).
 
 ## Where the project sits
 
-- **Current public release:** v0.9.3-beta — JSON save-file round-trip (export + import), onboarding empty-state fixes, first hand-drawn bug (ant).
+- **Current public release:** v0.9.4-beta — silhouette rendering for un-donated items, ACWW icon gap-fill (100% coverage), 768px hand-drawn icon pipeline, fourth hand-drawn icon (coelacanth).
 - **Cadence:** roughly one focused beta every 2-4 days since v0.6 (April 2026). The path to v1.0 holds that pace.
 - **Principle:** one focused track per beta. Polish bundles ship as their own betas, not bundled with feature work.
 
@@ -17,7 +17,7 @@ Last updated: **2026-05-07** (after v0.9.3-beta shipped; v0.9.4 in progress).
 | v0.9.1-beta | ACGCN item icons + UI wiring + credits/license | Shipped 2026-05-04 |
 | v0.9.2-beta | Cross-game icon routing + per-game gap audit | Shipped 2026-05-05 |
 | v0.9.3-beta | JSON save-file round-trip (export + import) + first hand-drawn bug (ant) | Shipped 2026-05-06 |
-| v0.9.4-beta | Silhouette rendering for un-donated items + ACWW icon gap-fill + higher-res hand-drawn icons | In progress |
+| v0.9.4-beta | Silhouette rendering for un-donated items + ACWW icon gap-fill + higher-res hand-drawn icons | Shipped 2026-05-07 |
 | v0.9.5-beta | ACNL icon gap-fill (53 items) | Planned |
 | v0.9.6-beta | ACNH icon gap-fill (106 items) | Planned |
 | v0.9.7-beta | SEO basics (OG tags, sitemap, meta, social cards per game) | Planned |
@@ -35,13 +35,13 @@ Shipped 2026-05-06. The original scoping targeted CSV import as the round-trip c
 v0.9.3 also delivered the first hand-drawn bug: ant. The ACGCN ant joins koi, sea-bass, and coelacanth (fish) as the first four hand-drawn pieces in the library.
 
 ### v0.9.4-beta — silhouette rendering + ACWW gap-fill + higher-res hand-drawn icons
-Bundles three related tracks:
+Shipped 2026-05-07. Bundles three related tracks:
 
-**Silhouette rendering (headline feature, issue #116).** CSS-filter-based silhouette rendering for un-donated items across all four categories. A new "Museum display" section in Settings exposes a toggle (default ON). Un-donated items render as a dark silhouette; donating an item triggers a 300ms reveal animation. Faithful to the canonical Animal Crossing museum experience of seeing silhouettes until a piece is donated.
+**Silhouette rendering (headline feature, PR #118, issue #116).** CSS-filter-based silhouette rendering for un-donated items across all four categories. A new "Museum display" section in Settings exposes a toggle (default ON). Un-donated items render as a dark silhouette; donating an item triggers a 300ms reveal animation. `prefers-reduced-motion` is honored, and `aria-label` conveys species + donation state for screen readers. Faithful to the canonical Animal Crossing museum experience of seeing silhouettes until a piece is donated.
 
-**ACWW icon gap-fill.** 9 unique items scraped from the wiki via the established algorithmic-resolver-plus-OVERRIDES pattern. Smallest of the remaining gap-fill releases, sequenced first so the silhouette feature has icon coverage in a second game at launch.
+**ACWW icon gap-fill (PR #119).** 84 items scraped from the Fandom wiki (21 fish + 27 bugs + 27 fossils + 9 art) via the established algorithmic-resolver-plus-OVERRIDES pattern. ACWW icon coverage now stands at 100%. As a side effect of cross-game ID matching introduced in v0.9.2, ACCF coverage rose to 95.5%, ACNL to 49.1%, and ACNH to 39.1% — partial free coverage for the upcoming v0.9.5/v0.9.6 betas.
 
-**Higher-resolution hand-drawn icons.** The icon export pipeline's TARGET_SIZE was bumped from 512 → 768 (PR #115), preserving painterly detail at larger display sizes. Coelacanth shipped as the first new hand-drawn fish under this pipeline (PR #114). These asset changes merged into `development` after the v0.9.3-beta tag, so they ship as part of v0.9.4.
+**Higher-resolution hand-drawn icons.** The icon export pipeline's TARGET_SIZE was bumped from 512 → 768 (PR #115), preserving painterly detail at larger display sizes. All four hand-drawn pieces (ant, koi, sea-bass, coelacanth) were re-exported at the new resolution. Coelacanth (PR #114) is the fourth hand-drawn piece in the library.
 
 One-track-per-beta is preserved in spirit: silhouette is the headline feature. The icon work is supporting asset/data changes, not a parallel feature.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "animalcrossingwebapp",
-  "version": "0.9.3-beta",
+  "version": "0.9.4-beta",
   "description": "Web companion app for tracking museum donations across all five Animal Crossing main-line games (GCN, WW, CF, NL, NH). Live at https://animalcrossingwebapp.vercel.app/",
   "type": "module",
   "main": "index.js",

--- a/public/version-history.html
+++ b/public/version-history.html
@@ -449,6 +449,30 @@
     <h2>Shipped versions</h2>
     <div class="timeline">
 
+      <!-- v0.9.4-beta -->
+      <div class="tl-entry">
+        <div class="tl-date">May 7<br/>2026</div>
+        <div class="tl-spine">
+          <div class="tl-dot"></div>
+          <div class="tl-line"></div>
+        </div>
+        <div class="tl-card">
+          <div class="tl-card-head">
+            <span class="version-badge">v0.9.4-beta</span>
+            <span class="version-title">Silhouette museum + ACWW icon gap-fill</span>
+            <span class="velocity-chip">1 day after v0.9.3</span>
+          </div>
+          <ul class="tl-bullets">
+            <li>Silhouette rendering for un-donated items — un-donated species render as black silhouettes that fade to full color on donation, faithful to the canonical Animal Crossing museum experience (closes #116)</li>
+            <li>New "Museum display" section in Settings exposes a single global toggle (default ON); 300ms reveal animation honors <code>prefers-reduced-motion</code>; screen readers hear species + donation state</li>
+            <li>ACWW icon gap-fill — 84 wiki-scraped items added (21 fish + 27 bugs + 27 fossils + 9 art); ACWW icon coverage now at 100%</li>
+            <li>Cross-game ID matching uplift carries through to ACCF (95.5%), ACNL (49.1%), and ACNH (39.1%) — partial free coverage for the upcoming v0.9.5 / v0.9.6 betas</li>
+            <li>Icon export pipeline's <code>TARGET_SIZE</code> bumped 512 → 768; all four hand-drawn pieces (ant, koi, sea-bass, coelacanth) re-exported at the higher resolution</li>
+            <li>Coelacanth is the fourth hand-drawn icon in the library (after sea-bass, koi, and ant)</li>
+          </ul>
+        </div>
+      </div>
+
       <!-- v0.9.3-beta -->
       <div class="tl-entry">
         <div class="tl-date">May 6<br/>2026</div>
@@ -989,11 +1013,17 @@
             <td style="padding:.6rem 1rem;">1 day</td>
             <td style="padding:.6rem 1rem;">Cross-game icon routing + first hand-drawn icons + bigger sizes</td>
           </tr>
-          <tr style="border-top:1px solid var(--border); background:#fafafa;">
+          <tr style="border-top:1px solid var(--border);">
             <td style="padding:.6rem 1rem; color:var(--leaf); font-weight:bold;">v0.9.3-beta</td>
             <td style="padding:.6rem 1rem;">May 6</td>
             <td style="padding:.6rem 1rem;">1 day</td>
             <td style="padding:.6rem 1rem;">JSON save-file export + import + onboarding fixes + ant icon</td>
+          </tr>
+          <tr style="border-top:1px solid var(--border); background:#fafafa;">
+            <td style="padding:.6rem 1rem; color:var(--leaf); font-weight:bold;">v0.9.4-beta</td>
+            <td style="padding:.6rem 1rem;">May 7</td>
+            <td style="padding:.6rem 1rem;">1 day</td>
+            <td style="padding:.6rem 1rem;">Silhouette rendering + ACWW icon gap-fill (100%) + 768px pipeline + coelacanth</td>
           </tr>
         </tbody>
       </table>
@@ -1001,7 +1031,7 @@
   </section>
 
   <footer>
-    <p><a href="https://animalcrossingwebapp.vercel.app">animalcrossingwebapp.vercel.app</a> · v0.9.3-beta shipped · v1.0 next · Dev preview at <a href="https://development-animalcrossingwebapp.vercel.app">development-animalcrossingwebapp.vercel.app</a></p>
+    <p><a href="https://animalcrossingwebapp.vercel.app">animalcrossingwebapp.vercel.app</a> · v0.9.4-beta shipped · v1.0 next · Dev preview at <a href="https://development-animalcrossingwebapp.vercel.app">development-animalcrossingwebapp.vercel.app</a></p>
   </footer>
 
 </div>


### PR DESCRIPTION
## Summary

Release prep for **v0.9.4-beta** — silhouette rendering for un-donated items is the headline feature, with ACWW icon coverage hitting 100% and the hand-drawn icon pipeline upgrading to 768px alongside it.

The four headline beats, all already merged into `development` since the v0.9.3-beta tag:

- **Silhouette museum (PR #118, closes #116)** — un-donated species render as black silhouettes that fade to full color on donation, faithful to the canonical Animal Crossing museum experience. CSS `filter: brightness(0)` on the existing PNGs (no new assets), 300ms reveal animation that honors `prefers-reduced-motion`, and `aria-label` carries species + donation state for screen readers. New "Museum display" Settings section exposes a single global toggle (`museumDisplay.silhouettesEnabled`, default ON). Applies across category rows, expand panels, Home shelves, search results, and the recent-activity feed.
- **ACWW icon gap-fill (PR #119)** — 84 wiki-scraped items added (21 fish + 27 bugs + 27 fossils + 9 art) via the established Fandom MediaWiki + algorithmic-resolver-plus-`OVERRIDES` pattern. ACWW now sits at 100% coverage. As a side effect of cross-game ID matching introduced in v0.9.2, ACCF rose to 95.5%, ACNL to 49.1%, and ACNH to 39.1% — partial free coverage for the upcoming v0.9.5 / v0.9.6 betas.
- **768px hand-drawn icon pipeline (PR #115)** — `scripts/export-icons.ts` `TARGET_SIZE` bumped 512 → 768. All four hand-drawn pieces (ant, koi, sea-bass, coelacanth) re-exported at the new resolution, preserving painterly detail at the larger expand-panel render sizes introduced in v0.9.2 without changing the source workflow.
- **Coelacanth (PR #114)** — fourth hand-drawn piece in the library, the first new fish under the higher-resolution pipeline.

## What this PR contains

Mechanical version-prep only — no feature code. All feature work merged via PRs #114, #115, #117, #118, #119 already on `development`.

- `package.json` → `0.9.4-beta`
- `CHANGELOG.md` — `[Unreleased]` finalized as `[0.9.4-beta] — 2026-05-07` with all four headline beats and PR refs
- `public/version-history.html` — new v0.9.4-beta timeline card, new highlighted table row, footer current-version updated
- `README.md`, `CLAUDE.md`, `docs/architecture.md`, `.claude/rules/architecture.md` — current-release strings bumped
- `CLAUDE.md` roadmap section — v0.9.4-beta entry expanded with PR list and shipped date; v0.9.5 next-milestone entry retargeted to ACNL (ACCF dropped — 0 unique items remain after the v0.9.4 cross-game uplift)
- `docs/roadmap-to-v1.md` — sequence-table status flipped to `Shipped 2026-05-07`; track note expanded with PR refs and corrected ACWW count (the placeholder "9 unique items" is replaced with the actual 84-item delivery); current-release line + last-updated rolled forward

## Decisions

- **Headline framing.** Silhouette rendering leads the release notes everywhere — it's the user-visible museum-experience upgrade. The icon work (768px pipeline + ACWW gap-fill + coelacanth) ships alongside as supporting asset/data changes rather than as parallel features. The roadmap doc states the same framing explicitly so future readers don't read this as a multi-track beta.
- **Roadmap correction.** The v0.9.4-beta track note in `docs/roadmap-to-v1.md` previously called ACWW gap-fill "9 unique items" — that was the pre-scope estimate. The actual scrape delivered 84 items at 100% coverage. Corrected here rather than in a follow-up so the roadmap doc reflects truth on merge day.
- **No back-references to retired planning docs.** README + CLAUDE.md previously pointed at `docs/v0.9-plan.md` as the canonical forward plan. v0.9 is shipped; both pointers now go to `docs/roadmap-to-v1.md`, which is the live planning doc.

## Testing

- `npm run build` — `tsc && vite build` pass, 1715 modules transformed, no errors
- `npm test -- --run` — 9 test files, **129 / 129 tests pass** (includes silhouette `ItemIcon` tests added in PR #118 and TownManager onboarding tests)
- Grep sweep across `*.md` / `*.html` / `*.json` / `*.ts` / `*.tsx` for `v0.9.3-beta`: only historical references remain (CHANGELOG entries for past releases, `docs/roadmap-to-v1.md` shipped row, `public/version-history.html` past-release card, `scripts/fetch-icons-acww.ts` audit comment, save-file `*.test.ts` fixture strings — all correctly retained)
- Vercel preview will deploy from this branch via the GitHub integration; verify the new version-history timeline card and the silhouette toggle live before merging

## After merge

Phase-2 release steps run after this lands and the Vercel deploy goes green:

1. Smoke-test live on the preview URL
2. Merge `development` → `main`
3. Annotated tag `v0.9.4-beta` on `main`
4. `gh release create v0.9.4-beta --notes-file <path>` (never `--notes` inline)
5. Back-merge `main` → `development`

Auto-delete-on-merge is enabled, so `release/v0.9.4-beta` cleans itself up.