### PR TITLE
doc-sync: stale dates, coverage %, icon count, and missing velocity row

### DIFF
--- a/docs/roadmap-to-v1.md
+++ b/docs/roadmap-to-v1.md
@@ -2,7 +2,7 @@
 
 This document is the canonical roadmap. It supersedes any earlier scattered planning notes.
 
-Last updated: **2026-05-07** (after v0.9.4-beta shipped).
+Last updated: **2026-05-10** (after v0.9.5-beta shipped).
 
 ## Where the project sits
 
@@ -57,7 +57,7 @@ After cross-game routing, each remaining game's scrape is much smaller than v0.9
 Shipped 2026-05-10. 135 items, ACNL 96.5%, ACCF 100% via cross-game, ACNH 68.8% via cross-game. 10 genuine gaps remain. Resolver improvements (Gallery deprioritization, sea-creature disambig) apply directly to the ACNH scrape next cycle. Three hand-drawn icons (frog, robust cicada, brown cicada) bring the hand-drawn library to seven pieces total.
 
 - ACNL: 53 unique items
-- ACNH: 106 unique items (largest catalog, save for last)
+- ACNH: 103 unique items (largest catalog, save for last)
 
 ACCF has 0 unique items after cross-game routing — no release needed for that game.
 
@@ -103,7 +103,7 @@ Per-game new items (the workload added by each release):
 | ACNH      |     10 |      21 |            10 |        41 |
 | **Total** | **94** | **116** |        **45** |   **255** |
 
-**Progress as of 2026-05-07:** 4 of 255 complete — ant (bug), koi (fish), sea-bass (fish), coelacanth (fish).
+**Progress as of 2026-05-10:** 7 of 255 complete — ant (bug), koi (fish), sea-bass (fish), coelacanth (fish), frog (fish), robust cicada (bug), brown cicada (bug).
 
 **Procreate canvas:** 2048×2048 px, transparent background, sRGB, exported as PNG. The production pipeline (sharp + pngquant) re-exports to 768×768 for deployment via `npm run icons:export`. Filename matches the canonical kebab-case item id (e.g. `sea-bass.png`, `tiger-swallowtail-butterfly.png`). Originals committed to `icon-sources/` for archival and reproduction.
 

--- a/public/version-history.html
+++ b/public/version-history.html
@@ -440,7 +440,7 @@
     <div class="page">
       <header>
         <h1>Animal Crossing Web App</h1>
-        <p>Version history &amp; roadmap · Updated May 9, 2026</p>
+        <p>Version history &amp; roadmap · Updated May 10, 2026</p>
       </header>
 
       <!-- Velocity banner -->
@@ -1073,8 +1073,8 @@
             <div class="check-item done">
               <div class="box">✓</div>
               <span class="text"
-                >ACWW icon coverage at 100% — 84 wiki-scraped items; ACCF 95.5%,
-                ACNL 49.1%, ACNH 39.1% via cross-game ID routing</span
+                >ACWW icon coverage at 100% — 84 wiki-scraped items; ACCF 100%,
+                ACNL 96.5%, ACNH 68.8% via cross-game ID routing</span
               >
             </div>
             <div class="check-item done">
@@ -1087,8 +1087,8 @@
             <div class="check-item done">
               <div class="box">✓</div>
               <span class="text"
-                >ACGCN item icons + cross-game routing + four hand-drawn icons
-                (sea-bass, koi, ant, coelacanth)</span
+                >ACGCN item icons + cross-game routing + seven hand-drawn icons
+                (sea-bass, koi, ant, coelacanth, frog, robust cicada, brown cicada)</span
               >
             </div>
             <div class="check-item done">
@@ -1505,6 +1505,23 @@
                 <td style="padding: 0.6rem 1rem">
                   Silhouette rendering + ACWW icon gap-fill (100%) + 768px
                   pipeline + coelacanth
+                </td>
+              </tr>
+              <tr style="border-top: 1px solid var(--border)">
+                <td
+                  style="
+                    padding: 0.6rem 1rem;
+                    color: var(--leaf);
+                    font-weight: bold;
+                  "
+                >
+                  v0.9.5-beta
+                </td>
+                <td style="padding: 0.6rem 1rem">May 10</td>
+                <td style="padding: 0.6rem 1rem">3 days</td>
+                <td style="padding: 0.6rem 1rem">
+                  ACNL icon gap-fill (96.5%) + ACCF 100% via cross-game +
+                  three hand-drawn icons (frog, robust cicada, brown cicada)
                 </td>
               </tr>
             </tbody>


### PR DESCRIPTION
## Summary

Seven cosmetic doc corrections surfaced by the nightly doc-sync audit (2026-05-11 run). All items were independently verified against the `v0.9.5-beta` release notes and the `development` branch HEAD.

Items 1–4 were pre-catalogued in issue #134. Items 5–7 are additional findings from this audit.

### `public/version-history.html`

1. **Header date** — `Updated May 9, 2026` → `Updated May 10, 2026` (v0.9.5 shipped May 10, not May 9). Closes #134 item 1.
2. **"Recently shipped" checklist — cross-game coverage numbers** — The ACWW checklist entry carried v0.9.4-era cross-game uplift figures (ACCF 95.5%, ACNL 49.1%, ACNH 39.1%). After v0.9.5, the correct figures are ACCF 100%, ACNL 96.5%, ACNH 68.8%. Closes #134 item 2.
3. **"Recently shipped" checklist — hand-drawn icon count** — Listed "four hand-drawn icons (sea-bass, koi, ant, coelacanth)" but v0.9.5 shipped three more (frog, robust cicada, brown cicada), bringing the library to seven.
4. **Velocity detail table — missing v0.9.5-beta row** — Table ended at v0.9.4-beta. Added v0.9.5-beta row (May 10, 3 days, ACNL gap-fill + three hand-drawn icons). Closes #134 item 3.

### `docs/roadmap-to-v1.md`

5. **"Last updated" header** — Still read `2026-05-07 (after v0.9.4-beta shipped)`; bumped to `2026-05-10 (after v0.9.5-beta shipped)`. Closes #134 item 4.
6. **Hand-drawn icon progress count** — `Progress as of 2026-05-07: 4 of 255 complete` updated to `Progress as of 2026-05-10: 7 of 255 complete` with the full updated list (+ frog, robust cicada, brown cicada).
7. **ACNH unique-items count** — Body text said "ACNH: 106 unique items" but the v0.9.5 cross-game uplift brought ACNH to 68.8% (227/330), leaving 103 items, not 106. The sequence table's v0.9.6 row already said "103 unique items" — this aligns the body with it.

## Test plan

- [ ] All changed strings verified against v0.9.5-beta release notes and CHANGELOG
- [ ] No functional code changes — HTML/Markdown only
- [ ] `npm run build` and `npm test` unaffected (no src/ changes)


---
_Generated by [Claude Code](https://claude.ai/code/session_01KCfZwgBqB3SJauKbY8JQx5)_