### PR TITLE
doc-sync: roadmap v0.9.6 in-progress + version-history goldfish correction

### DIFF
--- a/docs/roadmap-to-v1.md
+++ b/docs/roadmap-to-v1.md
@@ -2,7 +2,7 @@
 
 This document is the canonical roadmap. It supersedes any earlier scattered planning notes.
 
-Last updated: **2026-05-10** (after v0.9.5-beta shipped).
+Last updated: **2026-05-13** (after v0.9.5-beta shipped; v0.9.6-beta in progress).
 
 ## Where the project sits
 
@@ -19,7 +19,7 @@ Last updated: **2026-05-10** (after v0.9.5-beta shipped).
 | v0.9.3-beta | JSON save-file round-trip (export + import) + first hand-drawn bug (ant)                     | Shipped 2026-05-06 |
 | v0.9.4-beta | Silhouette rendering for un-donated items + ACWW icon gap-fill + higher-res hand-drawn icons | Shipped 2026-05-07 |
 | v0.9.5-beta | ACNL icon gap-fill + three hand-drawn icons                                                  | Shipped 2026-05-10 |
-| v0.9.6-beta | ACNH icon gap-fill (103 unique items)                                                        | Planned            |
+| v0.9.6-beta | ACNH icon gap-fill (103 unique items)                                                        | In progress (PR #140) |
 | v0.9.7-beta | SEO basics (OG tags, sitemap, meta, social cards per game)                                   | Planned            |
 | v0.9.8-beta | Light monetization footer + polish bug sweep                                                 | Planned            |
 | v1.0.0      | Final polish + public ship + all hand-drawn icons                                            | Target             |

--- a/public/version-history.html
+++ b/public/version-history.html
@@ -1087,8 +1087,8 @@
             <div class="check-item done">
               <div class="box">✓</div>
               <span class="text"
-                >ACGCN item icons + cross-game routing + eight hand-drawn icons
-                (sea-bass, koi, ant, coelacanth, frog, robust cicada, brown cicada, goldfish)</span
+                >ACGCN item icons + cross-game routing + seven hand-drawn icons
+                (sea-bass, koi, ant, coelacanth, frog, robust cicada, brown cicada)</span
               >
             </div>
             <div class="check-item done">


### PR DESCRIPTION
## Summary

Two clear-drift corrections found by the nightly doc-sync audit (2026-05-13 run).

**`docs/roadmap-to-v1.md`**
- v0.9.6-beta row changed from `Planned` → `In progress (PR #140)`. PR #140 ("feat: fill ACNH icon gaps") has been open since 2026-05-12; the roadmap table still read "Planned".
- "Last updated" header bumped from 2026-05-10 to 2026-05-13 to match the actual content date (the file was last edited 2026-05-11 by PR #135 and today's correction).

**`public/version-history.html`**
- "Recently shipped (v0.9.5-beta)" checklist item reverted from "eight hand-drawn icons (…, goldfish)" back to "seven hand-drawn icons (…)". Goldfish was added by PR #136, which was merged *after* the v0.9.5-beta tag. It lives in CHANGELOG `[Unreleased]`; the previous doc-sync run (PR #137) incorrectly attributed it to v0.9.5. The count and list are now consistent with what the tag actually contains.

## Sources of truth consulted

- Latest tag: `v0.9.5-beta` (published 2026-05-11T04:08:16Z)
- CHANGELOG `[Unreleased]`: goldfish (PR #136) — not yet tagged
- Open PR #140: v0.9.6-beta ACNH icon gap-fill (created 2026-05-12)

## Test plan

- [x] `docs/roadmap-to-v1.md` diff is minimal — two lines changed, no prose rewrite
- [x] `public/version-history.html` diff is minimal — one checklist item corrected
- [x] Both changes consistent with CHANGELOG and GitHub release list

---
_Generated by [Claude Code](https://claude.ai/code/session_017A4mHp1azahB88u6dbE6ES)_