### PR TITLE
chore: polish nits — close #60, #92.2, #92.4, #95, #124

### DIFF
--- a/public/version-history.html
+++ b/public/version-history.html
@@ -1,1043 +1,1480 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
-<head>
-  <meta charset="UTF-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>Animal Crossing Web App — Version History & Roadmap</title>
-  <link href="https://fonts.googleapis.com/css2?family=Fraunces:opsz,wght@9..144,400;9..144,500;9..144,600&family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet" />
-  <style>
-    *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Animal Crossing Web App — Version History & Roadmap</title>
+    <link
+      href="https://fonts.googleapis.com/css2?family=Fraunces:opsz,wght@9..144,400;9..144,500;9..144,600&family=Inter:wght@400;500;600;700&display=swap"
+      rel="stylesheet"
+    />
+    <style>
+      *,
+      *::before,
+      *::after {
+        box-sizing: border-box;
+        margin: 0;
+        padding: 0;
+      }
 
-    :root {
-      --wood:    #7B5E3B;
-      --paper:   #F5E9D4;
-      --ink:     #2A2A2A;
-      --leaf:    #3CA370;
-      --leaf-lt: #d4f0e3;
-      --border:  #E7DAC4;
-      --muted:   #5a4a35;
-      --sky:     #b8ddf5;
-      --sky-dk:  #5b9ec9;
-      --gold:    #c9922e;
-      --gold-lt: #fdf0d5;
-      --future:  #e8dff5;
-      --future-dk:#7a5fa0;
-    }
+      :root {
+        --wood: #7b5e3b;
+        --paper: #f5e9d4;
+        --ink: #2a2a2a;
+        --leaf: #3ca370;
+        --leaf-lt: #d4f0e3;
+        --border: #e7dac4;
+        --muted: #5a4a35;
+        --sky: #b8ddf5;
+        --sky-dk: #5b9ec9;
+        --gold: #c9922e;
+        --gold-lt: #fdf0d5;
+        --future: #e8dff5;
+        --future-dk: #7a5fa0;
+      }
 
-    body {
-      font-family: 'Inter', system-ui, sans-serif;
-      background: #eef7ee;
-      color: var(--ink);
-      min-height: 100vh;
-      padding: 2rem 1rem 4rem;
-    }
+      body {
+        font-family: 'Inter', system-ui, sans-serif;
+        background: #eef7ee;
+        color: var(--ink);
+        min-height: 100vh;
+        padding: 2rem 1rem 4rem;
+      }
 
-    /* ── Header ── */
-    header {
-      text-align: center;
-      margin-bottom: 3rem;
-    }
+      /* ── Header ── */
+      header {
+        text-align: center;
+        margin-bottom: 3rem;
+      }
 
-    header h1 {
-      font-size: 2rem;
-      color: var(--wood);
-      margin-bottom: .25rem;
-    }
+      header h1 {
+        font-size: 2rem;
+        color: var(--wood);
+        margin-bottom: 0.25rem;
+      }
 
-    header p {
-      color: var(--muted);
-      font-size: .95rem;
-    }
+      header p {
+        color: var(--muted);
+        font-size: 0.95rem;
+      }
 
-    /* ── Layout ── */
-    .page {
-      max-width: 860px;
-      margin: 0 auto;
-      display: flex;
-      flex-direction: column;
-      gap: 2.5rem;
-    }
+      /* ── Layout ── */
+      .page {
+        max-width: 860px;
+        margin: 0 auto;
+        display: flex;
+        flex-direction: column;
+        gap: 2.5rem;
+      }
 
-    section > h2 {
-      font-size: 1.1rem;
-      color: var(--muted);
-      text-transform: uppercase;
-      letter-spacing: .08em;
-      margin-bottom: 1.25rem;
-      display: flex;
-      align-items: center;
-      gap: .5rem;
-    }
+      section > h2 {
+        font-size: 1.1rem;
+        color: var(--muted);
+        text-transform: uppercase;
+        letter-spacing: 0.08em;
+        margin-bottom: 1.25rem;
+        display: flex;
+        align-items: center;
+        gap: 0.5rem;
+      }
 
-    section > h2::after {
-      content: '';
-      flex: 1;
-      height: 1px;
-      background: var(--border);
-    }
+      section > h2::after {
+        content: '';
+        flex: 1;
+        height: 1px;
+        background: var(--border);
+      }
 
-    /* ── Velocity banner ── */
-    .velocity-banner {
-      background: var(--wood);
-      color: #fff8ee;
-      border-radius: 14px;
-      padding: 1.25rem 1.75rem;
-      display: flex;
-      flex-wrap: wrap;
-      gap: 1.25rem 2rem;
-      align-items: center;
-      justify-content: space-between;
-    }
+      /* ── Velocity banner ── */
+      .velocity-banner {
+        background: var(--wood);
+        color: #fff8ee;
+        border-radius: 14px;
+        padding: 1.25rem 1.75rem;
+        display: flex;
+        flex-wrap: wrap;
+        gap: 1.25rem 2rem;
+        align-items: center;
+        justify-content: space-between;
+      }
 
-    .velocity-banner .headline {
-      font-size: 1.25rem;
-      font-weight: bold;
-    }
+      .velocity-banner .headline {
+        font-size: 1.25rem;
+        font-weight: bold;
+      }
 
-    .velocity-banner .sub {
-      font-size: .85rem;
-      opacity: .8;
-      margin-top: .2rem;
-    }
+      .velocity-banner .sub {
+        font-size: 0.85rem;
+        opacity: 0.8;
+        margin-top: 0.2rem;
+      }
 
-    .vel-stats {
-      display: flex;
-      gap: 1.5rem;
-      flex-wrap: wrap;
-    }
+      .vel-stats {
+        display: flex;
+        gap: 1.5rem;
+        flex-wrap: wrap;
+      }
 
-    .vel-stat {
-      text-align: center;
-    }
+      .vel-stat {
+        text-align: center;
+      }
 
-    .vel-stat .num {
-      font-size: 1.6rem;
-      color: #a8e6c5;
-      line-height: 1;
-    }
+      .vel-stat .num {
+        font-size: 1.6rem;
+        color: #a8e6c5;
+        line-height: 1;
+      }
 
-    .vel-stat .label {
-      font-size: .72rem;
-      opacity: .75;
-      margin-top: .15rem;
-    }
+      .vel-stat .label {
+        font-size: 0.72rem;
+        opacity: 0.75;
+        margin-top: 0.15rem;
+      }
 
-    /* ── Timeline ── */
-    .timeline {
-      display: flex;
-      flex-direction: column;
-      gap: 0;
-    }
+      /* ── Timeline ── */
+      .timeline {
+        display: flex;
+        flex-direction: column;
+        gap: 0;
+      }
 
-    .tl-entry {
-      display: grid;
-      grid-template-columns: 80px 28px 1fr;
-      gap: 0 .75rem;
-      align-items: start;
-    }
+      .tl-entry {
+        display: grid;
+        grid-template-columns: 80px 28px 1fr;
+        gap: 0 0.75rem;
+        align-items: start;
+      }
 
-    .tl-date {
-      text-align: right;
-      font-size: .8rem;
-      color: var(--muted);
-      padding-top: .65rem;
-      line-height: 1.3;
-    }
+      .tl-date {
+        text-align: right;
+        font-size: 0.8rem;
+        color: var(--muted);
+        padding-top: 0.65rem;
+        line-height: 1.3;
+      }
 
-    .tl-spine {
-      display: flex;
-      flex-direction: column;
-      align-items: center;
-    }
+      .tl-spine {
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+      }
 
-    .tl-dot {
-      width: 16px;
-      height: 16px;
-      border-radius: 50%;
-      background: var(--leaf);
-      border: 3px solid #eef7ee;
-      box-shadow: 0 0 0 2px var(--leaf);
-      flex-shrink: 0;
-      margin-top: .55rem;
-      z-index: 1;
-    }
+      .tl-dot {
+        width: 16px;
+        height: 16px;
+        border-radius: 50%;
+        background: var(--leaf);
+        border: 3px solid #eef7ee;
+        box-shadow: 0 0 0 2px var(--leaf);
+        flex-shrink: 0;
+        margin-top: 0.55rem;
+        z-index: 1;
+      }
 
-    .tl-dot.hotfix {
-      background: var(--gold);
-      box-shadow: 0 0 0 2px var(--gold);
-    }
+      .tl-dot.hotfix {
+        background: var(--gold);
+        box-shadow: 0 0 0 2px var(--gold);
+      }
 
-    .tl-line {
-      width: 2px;
-      flex: 1;
-      background: var(--border);
-      min-height: 18px;
-    }
+      .tl-line {
+        width: 2px;
+        flex: 1;
+        background: var(--border);
+        min-height: 18px;
+      }
 
-    .tl-card {
-      background: #fff;
-      border: 1px solid var(--border);
-      border-radius: 12px;
-      padding: 1rem 1.25rem;
-      margin-bottom: 1rem;
-    }
+      .tl-card {
+        background: #fff;
+        border: 1px solid var(--border);
+        border-radius: 12px;
+        padding: 1rem 1.25rem;
+        margin-bottom: 1rem;
+      }
 
-    .tl-card.hotfix {
-      border-color: #e8d0a0;
-      background: var(--gold-lt);
-    }
+      .tl-card.hotfix {
+        border-color: #e8d0a0;
+        background: var(--gold-lt);
+      }
 
-    .tl-card-head {
-      display: flex;
-      align-items: baseline;
-      gap: .6rem;
-      margin-bottom: .55rem;
-      flex-wrap: wrap;
-    }
+      .tl-card-head {
+        display: flex;
+        align-items: baseline;
+        gap: 0.6rem;
+        margin-bottom: 0.55rem;
+        flex-wrap: wrap;
+      }
 
-    .version-badge {
-      font-size: .95rem;
-      font-weight: bold;
-      color: var(--leaf);
-    }
+      .version-badge {
+        font-size: 0.95rem;
+        font-weight: bold;
+        color: var(--leaf);
+      }
 
-    .version-badge.hotfix { color: var(--gold); }
+      .version-badge.hotfix {
+        color: var(--gold);
+      }
 
-    .version-title {
-      font-size: .9rem;
-      color: var(--muted);
-    }
+      .version-title {
+        font-size: 0.9rem;
+        color: var(--muted);
+      }
 
-    .velocity-chip {
-      margin-left: auto;
-      font-size: .72rem;
-      background: var(--leaf-lt);
-      color: var(--leaf);
-      border-radius: 20px;
-      padding: .1rem .55rem;
-    }
+      .velocity-chip {
+        margin-left: auto;
+        font-size: 0.72rem;
+        background: var(--leaf-lt);
+        color: var(--leaf);
+        border-radius: 20px;
+        padding: 0.1rem 0.55rem;
+      }
 
