### PR TITLE
doc-sync: goldfish icon unreleased docs + stale 512→768 pipeline ref

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project are documented here.
 
 ## [Unreleased]
 
+### Added
+
+- Hand-drawn `fish/goldfish.png` icon (PR #136) — eighth hand-drawn piece in the library (after sea-bass, koi, ant, coelacanth, frog, robust cicada, brown cicada). 2048×2048 watercolour-and-ink source at `icon-sources/fish/goldfish.png`; exported to 768×768 (88.9 KB) via `npm run icons:export`. Replaces the scraped wiki placeholder. Cross-game routing propagates this to any game that maps to `fish/goldfish`.
+
 ## [v0.9.5-beta] — 2026-05-10
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -193,7 +193,7 @@ public/data/acnh/
   sea_creatures.json        # 40 sea creatures (NH/SH months)
 icon-sources/                # 2048×2048 hand-drawn PNG originals — committed (not gitignored).
                              # Mirrors public/icons/ layout: `<category>/<id>.png`.
-                             # Run `npm run icons:export` to regenerate the 512 deploy assets.
+                             # Run `npm run icons:export` to regenerate the 768 deploy assets.
 docs/
   dev-process.md            # PR checklist and dev process rules for Claude Code sessions
   architecture.md           # Deep architectural context: store schema, migrations, multi-game types

--- a/docs/roadmap-to-v1.md
+++ b/docs/roadmap-to-v1.md
@@ -103,7 +103,7 @@ Per-game new items (the workload added by each release):
 | ACNH      |     10 |      21 |            10 |        41 |
 | **Total** | **94** | **116** |        **45** |   **255** |
 
-**Progress as of 2026-05-10:** 7 of 255 complete — ant (bug), koi (fish), sea-bass (fish), coelacanth (fish), frog (fish), robust cicada (bug), brown cicada (bug).
+**Progress as of 2026-05-11:** 8 of 255 complete — ant (bug), koi (fish), sea-bass (fish), coelacanth (fish), frog (fish), robust cicada (bug), brown cicada (bug), goldfish (fish).
 
 **Procreate canvas:** 2048×2048 px, transparent background, sRGB, exported as PNG. The production pipeline (sharp + pngquant) re-exports to 768×768 for deployment via `npm run icons:export`. Filename matches the canonical kebab-case item id (e.g. `sea-bass.png`, `tiger-swallowtail-butterfly.png`). Originals committed to `icon-sources/` for archival and reproduction.
 

--- a/public/version-history.html
+++ b/public/version-history.html
@@ -1087,8 +1087,8 @@
             <div class="check-item done">
               <div class="box">✓</div>
               <span class="text"
-                >ACGCN item icons + cross-game routing + seven hand-drawn icons
-                (sea-bass, koi, ant, coelacanth, frog, robust cicada, brown cicada)</span
+                >ACGCN item icons + cross-game routing + eight hand-drawn icons
+                (sea-bass, koi, ant, coelacanth, frog, robust cicada, brown cicada, goldfish)</span
               >
             </div>
             <div class="check-item done">


### PR DESCRIPTION
## Summary

Four minimal corrections detected by the nightly doc-sync run on 2026-05-12. All stem from PR #136 (goldfish hand-drawn icon) merging to `development` on 2026-05-11 without corresponding doc updates, plus one stale comment in `CLAUDE.md` that has been wrong since v0.9.4-beta.

### Changes

| File | Change |
|------|--------|
| `CHANGELOG.md` | Add goldfish (PR #136, 8th hand-drawn icon) to `[Unreleased]` |
| `docs/roadmap-to-v1.md` | Hand-drawn progress 7 → 8 of 255; add goldfish to list; date → 2026-05-11 |
| `public/version-history.html` | "seven hand-drawn icons" → "eight"; add goldfish to Currently Building checklist |
| `CLAUDE.md` | `icon-sources/` comment: "512 deploy assets" → "768 deploy assets" (stale since PR #115 / v0.9.4-beta) |

### Why these files

- PR #136 committed goldfish to `development` but added no `[Unreleased]` CHANGELOG entry and did not update the roadmap's hand-drawn progress tally or the version-history page's running count.
- The `CLAUDE.md` `icon-sources/` comment predates the `TARGET_SIZE` bump from 512 → 768 in PR #115 and was never corrected.

### What this is not

- No logic or behaviour changes.
- No scope beyond the four factual corrections above.
- The v0.9.5-beta release entries in all files are correct and untouched.

### Test plan

- [ ] `CHANGELOG.md` `[Unreleased]` entry matches the PR #136 commit message details
- [ ] `docs/roadmap-to-v1.md` progress count reads "8 of 255" and lists goldfish
- [ ] `public/version-history.html` Currently Building checklist reads "eight hand-drawn icons (..., goldfish)"
- [ ] `CLAUDE.md` icon-sources comment reads "768 deploy assets"

---

*Generated by nightly doc-sync run 2026-05-12.*

---
_Generated by [Claude Code](https://claude.ai/code/session_01MEw8nPdnLDstoNHXVWs1SP)_