### PR TITLE
doc-sync: roadmap-to-v1.html hand-drawn count 7→8 (goldfish)

### DIFF
--- a/public/roadmap-to-v1.html
+++ b/public/roadmap-to-v1.html
@@ -465,7 +465,7 @@
   <body>
     <main class="page">
       <!-- ── Hero ── -->
-      <p class="eyebrow">Roadmap · 2026-05-12</p>
+      <p class="eyebrow">Roadmap · 2026-05-14</p>
       <h1>The road to <em>v1.0</em></h1>
       <p class="lede">
         Nine months in. Five games supported, ten beta releases shipped, a design system rebuilt from
@@ -493,7 +493,7 @@
           <div class="label">Lines in src/ today</div>
         </div>
         <div class="stat">
-          <div class="num">7 <small>/ 210</small></div>
+          <div class="num">8 <small>/ 210</small></div>
           <div class="label">Hand-drawn icons</div>
         </div>
       </div>
@@ -639,7 +639,7 @@
           <div style="display: flex; gap: 24px; align-items: baseline; margin-top: 12px;">
             <div>
               <div style="font-family: var(--display); font-size: 48px; font-weight: 500; line-height: 1; color: var(--accent-ink);">
-                7
+                8
               </div>
               <div style="font-size: 12px; color: var(--ink-muted); text-transform: uppercase; letter-spacing: 0.08em; margin-top: 6px;">
                 Hand-drawn shipped
@@ -647,7 +647,7 @@
             </div>
             <div>
               <div style="font-family: var(--display); font-size: 48px; font-weight: 500; line-height: 1; color: var(--ink-soft);">
-                203
+                202
               </div>
               <div style="font-size: 12px; color: var(--ink-muted); text-transform: uppercase; letter-spacing: 0.08em; margin-top: 6px;">
                 Unique species remaining
@@ -655,8 +655,8 @@
             </div>
           </div>
           <p style="margin: 16px 0 0; color: var(--ink-soft); font-size: 14px;">
-            Across all five games, deduped by item id. <strong>4 fish</strong> drawn (sea-bass,
-            koi, coelacanth, frog) · <strong>3 bugs</strong> drawn (ant, robust cicada, brown cicada).
+            Across all five games, deduped by item id. <strong>5 fish</strong> drawn (sea-bass,
+            koi, coelacanth, frog, goldfish) · <strong>3 bugs</strong> drawn (ant, robust cicada, brown cicada).
           </p>
         </div>
         <div class="card alt">
@@ -743,7 +743,7 @@
               <span class="milestone-tag next">Ongoing through v1.0</span>
             </div>
             <div class="milestone-body">
-              203 unique fish + bug species still need hand-drawn originals. 43 of those are the
+              202 unique fish + bug species still need hand-drawn originals. 43 of those are the
               5-game tier (highest ROI). If unsustainable before v1.0, the remaining tail moves
               post-launch.
             </div>
@@ -829,7 +829,7 @@
       </p>
 
       <div class="footer">
-        Generated 2026-05-12 · animalcrossingwebapp ·
+        Generated 2026-05-14 · animalcrossingwebapp ·
         <a href="https://animalcrossingwebapp.vercel.app">live</a> ·
         <a href="https://development-animalcrossingwebapp.vercel.app">dev preview</a>
       </div>


### PR DESCRIPTION
## Summary

One clear-drift correction found by the nightly doc-sync audit (2026-05-14 run).

**`public/roadmap-to-v1.html`** was generated on 2026-05-12 (PR #138) before the goldfish hand-drawn icon (PR #136) was recorded in other docs. The doc-sync commit that captured goldfish in `docs/roadmap-to-v1.md`, `CHANGELOG.md`, `CLAUDE.md`, and `public/version-history.html` (commit `94d17ed`) ran 34 seconds after PR #138 merged — so `public/roadmap-to-v1.html` was left behind.

### Changes

| Location | Was | Now |
|---|---|---|
| Stat tile (hand-drawn icons) | `7 / 210` | `8 / 210` |
| "Where we are" hero number | `7` | `8` |
| Unique species remaining (large number) | `203` | `202` |
| Unique species remaining (milestone body) | `203 unique fish…` | `202 unique fish…` |
| Fish list | 4 fish: sea-bass, koi, coelacanth, frog | 5 fish: + goldfish |
| Eyebrow date | `Roadmap · 2026-05-12` | `Roadmap · 2026-05-14` |
| Footer date | `Generated 2026-05-12` | `Generated 2026-05-14` |

### Out of scope

The per-game `gameBars` data in the inline JS block (drawn/scraped counts per game) are not updated — those require running `npm run audit:icons` to get precise numbers. The visible summary numbers above are the user-facing stat tiles and body text; the JS data can be refreshed in a future icon-audit pass.

### Sources of truth consulted

- Latest tag: `v0.9.5-beta` (published 2026-05-11T04:08:16Z)
- `docs/roadmap-to-v1.md` on `development`: "8 of 255 complete … goldfish (fish)" (as of 2026-05-11)
- `CHANGELOG.md [Unreleased]`: goldfish (PR #136) confirmed post-v0.9.5 ✓

### Test plan

- [x] Diff is minimal — 8 lines changed, all in `public/roadmap-to-v1.html`
- [x] All changed values consistent with `docs/roadmap-to-v1.md` and `CHANGELOG.md`
- [x] No other docs need changes for this specific item (prior PR #141 covers the remaining version-history.html and roadmap.md items)

---
_Generated by nightly doc-sync audit · 2026-05-14_

---
_Generated by [Claude Code](https://claude.ai/code/session_01W5ZSp5SuSQFFU6bQVUZhbU)_