-    .velocity-chip.fast { background: #fff0d0; color: var(--gold); }
+      .velocity-chip.fast {
+        background: #fff0d0;
+        color: var(--gold);
+      }
 
-    .tl-bullets {
-      list-style: none;
-      display: flex;
-      flex-direction: column;
-      gap: .3rem;
-    }
+      .tl-bullets {
+        list-style: none;
+        display: flex;
+        flex-direction: column;
+        gap: 0.3rem;
+      }
 
-    .tl-bullets li {
-      font-size: .85rem;
-      color: var(--ink);
-      padding-left: 1.1rem;
-      position: relative;
-    }
+      .tl-bullets li {
+        font-size: 0.85rem;
+        color: var(--ink);
+        padding-left: 1.1rem;
+        position: relative;
+      }
 
-    .tl-bullets li::before {
-      content: '·';
-      position: absolute;
-      left: .25rem;
-      color: var(--muted);
-      font-weight: bold;
-    }
+      .tl-bullets li::before {
+        content: '·';
+        position: absolute;
+        left: 0.25rem;
+        color: var(--muted);
+        font-weight: bold;
+      }
 
-    /* ── Currently building ── */
-    .building-card {
-      background: #fff;
-      border: 2px solid var(--leaf);
-      border-radius: 14px;
-      padding: 1.5rem;
-    }
+      /* ── Currently building ── */
+      .building-card {
+        background: #fff;
+        border: 2px solid var(--leaf);
+        border-radius: 14px;
+        padding: 1.5rem;
+      }
 
-    .building-head {
-      display: flex;
-      align-items: center;
-      gap: .75rem;
-      margin-bottom: 1.1rem;
-    }
+      .building-head {
+        display: flex;
+        align-items: center;
+        gap: 0.75rem;
+        margin-bottom: 1.1rem;
+      }
 
-    .building-badge {
-      background: var(--leaf);
-      color: #fff;
-      font-size: .8rem;
-      border-radius: 6px;
-      padding: .25rem .65rem;
-    }
+      .building-badge {
+        background: var(--leaf);
+        color: #fff;
+        font-size: 0.8rem;
+        border-radius: 6px;
+        padding: 0.25rem 0.65rem;
+      }
 
-    .building-head h3 {
-      font-size: 1.1rem;
-      color: var(--ink);
-    }
+      .building-head h3 {
+        font-size: 1.1rem;
+        color: var(--ink);
+      }
 
-    .building-note {
-      font-size: .8rem;
-      color: var(--muted);
-      margin-left: auto;
-    }
+      .building-note {
+        font-size: 0.8rem;
+        color: var(--muted);
+        margin-left: auto;
+      }
 
-    .checklist {
-      display: flex;
-      flex-direction: column;
-      gap: .45rem;
-    }
+      .checklist {
+        display: flex;
+        flex-direction: column;
+        gap: 0.45rem;
+      }
 
-    .check-item {
-      display: flex;
-      align-items: center;
-      gap: .65rem;
-      font-size: .88rem;
-    }
+      .check-item {
+        display: flex;
+        align-items: center;
+        gap: 0.65rem;
+        font-size: 0.88rem;
+      }
 
-    .check-item .box {
-      width: 18px;
-      height: 18px;
-      border-radius: 4px;
-      flex-shrink: 0;
-      display: flex;
-      align-items: center;
-      justify-content: center;
-      font-size: .8rem;
-    }
+      .check-item .box {
+        width: 18px;
+        height: 18px;
+        border-radius: 4px;
+        flex-shrink: 0;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        font-size: 0.8rem;
+      }
 
-    .check-item.done .box {
-      background: var(--leaf);
-      color: #fff;
-    }
+      .check-item.done .box {
+        background: var(--leaf);
+        color: #fff;
+      }
 
-    .check-item.todo .box {
-      background: #fff;
-      border: 2px solid var(--border);
-      color: transparent;
-    }
+      .check-item.todo .box {
+        background: #fff;
+        border: 2px solid var(--border);
+        color: transparent;
+      }
 
-    .check-item.done .text {
-      color: var(--muted);
-    }
+      .check-item.done .text {
+        color: var(--muted);
+      }
 
-    .check-item.todo .text {
-      color: var(--ink);
-      font-weight: 500;
-    }
+      .check-item.todo .text {
+        color: var(--ink);
+        font-weight: 500;
+      }
 
-    .checklist-section {
-      font-size: .75rem;
-      text-transform: uppercase;
-      letter-spacing: .06em;
-      color: var(--muted);
-      margin: .75rem 0 .3rem;
-    }
+      .checklist-section {
+        font-size: 0.75rem;
+        text-transform: uppercase;
+        letter-spacing: 0.06em;
+        color: var(--muted);
+        margin: 0.75rem 0 0.3rem;
+      }
 
-    /* ── Roadmap lanes ── */
-    .lanes {
-      display: grid;
-      grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
-      gap: 1rem;
-    }
+      /* ── Roadmap lanes ── */
+      .lanes {
+        display: grid;
+        grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+        gap: 1rem;
+      }
 
-    .lane {
-      border-radius: 12px;
-      padding: 1.1rem 1.25rem;
-      border: 1px solid transparent;
-    }
+      .lane {
+        border-radius: 12px;
+        padding: 1.1rem 1.25rem;
+        border: 1px solid transparent;
+      }
 
-    .lane.v09 {
-      background: var(--sky);
-      border-color: #9fcde8;
-    }
+      .lane.v09 {
+        background: var(--sky);
+        border-color: #9fcde8;
+      }
 
-    .lane.v10 {
-      background: #ffe8b0;
-      border-color: #e8c76a;
-    }
+      .lane.v10 {
+        background: #ffe8b0;
+        border-color: #e8c76a;
+      }
 
-    .lane.vpost {
-      background: var(--future);
-      border-color: #c3b0e0;
-    }
+      .lane.vpost {
+        background: var(--future);
+        border-color: #c3b0e0;
+      }
 
-    .lane-head {
-      display: flex;
-      align-items: center;
-      gap: .5rem;
-      margin-bottom: .85rem;
-    }
+      .lane-head {
+        display: flex;
+        align-items: center;
+        gap: 0.5rem;
+        margin-bottom: 0.85rem;
+      }
 
-    .lane-badge {
-      font-size: .75rem;
-      font-weight: bold;
-      border-radius: 5px;
-      padding: .2rem .5rem;
-    }
+      .lane-badge {
+        font-size: 0.75rem;
+        font-weight: bold;
+        border-radius: 5px;
+        padding: 0.2rem 0.5rem;
+      }
 
-    .lane.v09 .lane-badge { background: var(--sky-dk); color: #fff; }
-    .lane.v10 .lane-badge { background: #c9922e; color: #fff; }
-    .lane.vpost .lane-badge { background: var(--future-dk); color: #fff; }
+      .lane.v09 .lane-badge {
+        background: var(--sky-dk);
+        color: #fff;
+      }
+      .lane.v10 .lane-badge {
+        background: #c9922e;
+        color: #fff;
+      }
+      .lane.vpost .lane-badge {
+        background: var(--future-dk);
+        color: #fff;
+      }
 
-    .lane-title {
-      font-size: .88rem;
-      font-weight: bold;
-    }
+      .lane-title {
+        font-size: 0.88rem;
+        font-weight: bold;
+      }
 
-    .lane-items {
-      list-style: none;
-      display: flex;
-      flex-direction: column;
-      gap: .35rem;
-    }
+      .lane-items {
+        list-style: none;
+        display: flex;
+        flex-direction: column;
+        gap: 0.35rem;
+      }
 
-    .lane-items li {
-      font-size: .82rem;
-      padding-left: 1rem;
-      position: relative;
-      color: var(--ink);
-    }
+      .lane-items li {
+        font-size: 0.82rem;
+        padding-left: 1rem;
+        position: relative;
+        color: var(--ink);
+      }
 
-    .lane-items li::before {
-      content: '◦';
-      position: absolute;
-      left: 0;
-      color: var(--muted);
-    }
+      .lane-items li::before {
+        content: '◦';
+        position: absolute;
+        left: 0;
+        color: var(--muted);
+      }
 
-    /* ── Footer ── */
-    footer {
-      text-align: center;
-      font-size: .78rem;
-      color: var(--muted);
-      margin-top: 1rem;
-    }
+      /* ── Footer ── */
+      footer {
+        text-align: center;
+        font-size: 0.78rem;
+        color: var(--muted);
+        margin-top: 1rem;
+      }
 
-    footer a { color: var(--leaf); text-decoration: none; }
-  </style>
-</head>
-<body>
-<div class="page">
+      footer a {
+        color: var(--leaf);
+        text-decoration: none;
+      }
+    </style>
+  </head>
+  <body>
+    <div class="page">
+      <header>
+        <h1>Animal Crossing Web App</h1>
+        <p>Version history &amp; roadmap · Updated May 9, 2026</p>
+      </header>
 
-  <header>
-    <h1>Animal Crossing Web App</h1>
-    <p>Version history &amp; roadmap · Updated May 9, 2026</p>
-  </header>
+      <!-- Velocity banner -->
+      <div class="velocity-banner">
+        <div>
+          <div class="headline">v0.1 to v0.9 in 29 days</div>
+          <div class="sub">Sixteen releases. Blathers can't keep up.</div>
+        </div>
+        <div class="vel-stats">
+          <div class="vel-stat">
+            <div class="num">16</div>
+            <div class="label">releases shipped</div>
+          </div>
+          <div class="vel-stat">
+            <div class="num">29</div>
+            <div class="label">days elapsed</div>
+          </div>
+          <div class="vel-stat">
+            <div class="num">5</div>
+            <div class="label">games supported</div>
+          </div>
+          <div class="vel-stat">
+            <div class="num">1,000+</div>
+            <div class="label">items catalogued</div>
+          </div>
+        </div>
+      </div>
 
-  <!-- Velocity banner -->
-  <div class="velocity-banner">
-    <div>
-      <div class="headline">v0.1 to v0.9 in 25 days</div>
-      <div class="sub">Sixteen releases. Blathers can't keep up.</div>
+      <!-- Shipped timeline -->
+      <section>
+        <h2>Shipped versions</h2>
+        <div class="timeline">
+          <!-- v0.9.4-beta -->
+          <div class="tl-entry">
+            <div class="tl-date">May 7<br />2026</div>
+            <div class="tl-spine">
+              <div class="tl-dot"></div>
+              <div class="tl-line"></div>
+            </div>
+            <div class="tl-card">
+              <div class="tl-card-head">
+                <span class="version-badge">v0.9.4-beta</span>
+                <span class="version-title"
+                  >Silhouette museum + ACWW icon gap-fill</span
+                >
+                <span class="velocity-chip">1 day after v0.9.3</span>
+              </div>
+              <ul class="tl-bullets">
+                <li>
+                  Silhouette rendering for un-donated items — un-donated species
+                  render as black silhouettes that fade to full color on
+                  donation, faithful to the canonical Animal Crossing museum
+                  experience (closes #116)
+                </li>
+                <li>
+                  New "Museum display" section in Settings exposes a single
+                  global toggle (default ON); 300ms reveal animation honors
+                  <code>prefers-reduced-motion</code>; screen readers hear
+                  species + donation state
+                </li>
+                <li>
+                  ACWW icon gap-fill — 84 wiki-scraped items added (21 fish + 27
+                  bugs + 27 fossils + 9 art); ACWW icon coverage now at 100%
+                </li>
+                <li>
+                  Cross-game ID matching uplift carries through to ACCF (95.5%),
+                  ACNL (49.1%), and ACNH (39.1%) — partial free coverage for the
+                  upcoming v0.9.5 / v0.9.6 betas
+                </li>
+                <li>
+                  Icon export pipeline's <code>TARGET_SIZE</code> bumped 512 →
+                  768; all four hand-drawn pieces (ant, koi, sea-bass,
+                  coelacanth) re-exported at the higher resolution
+                </li>
+                <li>
+                  Coelacanth is the fourth hand-drawn icon in the library (after
+                  sea-bass, koi, and ant)
+                </li>
+              </ul>
+            </div>
+          </div>
+
+          <!-- v0.9.3-beta -->
+          <div class="tl-entry">
+            <div class="tl-date">May 6<br />2026</div>
+            <div class="tl-spine">
+              <div class="tl-dot"></div>
+              <div class="tl-line"></div>
+            </div>
+            <div class="tl-card">
+              <div class="tl-card-head">
+                <span class="version-badge">v0.9.3-beta</span>
+                <span class="version-title"
+                  >Save-file round trip + onboarding fixes</span
+                >
+                <span class="velocity-chip">1 day after v0.9.2</span>
+              </div>
+              <ul class="tl-bullets">
+                <li>
+                  JSON save-file export — new <code>Export save</code> button
+                  writes a versioned, lossless
+                  <code>ac-save-&lt;town&gt;-&lt;date&gt;.json</code> snapshot
+                  of one town and its donations
+                </li>
+                <li>
+                  JSON save-file import — round-trip companion with Replace /
+                  Merge / Import-as-new modes,
+                  <code>(name, gameId)</code> matching, and a heavy two-step
+                  confirmation when Replace would overwrite existing donations
+                </li>
+                <li>
+                  Sidebar foot now has two distinct buttons:
+                  <code>Export save</code> (the new JSON) and
+                  <code>Download report</code> (the existing human-readable CSV,
+                  unchanged)
+                </li>
+                <li>
+                  Onboarding fix: <code>Import save instead</code> link is
+                  visible in the empty-state TownManager so a fresh-device user
+                  can restore from a save file without first creating a
+                  placeholder town (closes #107)
+                </li>
+                <li>
+                  Third hand-drawn icon — ACGCN ant — replaces the wiki-scraped
+                  placeholder; 2048 source committed and exported through the
+                  v0.9.2 pipeline
+                </li>
+              </ul>
+            </div>
+          </div>
+
+          <!-- v0.9.2-beta -->
+          <div class="tl-entry">
+            <div class="tl-date">May 5<br />2026</div>
+            <div class="tl-spine">
+              <div class="tl-dot"></div>
+              <div class="tl-line"></div>
+            </div>
+            <div class="tl-card">
+              <div class="tl-card-head">
+                <span class="version-badge">v0.9.2-beta</span>
+                <span class="version-title"
+                  >Cross-game icons + first hand-drawn pieces</span
+                >
+                <span class="velocity-chip">1 day after v0.9.1</span>
+              </div>
+              <ul class="tl-bullets">
+                <li>
+                  Cross-game icon routing — items shared across games (sea bass,
+                  koi, common butterfly) now share a single icon file rather
+                  than duplicating per game
+                </li>
+                <li>
+                  First two hand-drawn icons land — sea bass and koi — a preview
+                  of the long-term direction away from wiki-sourced art
+                </li>
+                <li>
+                  Bigger icons in the expand panel, up to 192px on wide screens,
+                  so the artwork has room to read
+                </li>
+                <li>
+                  New <code>npm run icons:export</code> pipeline turns 2048
+                  source paintings into optimized 512 deploy assets
+                </li>
+                <li>
+                  Polish: Mona Lisa expand-panel clipping fixed; iOS overscroll
+                  background no longer flashes the wrong colour
+                </li>
+              </ul>
+            </div>
+          </div>
+
+          <!-- v0.9.1-beta -->
+          <div class="tl-entry">
+            <div class="tl-date">May 4<br />2026</div>
+            <div class="tl-spine">
+              <div class="tl-dot"></div>
+              <div class="tl-line"></div>
+            </div>
+            <div class="tl-card">
+              <div class="tl-card-head">
+                <span class="version-badge">v0.9.1-beta</span>
+                <span class="version-title">ACGCN item icons</span>
+                <span class="velocity-chip">1 day after v0.9.0</span>
+              </div>
+              <ul class="tl-bullets">
+                <li>
+                  Animal Crossing (GameCube) item icons across fish, bugs,
+                  fossils, and art — 118 items, sourced from the AC Fandom Wiki
+                  under CC BY-SA 3.0
+                </li>
+                <li>
+                  Icons appear across category rows, expand panels, global
+                  search results, and home tab strips
+                </li>
+                <li>
+                  Future games light up automatically when their icon assets
+                  land — no code change required
+                </li>
+                <li>
+                  New /credits route documenting third-party asset sources and
+                  licensing
+                </li>
+                <li>
+                  Other games (ACWW, ACCF, ACNL, ACNH) keep the existing
+                  monogram fallback until their icon sets ship
+                </li>
+              </ul>
+            </div>
+          </div>
+
+          <!-- v0.9.0-beta -->
+          <div class="tl-entry">
+            <div class="tl-date">May 3<br />2026</div>
+            <div class="tl-spine">
+              <div class="tl-dot"></div>
+              <div class="tl-line"></div>
+            </div>
+            <div class="tl-card">
+              <div class="tl-card-head">
+                <span class="version-badge">v0.9.0-beta</span>
+                <span class="version-title">Curator UI revamp</span>
+                <span class="velocity-chip">2 days after v0.8.2</span>
+              </div>
+              <ul class="tl-bullets">
+                <li>
+                  Full Meadow design language — Fraunces + Inter type,
+                  moss-green accent, retired the old parchment palette
+                </li>
+                <li>
+                  New sidebar shell with per-category counts replaces the old
+                  top-nav header
+                </li>
+                <li>
+                  Unified TownManager drawer for create, switch, edit, and
+                  delete
+                </li>
+                <li>
+                  Settings page with About + Danger zone (reset active town's
+                  donations, reset everything)
+                </li>
+                <li>
+                  HomeTab rebuilt — hero stat, month strip, leaving-soon and
+                  just-arrived shelves, segmented progress meter
+                </li>
+                <li>
+                  CategoryTab sectioned into Leaving / Available / Out of season
+                  / Already donated
+                </li>
+                <li>
+                  Global search dropdown with category groups, keyboard
+                  navigation, and search history
+                </li>
+                <li>
+                  StatsTab redesigned — per-category cards and a yearly rhythm
+                  chart
+                </li>
+                <li>
+                  Art tab now uses the same inline expand panel as every other
+                  category
+                </li>
+                <li>
+                  Wild World + City Folk art data added; full mobile responsive
+                  pass
+                </li>
+              </ul>
+            </div>
+          </div>
+
+          <!-- v0.8.2-alpha -->
+          <div class="tl-entry">
+            <div class="tl-date">May 1<br />2026</div>
+            <div class="tl-spine">
+              <div class="tl-dot"></div>
+              <div class="tl-line"></div>
+            </div>
+            <div class="tl-card">
+              <div class="tl-card-head">
+                <span class="version-badge">v0.8.2-alpha</span>
+                <span class="version-title">Sea Creatures tab</span>
+                <span class="velocity-chip">1 day after v0.8.1</span>
+              </div>
+              <ul class="tl-bullets">
+                <li>
+                  Sea Creatures tab — 40-species set for ACNH and ACNL with the
+                  same expand-panel UX as Fish and Bugs
+                </li>
+                <li>
+                  Sea creatures included in the home tab progress grid, global
+                  search, and CSV export
+                </li>
+                <li>Detail modal now resets cleanly on tab change</li>
+              </ul>
+            </div>
+          </div>
+
+          <!-- v0.8.1-alpha -->
+          <div class="tl-entry">
+            <div class="tl-date">Apr 30<br />2026</div>
+            <div class="tl-spine">
+              <div class="tl-dot"></div>
+              <div class="tl-line"></div>
+            </div>
+            <div class="tl-card">
+              <div class="tl-card-head">
+                <span class="version-badge">v0.8.1-alpha</span>
+                <span class="version-title">Edit Town modal fix</span>
+                <span class="velocity-chip">1 day after v0.8.0</span>
+              </div>
+              <ul class="tl-bullets">
+                <li>Edit Town modal no longer dismisses immediately on open</li>
+                <li>
+                  Edit/new-town buttons greyed out on category tabs as a stopgap
+                  until the v0.9 layout revamp
+                </li>
+              </ul>
+            </div>
+          </div>
+
+          <!-- v0.8.0-alpha -->
+          <div class="tl-entry">
+            <div class="tl-date">Apr 29<br />2026</div>
+            <div class="tl-spine">
+              <div class="tl-dot"></div>
+              <div class="tl-line"></div>
+            </div>
+            <div class="tl-card">
+              <div class="tl-card-head">
+                <span class="version-badge">v0.8.0-alpha</span>
+                <span class="version-title"
+                  >Full game coverage + item details</span
+                >
+                <span class="velocity-chip">12 days after v0.7</span>
+              </div>
+              <ul class="tl-bullets">
+                <li>
+                  New Leaf data — 72 fish, 70 bugs, 72 fossils, 36 art, 35 sea
+                  creatures
+                </li>
+                <li>
+                  New Horizons data — 81 fish, 80 bugs, 86 fossils, 43 art, 40
+                  sea creatures with NH/SH hemisphere months
+                </li>
+                <li>
+                  All five games now fully selectable when creating a town
+                </li>
+                <li>
+                  Per-town hemisphere toggle for ACNH; month grids respect
+                  hemisphere
+                </li>
+                <li>
+                  Inline item details — fish, bugs, and fossils expand in place
+                  with month grid, sell value, habitat, and notes
+                </li>
+                <li>
+                  URL-based routing — every town and tab has a shareable URL;
+                  browser back/forward works
+                </li>
+              </ul>
+            </div>
+          </div>
+
+          <!-- v0.7.0-alpha -->
+          <div class="tl-entry">
+            <div class="tl-date">Apr 17<br />2026</div>
+            <div class="tl-spine">
+              <div class="tl-dot"></div>
+              <div class="tl-line"></div>
+            </div>
+            <div class="tl-card">
+              <div class="tl-card-head">
+                <span class="version-badge">v0.7.0-alpha</span>
+                <span class="version-title">Multi-game foundation</span>
+                <span class="velocity-chip">2 days after v0.6.1</span>
+              </div>
+              <ul class="tl-bullets">
+                <li>
+                  Multi-game foundation — donations now scoped per town and per
+                  game so a single user can track several games at once
+                </li>
+                <li>
+                  Wild World &amp; City Folk data added (40–56 fish, bugs; 52
+                  fossils each)
+                </li>
+                <li>
+                  Game selector when creating a town, with a visual card UI
+                </li>
+                <li>Edit/rename town</li>
+                <li>
+                  Major internal refactor — split the monolithic canvas
+                  component into composable modules
+                </li>
+                <li>
+                  Seasonal analytics bug fixed — was previously counting all
+                  donations as Spring
+                </li>
+              </ul>
+            </div>
+          </div>
+
+          <!-- v0.6.1 -->
+          <div class="tl-entry">
+            <div class="tl-date">Apr 15<br />2026</div>
+            <div class="tl-spine">
+              <div class="tl-dot hotfix"></div>
+              <div class="tl-line"></div>
+            </div>
+            <div class="tl-card hotfix">
+              <div class="tl-card-head">
+                <span class="version-badge hotfix">v0.6.1</span>
+                <span class="version-title">Hotfix</span>
+                <span class="velocity-chip fast">1 day after v0.6.0</span>
+              </div>
+              <ul class="tl-bullets">
+                <li>Restored main branch after a bad v0.6.0 merge</li>
+                <li>Home tab routing stability improvements</li>
+              </ul>
+            </div>
+          </div>
+
+          <!-- v0.6.0 -->
+          <div class="tl-entry">
+            <div class="tl-date">Apr 14<br />2026</div>
+            <div class="tl-spine">
+              <div class="tl-dot"></div>
+              <div class="tl-line"></div>
+            </div>
+            <div class="tl-card">
+              <div class="tl-card-head">
+                <span class="version-badge">v0.6.0</span>
+                <span class="version-title">Home screen</span>
+                <span class="velocity-chip fast">1 day after v0.5</span>
+              </div>
+              <ul class="tl-bullets">
+                <li>
+                  New Home tab — seasonal availability overview at a glance
+                </li>
+                <li>
+                  "Available this month" — fish &amp; bugs catchable right now
+                </li>
+                <li>"Leaving soon" — creatures departing at month's end</li>
+                <li>Progress overview cards for all four museum categories</li>
+                <li>Recent donation activity feed</li>
+              </ul>
+            </div>
+          </div>
+
+          <!-- v0.5.0 -->
+          <div class="tl-entry">
+            <div class="tl-date">Apr 13<br />2026</div>
+            <div class="tl-spine">
+              <div class="tl-dot"></div>
+              <div class="tl-line"></div>
+            </div>
+            <div class="tl-card">
+              <div class="tl-card-head">
+                <span class="version-badge">v0.5.0</span>
+                <span class="version-title">Polish &amp; observability</span>
+                <span class="velocity-chip fast">same day as v0.4</span>
+              </div>
+              <ul class="tl-bullets">
+                <li>CSV export — download donations as a spreadsheet</li>
+                <li>Error banner and full-page error state UI</li>
+                <li>Monthly availability chart for fish &amp; bugs</li>
+                <li>Vercel Analytics wired up</li>
+              </ul>
+            </div>
+          </div>
+
+          <!-- v0.4.0 -->
+          <div class="tl-entry">
+            <div class="tl-date">Apr 13<br />2026</div>
+            <div class="tl-spine">
+              <div class="tl-dot"></div>
+              <div class="tl-line"></div>
+            </div>
+            <div class="tl-card">
+              <div class="tl-card-head">
+                <span class="version-badge">v0.4.0</span>
+                <span class="version-title">Search &amp; stats</span>
+                <span class="velocity-chip fast">same day as v0.3</span>
+              </div>
+              <ul class="tl-bullets">
+                <li>
+                  Global search across all museum categories with history
+                  popover
+                </li>
+                <li>
+                  Stats tab — analytics dashboard, monthly timeline, seasonal
+                  breakdown
+                </li>
+              </ul>
+            </div>
+          </div>
+
+          <!-- v0.3.0 -->
+          <div class="tl-entry">
+            <div class="tl-date">Apr 13<br />2026</div>
+            <div class="tl-spine">
+              <div class="tl-dot"></div>
+              <div class="tl-line"></div>
+            </div>
+            <div class="tl-card">
+              <div class="tl-card-head">
+                <span class="version-badge">v0.3.0</span>
+                <span class="version-title">Multi-town</span>
+                <span class="velocity-chip fast">1 day after v0.2</span>
+              </div>
+              <ul class="tl-bullets">
+                <li>Create and switch between multiple towns</li>
+                <li>Town switcher in header + Create Town modal</li>
+                <li>Per-town activity feed</li>
+              </ul>
+            </div>
+          </div>
+
+          <!-- v0.2.0 -->
+          <div class="tl-entry">
+            <div class="tl-date">Apr 12<br />2026</div>
+            <div class="tl-spine">
+              <div class="tl-dot"></div>
+              <div class="tl-line"></div>
+            </div>
+            <div class="tl-card">
+              <div class="tl-card-head">
+                <span class="version-badge">v0.2.0</span>
+                <span class="version-title">Detail &amp; search</span>
+                <span class="velocity-chip fast">2 days after v0.1</span>
+              </div>
+              <ul class="tl-bullets">
+                <li>Item detail modal</li>
+                <li>Per-category search &amp; filter</li>
+                <li>Donation timestamps</li>
+              </ul>
+            </div>
+          </div>
+
+          <!-- v0.1.0 -->
+          <div class="tl-entry">
+            <div class="tl-date">Apr 10<br />2026</div>
+            <div class="tl-spine">
+              <div class="tl-dot"></div>
+              <div class="tl-line" style="display: none"></div>
+            </div>
+            <div class="tl-card">
+              <div class="tl-card-head">
+                <span class="version-badge">v0.1.0</span>
+                <span class="version-title">Initial release</span>
+              </div>
+              <ul class="tl-bullets">
+                <li>
+                  Basic museum donation tracking (Fish, Bugs, Fossils, Art)
+                </li>
+                <li>Cozy parchment/GameCube aesthetic</li>
+                <li>40 fish · 40 bugs · 25 fossils · 13 art pieces</li>
+              </ul>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <!-- Currently building -->
+      <section>
+        <h2>Currently building — v1.0</h2>
+        <div class="building-card">
+          <div class="building-head">
+            <span class="building-badge">UP NEXT</span>
+            <h3>Launch ready</h3>
+            <span class="building-note">polish, PWA, accessibility</span>
+          </div>
+
+          <p class="checklist-section">Recently shipped (v0.9.4-beta)</p>
+          <div class="checklist">
+            <div class="check-item done">
+              <div class="box">✓</div>
+              <span class="text"
+                >Silhouette rendering for un-donated items — black silhouettes
+                fade to full colour on donation; Settings toggle (default ON);
+                honors prefers-reduced-motion</span
+              >
+            </div>
+            <div class="check-item done">
+              <div class="box">✓</div>
+              <span class="text"
+                >ACWW icon coverage at 100% — 84 wiki-scraped items; ACCF 95.5%,
+                ACNL 49.1%, ACNH 39.1% via cross-game ID routing</span
+              >
+            </div>
+            <div class="check-item done">
+              <div class="box">✓</div>
+              <span class="text"
+                >JSON save-file export + import — portable round-trip backup
+                with Replace / Merge / Import-as-new modes</span
+              >
+            </div>
+            <div class="check-item done">
+              <div class="box">✓</div>
+              <span class="text"
+                >ACGCN item icons + cross-game routing + four hand-drawn icons
+                (sea-bass, koi, ant, coelacanth)</span
+              >
+            </div>
+            <div class="check-item done">
+              <div class="box">✓</div>
+              <span class="text"
+                >v0.9.0-beta Meadow UI revamp — Sidebar, TownManager, sectioned
+                CategoryTab, mobile responsive</span
+              >
+            </div>
+          </div>
+
+          <p class="checklist-section">Planned</p>
+          <div class="checklist">
+            <div class="check-item todo">
+              <div class="box">·</div>
+              <span class="text">PWA support — install to home screen</span>
+            </div>
+            <div class="check-item todo">
+              <div class="box">·</div>
+              <span class="text"
+                >First-run onboarding / empty state improvements</span
+              >
+            </div>
+            <div class="check-item todo">
+              <div class="box">·</div>
+              <span class="text"
+                >Full accessibility audit — keyboard nav, ARIA, focus
+                rings</span
+              >
+            </div>
+            <div class="check-item todo">
+              <div class="box">·</div>
+              <span class="text"
+                >SEO + Open Graph metadata; performance pass</span
+              >
+            </div>
+            <div class="check-item todo">
+              <div class="box">·</div>
+              <span class="text"
+                >Branding &amp; identity polish — drop the alpha/beta
+                label</span
+              >
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <!-- Roadmap lanes -->
+      <section>
+        <h2>Roadmap</h2>
+        <div class="lanes">
+          <div class="lane v09">
+            <div class="lane-head">
+              <span class="lane-badge">v0.9</span>
+              <span class="lane-title">Polish &amp; PWA</span>
+            </div>
+            <ul class="lane-items">
+              <li>UI redesign pass — cozy-er, more expressive</li>
+              <li>PWA support — install to home screen</li>
+              <li>Mobile-first responsive layout</li>
+              <li>First-run onboarding / empty states</li>
+              <li>Improved accessibility (keyboard nav, focus rings)</li>
+            </ul>
+          </div>
+
+          <div class="lane v10">
+            <div class="lane-head">
+              <span class="lane-badge">v1.0</span>
+              <span class="lane-title">Launch ready</span>
+            </div>
+            <ul class="lane-items">
+              <li>Branding &amp; identity polish</li>
+              <li>SEO metadata + Open Graph</li>
+              <li>Full accessibility audit (WCAG)</li>
+              <li>Performance pass — Lighthouse green</li>
+              <li>Stable release — remove alpha label</li>
+            </ul>
+          </div>
+
+          <div class="lane vpost">
+            <div class="lane-head">
+              <span class="lane-badge">Post-1.0</span>
+              <span class="lane-title">What's next</span>
+            </div>
+            <ul class="lane-items">
+              <li>Cloud sync / account support</li>
+              <li>Share town progress with friends</li>
+              <li>New Horizons critterpedia features</li>
+              <li>Price guide &amp; art authenticity tracker</li>
+              <li>Seasonal event calendar</li>
+            </ul>
+          </div>
+        </div>
+      </section>
+
+      <!-- Velocity detail -->
+      <section>
+        <h2>Velocity detail</h2>
+        <div
+          style="
+            background: #fff;
+            border: 1px solid var(--border);
+            border-radius: 12px;
+            overflow: hidden;
+          "
+        >
+          <table
+            style="width: 100%; border-collapse: collapse; font-size: 0.85rem"
+          >
+            <thead>
+              <tr style="background: var(--paper)">
+                <th
+                  style="
+                    padding: 0.65rem 1rem;
+                    text-align: left;
+                    color: var(--muted);
+                    font-weight: normal;
+                  "
+                >
+                  Release
+                </th>
+                <th
+                  style="
+                    padding: 0.65rem 1rem;
+                    text-align: left;
+                    color: var(--muted);
+                    font-weight: normal;
+                  "
+                >
+                  Date
+                </th>
+                <th
+                  style="
+                    padding: 0.65rem 1rem;
+                    text-align: left;
+                    color: var(--muted);
+                    font-weight: normal;
+                  "
+                >
+                  Days since last
+                </th>
+                <th
+                  style="
+                    padding: 0.65rem 1rem;
+                    text-align: left;
+                    color: var(--muted);
+                    font-weight: normal;
+                  "
+                >
+                  Highlight
+                </th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr style="border-top: 1px solid var(--border)">
+                <td
+                  style="
+                    padding: 0.6rem 1rem;
+                    color: var(--leaf);
+                    font-weight: bold;
+                  "
+                >
+                  v0.1.0
+                </td>
+                <td style="padding: 0.6rem 1rem">Apr 10</td>
+                <td style="padding: 0.6rem 1rem">—</td>
+                <td style="padding: 0.6rem 1rem">First commit → live app</td>
+              </tr>
+              <tr
+                style="border-top: 1px solid var(--border); background: #fafafa"
+              >
+                <td
+                  style="
+                    padding: 0.6rem 1rem;
+                    color: var(--leaf);
+                    font-weight: bold;
+                  "
+                >
+                  v0.2.0
+                </td>
+                <td style="padding: 0.6rem 1rem">Apr 12</td>
+                <td style="padding: 0.6rem 1rem">2 days</td>
+                <td style="padding: 0.6rem 1rem">
+                  Detail modal + donation timestamps
+                </td>
+              </tr>
+              <tr style="border-top: 1px solid var(--border)">
+                <td
+                  style="
+                    padding: 0.6rem 1rem;
+                    color: var(--leaf);
+                    font-weight: bold;
+                  "
+                >
+                  v0.3.0
+                </td>
+                <td style="padding: 0.6rem 1rem">Apr 13</td>
+                <td style="padding: 0.6rem 1rem">1 day</td>
+                <td style="padding: 0.6rem 1rem">Multi-town support</td>
+              </tr>
+              <tr
+                style="border-top: 1px solid var(--border); background: #fafafa"
+              >
+                <td
+                  style="
+                    padding: 0.6rem 1rem;
+                    color: var(--leaf);
+                    font-weight: bold;
+                  "
+                >
+                  v0.4.0
+                </td>
+                <td style="padding: 0.6rem 1rem">Apr 13</td>
+                <td style="padding: 0.6rem 1rem">&lt;1 day</td>
+                <td style="padding: 0.6rem 1rem">Global search + stats tab</td>
+              </tr>
+              <tr style="border-top: 1px solid var(--border)">
+                <td
+                  style="
+                    padding: 0.6rem 1rem;
+                    color: var(--leaf);
+                    font-weight: bold;
+                  "
+                >
+                  v0.5.0
+                </td>
+                <td style="padding: 0.6rem 1rem">Apr 13</td>
+                <td style="padding: 0.6rem 1rem">&lt;1 day</td>
+                <td style="padding: 0.6rem 1rem">
+                  CSV export + error UI + analytics
+                </td>
+              </tr>
+              <tr
+                style="border-top: 1px solid var(--border); background: #fafafa"
+              >
+                <td
+                  style="
+                    padding: 0.6rem 1rem;
+                    color: var(--leaf);
+                    font-weight: bold;
+                  "
+                >
+                  v0.6.0
+                </td>
+                <td style="padding: 0.6rem 1rem">Apr 14</td>
+                <td style="padding: 0.6rem 1rem">1 day</td>
+                <td style="padding: 0.6rem 1rem">Home screen tab</td>
+              </tr>
+              <tr style="border-top: 1px solid var(--border)">
+                <td
+                  style="
+                    padding: 0.6rem 1rem;
+                    color: var(--gold);
+                    font-weight: bold;
+                  "
+                >
+                  v0.6.1
+                </td>
+                <td style="padding: 0.6rem 1rem">Apr 15</td>
+                <td style="padding: 0.6rem 1rem">1 day</td>
+                <td style="padding: 0.6rem 1rem">
+                  Hotfix — main branch restored
+                </td>
+              </tr>
+              <tr
+                style="border-top: 1px solid var(--border); background: #fafafa"
+              >
+                <td
+                  style="
+                    padding: 0.6rem 1rem;
+                    color: var(--leaf);
+                    font-weight: bold;
+                  "
+                >
+                  v0.7.0-alpha
+                </td>
+                <td style="padding: 0.6rem 1rem">Apr 17</td>
+                <td style="padding: 0.6rem 1rem">2 days</td>
+                <td style="padding: 0.6rem 1rem">
+                  Multi-game foundation — largest refactor yet
+                </td>
+              </tr>
+              <tr style="border-top: 1px solid var(--border)">
+                <td
+                  style="
+                    padding: 0.6rem 1rem;
+                    color: var(--leaf);
+                    font-weight: bold;
+                  "
+                >
+                  v0.8.0-alpha
+                </td>
+                <td style="padding: 0.6rem 1rem">Apr 29</td>
+                <td style="padding: 0.6rem 1rem">12 days</td>
+                <td style="padding: 0.6rem 1rem">
+                  Full game coverage — ACNL + ACNH, 1,000+ items, inline
+                  details, URL routing
+                </td>
+              </tr>
+              <tr
+                style="border-top: 1px solid var(--border); background: #fafafa"
+              >
+                <td
+                  style="
+                    padding: 0.6rem 1rem;
+                    color: var(--leaf);
+                    font-weight: bold;
+                  "
+                >
+                  v0.8.1-alpha
+                </td>
+                <td style="padding: 0.6rem 1rem">Apr 30</td>
+                <td style="padding: 0.6rem 1rem">1 day</td>
+                <td style="padding: 0.6rem 1rem">Edit Town modal fix</td>
+              </tr>
+              <tr style="border-top: 1px solid var(--border)">
+                <td
+                  style="
+                    padding: 0.6rem 1rem;
+                    color: var(--leaf);
+                    font-weight: bold;
+                  "
+                >
+                  v0.8.2-alpha
+                </td>
+                <td style="padding: 0.6rem 1rem">May 1</td>
+                <td style="padding: 0.6rem 1rem">1 day</td>
+                <td style="padding: 0.6rem 1rem">
+                  Sea Creatures tab (ACNH + ACNL)
+                </td>
+              </tr>
+              <tr
+                style="border-top: 1px solid var(--border); background: #fafafa"
+              >
+                <td
+                  style="
+                    padding: 0.6rem 1rem;
+                    color: var(--leaf);
+                    font-weight: bold;
+                  "
+                >
+                  v0.9.0-beta
+                </td>
+                <td style="padding: 0.6rem 1rem">May 3</td>
+                <td style="padding: 0.6rem 1rem">2 days</td>
+                <td style="padding: 0.6rem 1rem">
+                  Curator UI revamp — Meadow design, Sidebar, TownManager,
+                  sectioned categories
+                </td>
+              </tr>
+              <tr style="border-top: 1px solid var(--border)">
+                <td
+                  style="
+                    padding: 0.6rem 1rem;
+                    color: var(--leaf);
+                    font-weight: bold;
+                  "
+                >
+                  v0.9.1-beta
+                </td>
+                <td style="padding: 0.6rem 1rem">May 4</td>
+                <td style="padding: 0.6rem 1rem">1 day</td>
+                <td style="padding: 0.6rem 1rem">
+                  ACGCN item icons + /credits route + MIT LICENSE/NOTICE
+                </td>
+              </tr>
+              <tr style="border-top: 1px solid var(--border)">
+                <td
+                  style="
+                    padding: 0.6rem 1rem;
+                    color: var(--leaf);
+                    font-weight: bold;
+                  "
+                >
+                  v0.9.2-beta
+                </td>
+                <td style="padding: 0.6rem 1rem">May 5</td>
+                <td style="padding: 0.6rem 1rem">1 day</td>
+                <td style="padding: 0.6rem 1rem">
+                  Cross-game icon routing + first hand-drawn icons + bigger
+                  sizes
+                </td>
+              </tr>
+              <tr style="border-top: 1px solid var(--border)">
+                <td
+                  style="
+                    padding: 0.6rem 1rem;
+                    color: var(--leaf);
+                    font-weight: bold;
+                  "
+                >
+                  v0.9.3-beta
+                </td>
+                <td style="padding: 0.6rem 1rem">May 6</td>
+                <td style="padding: 0.6rem 1rem">1 day</td>
+                <td style="padding: 0.6rem 1rem">
+                  JSON save-file export + import + onboarding fixes + ant icon
+                </td>
+              </tr>
+              <tr
+                style="border-top: 1px solid var(--border); background: #fafafa"
+              >
+                <td
+                  style="
+                    padding: 0.6rem 1rem;
+                    color: var(--leaf);
+                    font-weight: bold;
+                  "
+                >
+                  v0.9.4-beta
+                </td>
+                <td style="padding: 0.6rem 1rem">May 7</td>
+                <td style="padding: 0.6rem 1rem">1 day</td>
+                <td style="padding: 0.6rem 1rem">
+                  Silhouette rendering + ACWW icon gap-fill (100%) + 768px
+                  pipeline + coelacanth
+                </td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      </section>
+
+      <footer>
+        <p>
+          <a href="https://animalcrossingwebapp.vercel.app"
+            >animalcrossingwebapp.vercel.app</a
+          >
+          · v0.9.4-beta shipped · v1.0 next · Dev preview at
+          <a href="https://development-animalcrossingwebapp.vercel.app"
+            >development-animalcrossingwebapp.vercel.app</a
+          >
+        </p>
+      </footer>
     </div>
-    <div class="vel-stats">
-      <div class="vel-stat">
-        <div class="num">16</div>
-        <div class="label">releases shipped</div>
-      </div>
-      <div class="vel-stat">
-        <div class="num">29</div>
-        <div class="label">days elapsed</div>
-      </div>
-      <div class="vel-stat">
-        <div class="num">5</div>
-        <div class="label">games supported</div>
-      </div>
-      <div class="vel-stat">
-        <div class="num">1,000+</div>
-        <div class="label">items catalogued</div>
-      </div>
-    </div>
-  </div>
-
-  <!-- Shipped timeline -->
-  <section>
-    <h2>Shipped versions</h2>
-    <div class="timeline">
-
-      <!-- v0.9.4-beta -->
-      <div class="tl-entry">
-        <div class="tl-date">May 7<br/>2026</div>
-        <div class="tl-spine">
-          <div class="tl-dot"></div>
-          <div class="tl-line"></div>
-        </div>
-        <div class="tl-card">
-          <div class="tl-card-head">
-            <span class="version-badge">v0.9.4-beta</span>
-            <span class="version-title">Silhouette museum + ACWW icon gap-fill</span>
-            <span class="velocity-chip">1 day after v0.9.3</span>
-          </div>
-          <ul class="tl-bullets">
-            <li>Silhouette rendering for un-donated items — un-donated species render as black silhouettes that fade to full color on donation, faithful to the canonical Animal Crossing museum experience (closes #116)</li>
-            <li>New "Museum display" section in Settings exposes a single global toggle (default ON); 300ms reveal animation honors <code>prefers-reduced-motion</code>; screen readers hear species + donation state</li>
-            <li>ACWW icon gap-fill — 84 wiki-scraped items added (21 fish + 27 bugs + 27 fossils + 9 art); ACWW icon coverage now at 100%</li>
-            <li>Cross-game ID matching uplift carries through to ACCF (95.5%), ACNL (49.1%), and ACNH (39.1%) — partial free coverage for the upcoming v0.9.5 / v0.9.6 betas</li>
-            <li>Icon export pipeline's <code>TARGET_SIZE</code> bumped 512 → 768; all four hand-drawn pieces (ant, koi, sea-bass, coelacanth) re-exported at the higher resolution</li>
-            <li>Coelacanth is the fourth hand-drawn icon in the library (after sea-bass, koi, and ant)</li>
-          </ul>
-        </div>
-      </div>
-
-      <!-- v0.9.3-beta -->
-      <div class="tl-entry">
-        <div class="tl-date">May 6<br/>2026</div>
-        <div class="tl-spine">
-          <div class="tl-dot"></div>
-          <div class="tl-line"></div>
-        </div>
-        <div class="tl-card">
-          <div class="tl-card-head">
-            <span class="version-badge">v0.9.3-beta</span>
-            <span class="version-title">Save-file round trip + onboarding fixes</span>
-            <span class="velocity-chip">1 day after v0.9.2</span>
-          </div>
-          <ul class="tl-bullets">
-            <li>JSON save-file export — new <code>Export save</code> button writes a versioned, lossless <code>ac-save-&lt;town&gt;-&lt;date&gt;.json</code> snapshot of one town and its donations</li>
-            <li>JSON save-file import — round-trip companion with Replace / Merge / Import-as-new modes, <code>(name, gameId)</code> matching, and a heavy two-step confirmation when Replace would overwrite existing donations</li>
-            <li>Sidebar foot now has two distinct buttons: <code>Export save</code> (the new JSON) and <code>Download report</code> (the existing human-readable CSV, unchanged)</li>
-            <li>Onboarding fix: <code>Import save instead</code> link is visible in the empty-state TownManager so a fresh-device user can restore from a save file without first creating a placeholder town (closes #107)</li>
-            <li>Third hand-drawn icon — ACGCN ant — replaces the wiki-scraped placeholder; 2048 source committed and exported through the v0.9.2 pipeline</li>
-          </ul>
-        </div>
-      </div>
-
-      <!-- v0.9.2-beta -->
-      <div class="tl-entry">
-        <div class="tl-date">May 5<br/>2026</div>
-        <div class="tl-spine">
-          <div class="tl-dot"></div>
-          <div class="tl-line"></div>
-        </div>
-        <div class="tl-card">
-          <div class="tl-card-head">
-            <span class="version-badge">v0.9.2-beta</span>
-            <span class="version-title">Cross-game icons + first hand-drawn pieces</span>
-            <span class="velocity-chip">1 day after v0.9.1</span>
-          </div>
-          <ul class="tl-bullets">
-            <li>Cross-game icon routing — items shared across games (sea bass, koi, common butterfly) now share a single icon file rather than duplicating per game</li>
-            <li>First two hand-drawn icons land — sea bass and koi — a preview of the long-term direction away from wiki-sourced art</li>
-            <li>Bigger icons in the expand panel, up to 192px on wide screens, so the artwork has room to read</li>
-            <li>New <code>npm run icons:export</code> pipeline turns 2048 source paintings into optimized 512 deploy assets</li>
-            <li>Polish: Mona Lisa expand-panel clipping fixed; iOS overscroll background no longer flashes the wrong colour</li>
-          </ul>
-        </div>
-      </div>
-
-      <!-- v0.9.1-beta -->
-      <div class="tl-entry">
-        <div class="tl-date">May 4<br/>2026</div>
-        <div class="tl-spine">
-          <div class="tl-dot"></div>
-          <div class="tl-line"></div>
-        </div>
-        <div class="tl-card">
-          <div class="tl-card-head">
-            <span class="version-badge">v0.9.1-beta</span>
-            <span class="version-title">ACGCN item icons</span>
-            <span class="velocity-chip">1 day after v0.9.0</span>
-          </div>
-          <ul class="tl-bullets">
-            <li>Animal Crossing (GameCube) item icons across fish, bugs, fossils, and art — 118 items, sourced from the AC Fandom Wiki under CC BY-SA 3.0</li>
-            <li>Icons appear across category rows, expand panels, global search results, and home tab strips</li>
-            <li>Future games light up automatically when their icon assets land — no code change required</li>
-            <li>New /credits route documenting third-party asset sources and licensing</li>
-            <li>Other games (ACWW, ACCF, ACNL, ACNH) keep the existing monogram fallback until their icon sets ship</li>
-          </ul>
-        </div>
-      </div>
-
-      <!-- v0.9.0-beta -->
-      <div class="tl-entry">
-        <div class="tl-date">May 3<br/>2026</div>
-        <div class="tl-spine">
-          <div class="tl-dot"></div>
-          <div class="tl-line"></div>
-        </div>
-        <div class="tl-card">
-          <div class="tl-card-head">
-            <span class="version-badge">v0.9.0-beta</span>
-            <span class="version-title">Curator UI revamp</span>
-            <span class="velocity-chip">2 days after v0.8.2</span>
-          </div>
-          <ul class="tl-bullets">
-            <li>Full Meadow design language — Fraunces + Inter type, moss-green accent, retired the old parchment palette</li>
-            <li>New sidebar shell with per-category counts replaces the old top-nav header</li>
-            <li>Unified TownManager drawer for create, switch, edit, and delete</li>
-            <li>Settings page with About + Danger zone (reset active town's donations, reset everything)</li>
-            <li>HomeTab rebuilt — hero stat, month strip, leaving-soon and just-arrived shelves, segmented progress meter</li>
-            <li>CategoryTab sectioned into Leaving / Available / Out of season / Already donated</li>
-            <li>Global search dropdown with category groups, keyboard navigation, and search history</li>
-            <li>StatsTab redesigned — per-category cards and a yearly rhythm chart</li>
-            <li>Art tab now uses the same inline expand panel as every other category</li>
-            <li>Wild World + City Folk art data added; full mobile responsive pass</li>
-          </ul>
-        </div>
-      </div>
-
-      <!-- v0.8.2-alpha -->
-      <div class="tl-entry">
-        <div class="tl-date">May 1<br/>2026</div>
-        <div class="tl-spine">
-          <div class="tl-dot"></div>
-          <div class="tl-line"></div>
-        </div>
-        <div class="tl-card">
-          <div class="tl-card-head">
-            <span class="version-badge">v0.8.2-alpha</span>
-            <span class="version-title">Sea Creatures tab</span>
-            <span class="velocity-chip">1 day after v0.8.1</span>
-          </div>
-          <ul class="tl-bullets">
-            <li>Sea Creatures tab — 40-species set for ACNH and ACNL with the same expand-panel UX as Fish and Bugs</li>
-            <li>Sea creatures included in the home tab progress grid, global search, and CSV export</li>
-            <li>Detail modal now resets cleanly on tab change</li>
-          </ul>
-        </div>
-      </div>
-
-      <!-- v0.8.1-alpha -->
-      <div class="tl-entry">
-        <div class="tl-date">Apr 30<br/>2026</div>
-        <div class="tl-spine">
-          <div class="tl-dot"></div>
-          <div class="tl-line"></div>
-        </div>
-        <div class="tl-card">
-          <div class="tl-card-head">
-            <span class="version-badge">v0.8.1-alpha</span>
-            <span class="version-title">Edit Town modal fix</span>
-            <span class="velocity-chip">1 day after v0.8.0</span>
-          </div>
-          <ul class="tl-bullets">
-            <li>Edit Town modal no longer dismisses immediately on open</li>
-            <li>Edit/new-town buttons greyed out on category tabs as a stopgap until the v0.9 layout revamp</li>
-          </ul>
-        </div>
-      </div>
-
-      <!-- v0.8.0-alpha -->
-      <div class="tl-entry">
-        <div class="tl-date">Apr 29<br/>2026</div>
-        <div class="tl-spine">
-          <div class="tl-dot"></div>
-          <div class="tl-line"></div>
-        </div>
-        <div class="tl-card">
-          <div class="tl-card-head">
-            <span class="version-badge">v0.8.0-alpha</span>
-            <span class="version-title">Full game coverage + item details</span>
-            <span class="velocity-chip">12 days after v0.7</span>
-          </div>
-          <ul class="tl-bullets">
-            <li>New Leaf data — 72 fish, 70 bugs, 72 fossils, 36 art, 35 sea creatures</li>
-            <li>New Horizons data — 81 fish, 80 bugs, 86 fossils, 43 art, 40 sea creatures with NH/SH hemisphere months</li>
-            <li>All five games now fully selectable when creating a town</li>
-            <li>Per-town hemisphere toggle for ACNH; month grids respect hemisphere</li>
-            <li>Inline item details — fish, bugs, and fossils expand in place with month grid, sell value, habitat, and notes</li>
-            <li>URL-based routing — every town and tab has a shareable URL; browser back/forward works</li>
-          </ul>
-        </div>
-      </div>
-
-      <!-- v0.7.0-alpha -->
-      <div class="tl-entry">
-        <div class="tl-date">Apr 17<br/>2026</div>
-        <div class="tl-spine">
-          <div class="tl-dot"></div>
-          <div class="tl-line"></div>
-        </div>
-        <div class="tl-card">
-          <div class="tl-card-head">
-            <span class="version-badge">v0.7.0-alpha</span>
-            <span class="version-title">Multi-game foundation</span>
-            <span class="velocity-chip">2 days after v0.6.1</span>
-          </div>
-          <ul class="tl-bullets">
-            <li>Multi-game foundation — donations now scoped per town and per game so a single user can track several games at once</li>
-            <li>Wild World &amp; City Folk data added (40–56 fish, bugs; 52 fossils each)</li>
-            <li>Game selector when creating a town, with a visual card UI</li>
-            <li>Edit/rename town</li>
-            <li>Major internal refactor — split the monolithic canvas component into composable modules</li>
-            <li>Seasonal analytics bug fixed — was previously counting all donations as Spring</li>
-          </ul>
-        </div>
-      </div>
-
-      <!-- v0.6.1 -->
-      <div class="tl-entry">
-        <div class="tl-date">Apr 15<br/>2026</div>
-        <div class="tl-spine">
-          <div class="tl-dot hotfix"></div>
-          <div class="tl-line"></div>
-        </div>
-        <div class="tl-card hotfix">
-          <div class="tl-card-head">
-            <span class="version-badge hotfix">v0.6.1</span>
-            <span class="version-title">Hotfix</span>
-            <span class="velocity-chip fast">1 day after v0.6.0</span>
-          </div>
-          <ul class="tl-bullets">
-            <li>Restored main branch after a bad v0.6.0 merge</li>
-            <li>Home tab routing stability improvements</li>
-          </ul>
-        </div>
-      </div>
-
-      <!-- v0.6.0 -->
-      <div class="tl-entry">
-        <div class="tl-date">Apr 14<br/>2026</div>
-        <div class="tl-spine">
-          <div class="tl-dot"></div>
-          <div class="tl-line"></div>
-        </div>
-        <div class="tl-card">
-          <div class="tl-card-head">
-            <span class="version-badge">v0.6.0</span>
-            <span class="version-title">Home screen</span>
-            <span class="velocity-chip fast">1 day after v0.5</span>
-          </div>
-          <ul class="tl-bullets">
-            <li>New Home tab — seasonal availability overview at a glance</li>
-            <li>"Available this month" — fish &amp; bugs catchable right now</li>
-            <li>"Leaving soon" — creatures departing at month's end</li>
-            <li>Progress overview cards for all four museum categories</li>
-            <li>Recent donation activity feed</li>
-          </ul>
-        </div>
-      </div>
-
-      <!-- v0.5.0 -->
-      <div class="tl-entry">
-        <div class="tl-date">Apr 13<br/>2026</div>
-        <div class="tl-spine">
-          <div class="tl-dot"></div>
-          <div class="tl-line"></div>
-        </div>
-        <div class="tl-card">
-          <div class="tl-card-head">
-            <span class="version-badge">v0.5.0</span>
-            <span class="version-title">Polish &amp; observability</span>
-            <span class="velocity-chip fast">same day as v0.4</span>
-          </div>
-          <ul class="tl-bullets">
-            <li>CSV export — download donations as a spreadsheet</li>
-            <li>Error banner and full-page error state UI</li>
-            <li>Monthly availability chart for fish &amp; bugs</li>
-            <li>Vercel Analytics wired up</li>
-          </ul>
-        </div>
-      </div>
-
-      <!-- v0.4.0 -->
-      <div class="tl-entry">
-        <div class="tl-date">Apr 13<br/>2026</div>
-        <div class="tl-spine">
-          <div class="tl-dot"></div>
-          <div class="tl-line"></div>
-        </div>
-        <div class="tl-card">
-          <div class="tl-card-head">
-            <span class="version-badge">v0.4.0</span>
-            <span class="version-title">Search &amp; stats</span>
-            <span class="velocity-chip fast">same day as v0.3</span>
-          </div>
-          <ul class="tl-bullets">
-            <li>Global search across all museum categories with history popover</li>
-            <li>Stats tab — analytics dashboard, monthly timeline, seasonal breakdown</li>
-          </ul>
-        </div>
-      </div>
-
-      <!-- v0.3.0 -->
-      <div class="tl-entry">
-        <div class="tl-date">Apr 13<br/>2026</div>
-        <div class="tl-spine">
-          <div class="tl-dot"></div>
-          <div class="tl-line"></div>
-        </div>
-        <div class="tl-card">
-          <div class="tl-card-head">
-            <span class="version-badge">v0.3.0</span>
-            <span class="version-title">Multi-town</span>
-            <span class="velocity-chip fast">1 day after v0.2</span>
-          </div>
-          <ul class="tl-bullets">
-            <li>Create and switch between multiple towns</li>
-            <li>Town switcher in header + Create Town modal</li>
-            <li>Per-town activity feed</li>
-          </ul>
-        </div>
-      </div>
-
-      <!-- v0.2.0 -->
-      <div class="tl-entry">
-        <div class="tl-date">Apr 12<br/>2026</div>
-        <div class="tl-spine">
-          <div class="tl-dot"></div>
-          <div class="tl-line"></div>
-        </div>
-        <div class="tl-card">
-          <div class="tl-card-head">
-            <span class="version-badge">v0.2.0</span>
-            <span class="version-title">Detail &amp; search</span>
-            <span class="velocity-chip fast">2 days after v0.1</span>
-          </div>
-          <ul class="tl-bullets">
-            <li>Item detail modal</li>
-            <li>Per-category search &amp; filter</li>
-            <li>Donation timestamps</li>
-          </ul>
-        </div>
-      </div>
-
-      <!-- v0.1.0 -->
-      <div class="tl-entry">
-        <div class="tl-date">Apr 10<br/>2026</div>
-        <div class="tl-spine">
-          <div class="tl-dot"></div>
-          <div class="tl-line" style="display:none"></div>
-        </div>
-        <div class="tl-card">
-          <div class="tl-card-head">
-            <span class="version-badge">v0.1.0</span>
-            <span class="version-title">Initial release</span>
-          </div>
-          <ul class="tl-bullets">
-            <li>Basic museum donation tracking (Fish, Bugs, Fossils, Art)</li>
-            <li>Cozy parchment/GameCube aesthetic</li>
-            <li>40 fish · 40 bugs · 25 fossils · 13 art pieces</li>
-          </ul>
-        </div>
-      </div>
-
-    </div>
-  </section>
-
-  <!-- Currently building -->
-  <section>
-    <h2>Currently building — v1.0</h2>
-    <div class="building-card">
-      <div class="building-head">
-        <span class="building-badge">UP NEXT</span>
-        <h3>Launch ready</h3>
-        <span class="building-note">polish, PWA, accessibility</span>
-      </div>
-
-      <p class="checklist-section">Recently shipped (v0.9.4-beta)</p>
-      <div class="checklist">
-        <div class="check-item done">
-          <div class="box">✓</div>
-          <span class="text">Silhouette rendering for un-donated items — black silhouettes fade to full colour on donation; Settings toggle (default ON); honors prefers-reduced-motion</span>
-        </div>
-        <div class="check-item done">
-          <div class="box">✓</div>
-          <span class="text">ACWW icon coverage at 100% — 84 wiki-scraped items; ACCF 95.5%, ACNL 49.1%, ACNH 39.1% via cross-game ID routing</span>
-        </div>
-        <div class="check-item done">
-          <div class="box">✓</div>
-          <span class="text">JSON save-file export + import — portable round-trip backup with Replace / Merge / Import-as-new modes</span>
-        </div>
-        <div class="check-item done">
-          <div class="box">✓</div>
-          <span class="text">ACGCN item icons + cross-game routing + four hand-drawn icons (sea-bass, koi, ant, coelacanth)</span>
-        </div>
-        <div class="check-item done">
-          <div class="box">✓</div>
-          <span class="text">v0.9.0-beta Meadow UI revamp — Sidebar, TownManager, sectioned CategoryTab, mobile responsive</span>
-        </div>
-      </div>
-
-      <p class="checklist-section">Planned</p>
-      <div class="checklist">
-        <div class="check-item todo">
-          <div class="box">·</div>
-          <span class="text">PWA support — install to home screen</span>
-        </div>
-        <div class="check-item todo">
-          <div class="box">·</div>
-          <span class="text">First-run onboarding / empty state improvements</span>
-        </div>
-        <div class="check-item todo">
-          <div class="box">·</div>
-          <span class="text">Full accessibility audit — keyboard nav, ARIA, focus rings</span>
-        </div>
-        <div class="check-item todo">
-          <div class="box">·</div>
-          <span class="text">SEO + Open Graph metadata; performance pass</span>
-        </div>
-        <div class="check-item todo">
-          <div class="box">·</div>
-          <span class="text">Branding &amp; identity polish — drop the alpha/beta label</span>
-        </div>
-      </div>
-    </div>
-  </section>
-
-  <!-- Roadmap lanes -->
-  <section>
-    <h2>Roadmap</h2>
-    <div class="lanes">
-
-      <div class="lane v09">
-        <div class="lane-head">
-          <span class="lane-badge">v0.9</span>
-          <span class="lane-title">Polish &amp; PWA</span>
-        </div>
-        <ul class="lane-items">
-          <li>UI redesign pass — cozy-er, more expressive</li>
-          <li>PWA support — install to home screen</li>
-          <li>Mobile-first responsive layout</li>
-          <li>First-run onboarding / empty states</li>
-          <li>Improved accessibility (keyboard nav, focus rings)</li>
-        </ul>
-      </div>
-
-      <div class="lane v10">
-        <div class="lane-head">
-          <span class="lane-badge">v1.0</span>
-          <span class="lane-title">Launch ready</span>
-        </div>
-        <ul class="lane-items">
-          <li>Branding &amp; identity polish</li>
-          <li>SEO metadata + Open Graph</li>
-          <li>Full accessibility audit (WCAG)</li>
-          <li>Performance pass — Lighthouse green</li>
-          <li>Stable release — remove alpha label</li>
-        </ul>
-      </div>
-
-      <div class="lane vpost">
-        <div class="lane-head">
-          <span class="lane-badge">Post-1.0</span>
-          <span class="lane-title">What's next</span>
-        </div>
-        <ul class="lane-items">
-          <li>Cloud sync / account support</li>
-          <li>Share town progress with friends</li>
-          <li>New Horizons critterpedia features</li>
-          <li>Price guide &amp; art authenticity tracker</li>
-          <li>Seasonal event calendar</li>
-        </ul>
-      </div>
-
-    </div>
-  </section>
-
-  <!-- Velocity detail -->
-  <section>
-    <h2>Velocity detail</h2>
-    <div style="background:#fff; border:1px solid var(--border); border-radius:12px; overflow:hidden;">
-      <table style="width:100%; border-collapse:collapse; font-size:.85rem;">
-        <thead>
-          <tr style="background:var(--paper);">
-            <th style="padding:.65rem 1rem; text-align:left; color:var(--muted); font-weight:normal;">Release</th>
-            <th style="padding:.65rem 1rem; text-align:left; color:var(--muted); font-weight:normal;">Date</th>
-            <th style="padding:.65rem 1rem; text-align:left; color:var(--muted); font-weight:normal;">Days since last</th>
-            <th style="padding:.65rem 1rem; text-align:left; color:var(--muted); font-weight:normal;">Highlight</th>
-          </tr>
-        </thead>
-        <tbody>
-          <tr style="border-top:1px solid var(--border);">
-            <td style="padding:.6rem 1rem; color:var(--leaf); font-weight:bold;">v0.1.0</td>
-            <td style="padding:.6rem 1rem;">Apr 10</td>
-            <td style="padding:.6rem 1rem;">—</td>
-            <td style="padding:.6rem 1rem;">First commit → live app</td>
-          </tr>
-          <tr style="border-top:1px solid var(--border); background:#fafafa;">
-            <td style="padding:.6rem 1rem; color:var(--leaf); font-weight:bold;">v0.2.0</td>
-            <td style="padding:.6rem 1rem;">Apr 12</td>
-            <td style="padding:.6rem 1rem;">2 days</td>
-            <td style="padding:.6rem 1rem;">Detail modal + donation timestamps</td>
-          </tr>
-          <tr style="border-top:1px solid var(--border);">
-            <td style="padding:.6rem 1rem; color:var(--leaf); font-weight:bold;">v0.3.0</td>
-            <td style="padding:.6rem 1rem;">Apr 13</td>
-            <td style="padding:.6rem 1rem;">1 day</td>
-            <td style="padding:.6rem 1rem;">Multi-town support</td>
-          </tr>
-          <tr style="border-top:1px solid var(--border); background:#fafafa;">
-            <td style="padding:.6rem 1rem; color:var(--leaf); font-weight:bold;">v0.4.0</td>
-            <td style="padding:.6rem 1rem;">Apr 13</td>
-            <td style="padding:.6rem 1rem;">&lt;1 day</td>
-            <td style="padding:.6rem 1rem;">Global search + stats tab</td>
-          </tr>
-          <tr style="border-top:1px solid var(--border);">
-            <td style="padding:.6rem 1rem; color:var(--leaf); font-weight:bold;">v0.5.0</td>
-            <td style="padding:.6rem 1rem;">Apr 13</td>
-            <td style="padding:.6rem 1rem;">&lt;1 day</td>
-            <td style="padding:.6rem 1rem;">CSV export + error UI + analytics</td>
-          </tr>
-          <tr style="border-top:1px solid var(--border); background:#fafafa;">
-            <td style="padding:.6rem 1rem; color:var(--leaf); font-weight:bold;">v0.6.0</td>
-            <td style="padding:.6rem 1rem;">Apr 14</td>
-            <td style="padding:.6rem 1rem;">1 day</td>
-            <td style="padding:.6rem 1rem;">Home screen tab</td>
-          </tr>
-          <tr style="border-top:1px solid var(--border);">
-            <td style="padding:.6rem 1rem; color:var(--gold); font-weight:bold;">v0.6.1</td>
-            <td style="padding:.6rem 1rem;">Apr 15</td>
-            <td style="padding:.6rem 1rem;">1 day</td>
-            <td style="padding:.6rem 1rem;">Hotfix — main branch restored</td>
-          </tr>
-          <tr style="border-top:1px solid var(--border); background:#fafafa;">
-            <td style="padding:.6rem 1rem; color:var(--leaf); font-weight:bold;">v0.7.0-alpha</td>
-            <td style="padding:.6rem 1rem;">Apr 17</td>
-            <td style="padding:.6rem 1rem;">2 days</td>
-            <td style="padding:.6rem 1rem;">Multi-game foundation — largest refactor yet</td>
-          </tr>
-          <tr style="border-top:1px solid var(--border);">
-            <td style="padding:.6rem 1rem; color:var(--leaf); font-weight:bold;">v0.8.0-alpha</td>
-            <td style="padding:.6rem 1rem;">Apr 29</td>
-            <td style="padding:.6rem 1rem;">12 days</td>
-            <td style="padding:.6rem 1rem;">Full game coverage — ACNL + ACNH, 1,000+ items, inline details, URL routing</td>
-          </tr>
-          <tr style="border-top:1px solid var(--border); background:#fafafa;">
-            <td style="padding:.6rem 1rem; color:var(--leaf); font-weight:bold;">v0.8.1-alpha</td>
-            <td style="padding:.6rem 1rem;">Apr 30</td>
-            <td style="padding:.6rem 1rem;">1 day</td>
-            <td style="padding:.6rem 1rem;">Edit Town modal fix</td>
-          </tr>
-          <tr style="border-top:1px solid var(--border);">
-            <td style="padding:.6rem 1rem; color:var(--leaf); font-weight:bold;">v0.8.2-alpha</td>
-            <td style="padding:.6rem 1rem;">May 1</td>
-            <td style="padding:.6rem 1rem;">1 day</td>
-            <td style="padding:.6rem 1rem;">Sea Creatures tab (ACNH + ACNL)</td>
-          </tr>
-          <tr style="border-top:1px solid var(--border); background:#fafafa;">
-            <td style="padding:.6rem 1rem; color:var(--leaf); font-weight:bold;">v0.9.0-beta</td>
-            <td style="padding:.6rem 1rem;">May 3</td>
-            <td style="padding:.6rem 1rem;">2 days</td>
-            <td style="padding:.6rem 1rem;">Curator UI revamp — Meadow design, Sidebar, TownManager, sectioned categories</td>
-          </tr>
-          <tr style="border-top:1px solid var(--border);">
-            <td style="padding:.6rem 1rem; color:var(--leaf); font-weight:bold;">v0.9.1-beta</td>
-            <td style="padding:.6rem 1rem;">May 4</td>
-            <td style="padding:.6rem 1rem;">1 day</td>
-            <td style="padding:.6rem 1rem;">ACGCN item icons + /credits route + MIT LICENSE/NOTICE</td>
-          </tr>
-          <tr style="border-top:1px solid var(--border);">
-            <td style="padding:.6rem 1rem; color:var(--leaf); font-weight:bold;">v0.9.2-beta</td>
-            <td style="padding:.6rem 1rem;">May 5</td>
-            <td style="padding:.6rem 1rem;">1 day</td>
-            <td style="padding:.6rem 1rem;">Cross-game icon routing + first hand-drawn icons + bigger sizes</td>
-          </tr>
-          <tr style="border-top:1px solid var(--border);">
-            <td style="padding:.6rem 1rem; color:var(--leaf); font-weight:bold;">v0.9.3-beta</td>
-            <td style="padding:.6rem 1rem;">May 6</td>
-            <td style="padding:.6rem 1rem;">1 day</td>
-            <td style="padding:.6rem 1rem;">JSON save-file export + import + onboarding fixes + ant icon</td>
-          </tr>
-          <tr style="border-top:1px solid var(--border); background:#fafafa;">
-            <td style="padding:.6rem 1rem; color:var(--leaf); font-weight:bold;">v0.9.4-beta</td>
-            <td style="padding:.6rem 1rem;">May 7</td>
-            <td style="padding:.6rem 1rem;">1 day</td>
-            <td style="padding:.6rem 1rem;">Silhouette rendering + ACWW icon gap-fill (100%) + 768px pipeline + coelacanth</td>
-          </tr>
-        </tbody>
-      </table>
-    </div>
-  </section>
-
-  <footer>
-    <p><a href="https://animalcrossingwebapp.vercel.app">animalcrossingwebapp.vercel.app</a> · v0.9.4-beta shipped · v1.0 next · Dev preview at <a href="https://development-animalcrossingwebapp.vercel.app">development-animalcrossingwebapp.vercel.app</a></p>
-  </footer>
-
-</div>
-</body>
+  </body>
 </html>

--- a/src/components/ItemIcon.test.tsx
+++ b/src/components/ItemIcon.test.tsx
@@ -44,6 +44,7 @@ beforeEach(() => {
 
 afterEach(() => {
   vi.restoreAllMocks();
+  vi.unstubAllGlobals();
 });
 
 describe('resolveIconUrl', () => {

--- a/src/components/itemIconUtils.ts
+++ b/src/components/itemIconUtils.ts
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import type { CategoryId } from '../lib/types';
 
 /**
@@ -156,9 +156,12 @@ export function useIconChecker(): (
   id: string
 ) => boolean {
   const state = useManifestState();
-  if (state.status !== 'present') return () => false;
-  const manifest = state.manifest;
-  return (category, id) => resolveIconUrl(manifest, category, id) !== null;
+  const manifest = state.status === 'present' ? state.manifest : null;
+  return useMemo(() => {
+    if (!manifest) return () => false;
+    return (category: CategoryId, id: string) =>
+      resolveIconUrl(manifest, category, id) !== null;
+  }, [manifest]);
 }
 
 /**


### PR DESCRIPTION
## Summary

- **#124** — velocity-history.html headline corrected from "25 days" to "29 days" to match the stat counter elsewhere on the page
- **#95** — `useIconChecker` now returns a `useMemo`-wrapped closure keyed on the manifest reference, preventing a new function allocation on every render
- **#92 item 4** — added `vi.unstubAllGlobals()` to the `afterEach` in `ItemIcon.test.tsx`; `vi.restoreAllMocks()` alone doesn't clean up `vi.stubGlobal` calls, so stubs could leak between test files

## Dropped fixes (already resolved at inspection)

- **#92 item 2** — no `?? 'ACGCN'` fallback found in `ItemExpandPanel.tsx` or `CollectibleRow.tsx`; was already cleaned up
- **#60** — `App.tsx:103` already had `branch.startsWith('release/')` in the carve-out condition; nothing to do

Addresses items 2 and 4 of #92.

## Test plan

- `npm test` — 3288/3288 passed
- `npm run build` — clean
- `npx eslint src/components/itemIconUtils.ts src/components/ItemIcon.test.tsx` — no errors
- `npx prettier --check` — clean after auto-format on version-history.html

Closes #95
Closes #124