### PR TITLE
doc-sync: backfill art/sea data entries + refresh version-history

### DIFF
--- a/.claude/rules/architecture.md
+++ b/.claude/rules/architecture.md
@@ -45,7 +45,7 @@ Vite + React 19 + TypeScript + Tailwind CSS v4 + Zustand (persist + non-persiste
 - `src/components/search/GlobalSearchDropdown.tsx` — Phase 8 unified search dropdown (anchored under Home topbar). Grouped category results (5 groups for ACNL/ACNH, 4 elsewhere), keyboard nav (↑↓↵esc), search history at localStorage key `ac-curator-search-history` (max 8). Replaces GlobalSearchBar / GlobalSearchResults / SearchHistoryPopover.
 
 ### Data
-- `public/data/<gameId>/` — `acgcn/`, `acww/`, `accf/`, `acnl/`, `acnh/` all present. Sea creatures for ACNL + ACNH. Art for ACGCN + ACNH today; ACWW + ACCF art incoming via PR #78 (closes Issue #74).
+- `public/data/<gameId>/` — `acgcn/`, `acww/`, `accf/`, `acnl/`, `acnh/` all present. Sea creatures for ACNL + ACNH. Art for all five games: ACGCN (13), ACWW (20), ACCF (23), ACNL (36), ACNH (43).
 
 ## Store Schema (v3)
 ```

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -156,10 +156,18 @@ public/data/acww/
   fish.json                 # 56 species (Wild World)
   bugs.json                 # 56 species (Wild World)
   fossils.json              # 52 fossil items (Wild World)
+  art.json                  # 20 paintings (Wild World)
 public/data/accf/
   fish.json                 # 40 species (City Folk)
   bugs.json                 # 40 species (City Folk)
   fossils.json              # 52 fossil items (City Folk)
+  art.json                  # 23 paintings (City Folk)
+public/data/acnl/
+  fish.json                 # fish (New Leaf)
+  bugs.json                 # bugs (New Leaf)
+  fossils.json              # fossils (New Leaf)
+  art.json                  # 36 paintings (New Leaf)
+  sea_creatures.json        # sea creatures (New Leaf)
 public/data/acnh/
   fish.json                 # 81 species (NH/SH months_nh/months_sh)
   bugs.json                 # 80 species (NH/SH months_nh/months_sh)

--- a/README.md
+++ b/README.md
@@ -55,9 +55,9 @@ npm run lint      # Lint with ESLint
 
 Museum data lives in `public/data/<game>/`:
 - `public/data/acgcn/` — GameCube: 40 fish, 40 bugs, 25 fossils, 13 paintings
-- `public/data/acww/` — Wild World: 56 fish, 56 bugs, 52 fossils
-- `public/data/accf/` — City Folk: 40 fish, 40 bugs, 52 fossils
-- `public/data/acnl/` — New Leaf: fish, bugs, fossils
+- `public/data/acww/` — Wild World: 56 fish, 56 bugs, 52 fossils, 20 art
+- `public/data/accf/` — City Folk: 40 fish, 40 bugs, 52 fossils, 23 art
+- `public/data/acnl/` — New Leaf: fish, bugs, fossils, 36 art, sea creatures
 - `public/data/acnh/` — New Horizons: 81 fish, 80 bugs, 86 fossils, 43 art, 40 sea creatures (NH/SH month availability)
 
 > Sea creatures are fully supported for New Horizons and New Leaf — a dedicated Sea entry appears in the sidebar nav for those games (shipped in v0.8.2).

--- a/public/version-history.html
+++ b/public/version-history.html
@@ -415,22 +415,22 @@
 
   <header>
     <h1>Animal Crossing Web App</h1>
-    <p>Version history &amp; roadmap · Updated May 5, 2026</p>
+    <p>Version history &amp; roadmap · Updated May 9, 2026</p>
   </header>
 
   <!-- Velocity banner -->
   <div class="velocity-banner">
     <div>
       <div class="headline">v0.1 to v0.9 in 25 days</div>
-      <div class="sub">Thirteen releases. Blathers can't keep up.</div>
+      <div class="sub">Sixteen releases. Blathers can't keep up.</div>
     </div>
     <div class="vel-stats">
       <div class="vel-stat">
-        <div class="num">13</div>
+        <div class="num">16</div>
         <div class="label">releases shipped</div>
       </div>
       <div class="vel-stat">
-        <div class="num">25</div>
+        <div class="num">29</div>
         <div class="label">days elapsed</div>
       </div>
       <div class="vel-stat">
@@ -819,19 +819,23 @@
         <span class="building-note">polish, PWA, accessibility</span>
       </div>
 
-      <p class="checklist-section">Recently shipped (v0.9.1-beta)</p>
+      <p class="checklist-section">Recently shipped (v0.9.4-beta)</p>
       <div class="checklist">
         <div class="check-item done">
           <div class="box">✓</div>
-          <span class="text">ACGCN item icons across category rows, expand panels, global search, and home tab</span>
+          <span class="text">Silhouette rendering for un-donated items — black silhouettes fade to full colour on donation; Settings toggle (default ON); honors prefers-reduced-motion</span>
         </div>
         <div class="check-item done">
           <div class="box">✓</div>
-          <span class="text">Future games light up automatically when their icon assets are added</span>
+          <span class="text">ACWW icon coverage at 100% — 84 wiki-scraped items; ACCF 95.5%, ACNL 49.1%, ACNH 39.1% via cross-game ID routing</span>
         </div>
         <div class="check-item done">
           <div class="box">✓</div>
-          <span class="text">New /credits route, MIT LICENSE + NOTICE files at the repo root</span>
+          <span class="text">JSON save-file export + import — portable round-trip backup with Replace / Merge / Import-as-new modes</span>
+        </div>
+        <div class="check-item done">
+          <div class="box">✓</div>
+          <span class="text">ACGCN item icons + cross-game routing + four hand-drawn icons (sea-bass, koi, ant, coelacanth)</span>
         </div>
         <div class="check-item done">
           <div class="box">✓</div>


### PR DESCRIPTION
## Summary

Nightly doc-sync run (2026-05-09) found four files with verifiable drift vs repo state. All corrections are minimal — no prose rewrites, no scope expansion.

### Changes

**`CLAUDE.md` — file-structure block**
- Added `art.json` to `public/data/acww/` (20 paintings) and `public/data/accf/` (23 paintings) — both files have existed since v0.9.0 (PR #78) but were never listed
- Added the missing `public/data/acnl/` section (fish, bugs, fossils, art, sea_creatures) — all files present since v0.8.0 (PR #34) and v0.8.2, never listed in the file-structure block

**`README.md` — Data section**
- Same omissions corrected: art counts added to acww/accf lines; art + sea_creatures added to acnl line

**`.claude/rules/architecture.md` — Data section**
- Replaced "ACWW + ACCF art incoming via PR #78 (closes Issue #74)" with accurate current summary: art present for all five games. PR #78 merged in v0.9.0 (2026-05-03); the "incoming" language was 6+ days stale

**`public/version-history.html`**
- Header date: May 5 → May 9
- Velocity banner: release count 13 → 16; days elapsed 25 → 29 (both now consistent with the velocity detail table in the same file, which already had all 16 rows)
- "Currently building" checklist: updated "Recently shipped" label from v0.9.1-beta to v0.9.4-beta; replaced checklist items to reflect v0.9.2–v0.9.4 shipped work

### What was not changed
- `CHANGELOG.md` — `[Unreleased]` is empty; latest entry is `[0.9.4-beta]`. Clean.
- `docs/roadmap-to-v1.md` — current; v0.9.4 marked shipped, v0.9.5 marked planned.
- `docs/architecture.md` — thin redirect file; no content drift (stale line was in `.claude/rules/architecture.md`).
- `package.json` version `0.9.4-beta` — matches latest GitHub release tag.

### Test plan
- [ ] `npm run build` passes
- [ ] No TypeScript errors introduced (docs-only change — none expected)

---
*Generated by nightly doc-sync routine — 2026-05-09*

---
_Generated by [Claude Code](https://claude.ai/code/session_012rf2b3KMvBYRFMqzujpomY)_