### PR TITLE
doc-sync: record ACNH gap-fill + hand-drawn count 8→10 in unreleased docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to this project are documented here.
 ### Added
 
 - Hand-drawn `fish/goldfish.png` icon (PR #136) — eighth hand-drawn piece in the library (after sea-bass, koi, ant, coelacanth, frog, robust cicada, brown cicada). 2048×2048 watercolour-and-ink source at `icon-sources/fish/goldfish.png`; exported to 768×768 (88.9 KB) via `npm run icons:export`. Replaces the scraped wiki placeholder. Cross-game routing propagates this to any game that maps to `fish/goldfish`.
+- **ACNH icon gap-fill** (PR #140) — 88 wiki-scraped items across all five ACNH categories (9 fish + 16 bugs + 47 fossils + 6 art + 10 sea creatures); ACNH icon coverage **68.8% → 95.5%** (315/330). Fifteen items remain genuine wiki gaps logged to `scripts/missing-acnh.txt`. Two general-purpose resolver improvements: `a:sentence` probe handles MediaWiki's first-char-only auto-capitalize; `c:search` deprioritizes `* model` furniture pages. Multi-part fossil pieces collapse to parent species articles via ~50 new OVERRIDES entries
 - Hand-drawn `fish/tadpole.png` icon — ninth hand-drawn piece in the library. 2048×2048 Procreate source at `icon-sources/fish/tadpole.png`; exported to 768×768 (24 KB) via `npm run icons:export`
 - Hand-drawn `bugs/agrias-butterfly.png` icon — tenth hand-drawn piece. Replaces the wiki-scraped `.jpg` placeholder. 2048×2048 source at `icon-sources/bugs/agrias-butterfly.png`; exported to 768×768 (62 KB) via `npm run icons:export`. Manifest updated from `jpg` → `png` for this entry
 

--- a/docs/roadmap-to-v1.md
+++ b/docs/roadmap-to-v1.md
@@ -2,7 +2,7 @@
 
 This document is the canonical roadmap. It supersedes any earlier scattered planning notes.
 
-Last updated: **2026-05-10** (after v0.9.5-beta shipped).
+Last updated: **2026-05-25** (after PRs #140 + #144 merged to development).
 
 ## Where the project sits
 
@@ -19,7 +19,7 @@ Last updated: **2026-05-10** (after v0.9.5-beta shipped).
 | v0.9.3-beta | JSON save-file round-trip (export + import) + first hand-drawn bug (ant)                     | Shipped 2026-05-06 |
 | v0.9.4-beta | Silhouette rendering for un-donated items + ACWW icon gap-fill + higher-res hand-drawn icons | Shipped 2026-05-07 |
 | v0.9.5-beta | ACNL icon gap-fill + three hand-drawn icons                                                  | Shipped 2026-05-10 |
-| v0.9.6-beta | ACNH icon gap-fill (103 unique items)                                                        | Planned            |
+| v0.9.6-beta | ACNH icon gap-fill (88 wiki-scraped items; 95.5% coverage)                                  | In progress        |
 | v0.9.7-beta | SEO basics (OG tags, sitemap, meta, social cards per game)                                   | Planned            |
 | v0.9.8-beta | Light monetization footer + polish bug sweep                                                 | Planned            |
 | v1.0.0      | Final polish + public ship + all hand-drawn icons                                            | Target             |
@@ -103,7 +103,7 @@ Per-game new items (the workload added by each release):
 | ACNH      |     10 |      21 |            10 |        41 |
 | **Total** | **94** | **116** |        **45** |   **255** |
 
-**Progress as of 2026-05-11:** 8 of 255 complete — ant (bug), koi (fish), sea-bass (fish), coelacanth (fish), frog (fish), robust cicada (bug), brown cicada (bug), goldfish (fish).
+**Progress as of 2026-05-25:** 10 of 255 complete — ant (bug), koi (fish), sea-bass (fish), coelacanth (fish), frog (fish), robust cicada (bug), brown cicada (bug), goldfish (fish), tadpole (fish), agrias butterfly (bug).
 
 **Procreate canvas:** 2048×2048 px, transparent background, sRGB, exported as PNG. The production pipeline (sharp + pngquant) re-exports to 768×768 for deployment via `npm run icons:export`. Filename matches the canonical kebab-case item id (e.g. `sea-bass.png`, `tiger-swallowtail-butterfly.png`). Originals committed to `icon-sources/` for archival and reproduction.
 

--- a/public/version-history.html
+++ b/public/version-history.html
@@ -440,7 +440,7 @@
     <div class="page">
       <header>
         <h1>Animal Crossing Web App</h1>
-        <p>Version history &amp; roadmap · Updated May 10, 2026</p>
+        <p>Version history &amp; roadmap · Updated May 25, 2026</p>
       </header>
 
       <!-- Velocity banner -->
@@ -1074,7 +1074,7 @@
               <div class="box">✓</div>
               <span class="text"
                 >ACWW icon coverage at 100% — 84 wiki-scraped items; ACCF 100%,
-                ACNL 96.5%, ACNH 68.8% via cross-game ID routing</span
+                ACNL 96.5%, ACNH 95.5% via cross-game ID routing + dedicated gap-fill (PR #140)</span
               >
             </div>
             <div class="check-item done">
@@ -1087,8 +1087,8 @@
             <div class="check-item done">
               <div class="box">✓</div>
               <span class="text"
-                >ACGCN item icons + cross-game routing + eight hand-drawn icons
-                (sea-bass, koi, ant, coelacanth, frog, robust cicada, brown cicada, goldfish)</span
+                >ACGCN item icons + cross-game routing + ten hand-drawn icons
+                (sea-bass, koi, ant, coelacanth, frog, robust cicada, brown cicada, goldfish, tadpole, agrias butterfly)</span
               >
             </div>
             <div class="check-item done">


### PR DESCRIPTION
## Summary

Nightly doc-sync audit 2026-05-25 found four clear-drift corrections across three files. All changes reflect work already merged to `development` (PRs #140 and #144, both merged 2026-05-24) that was not yet reflected in the living docs.

### What changed

**`CHANGELOG.md` — `[Unreleased]` section**
- Added the ACNH icon gap-fill entry (PR #140): 88 wiki-scraped items across all five ACNH categories, coverage 68.8% → 95.5% (315/330). This entry was entirely absent despite the PR merging to `development` on 2026-05-24.

**`docs/roadmap-to-v1.md`**
- v0.9.6-beta row: `Planned` → `In progress` (ACNH gap-fill has merged to development via PR #140)
- Hand-drawn icon count: `8 of 255 complete` → `10 of 255 complete` (tadpole + agrias butterfly from PR #144)
- Hand-drawn list: added tadpole (fish) and agrias butterfly (bug) to the named list
- Last-updated date: `2026-05-10` → `2026-05-25`

**`public/version-history.html`**
- "Currently building" checklist: `eight hand-drawn icons (…, goldfish)` → `ten hand-drawn icons (…, goldfish, tadpole, agrias butterfly)`
- Same checklist: ACNH coverage `68.8% via cross-game ID routing` → `95.5% via cross-game ID routing + dedicated gap-fill (PR #140)`
- Header date: `Updated May 10, 2026` → `Updated May 25, 2026`

### Not touched

- `package.json` version — still `0.9.5-beta`, correct (no new release tag)
- `README.md` — version line reflects latest tag (`v0.9.5-beta`), correct
- `CLAUDE.md` — stale v0.9.6-beta language is covered by existing ambiguous-drift issue #143; that issue now also covers the ACNH gap-fill and new hand-drawn pieces
- `docs/architecture.md` — no stale path references detected

### Skipped (already filed)

- Issue #143: `CLAUDE.md` v0.9.6 section missing unreleased merged work — open, covers the same ambiguous convention question. No new issue filed.

## Test plan

- [ ] `CHANGELOG.md`: confirm ACNH gap-fill bullet appears between goldfish and tadpole in `[Unreleased]`
- [ ] `docs/roadmap-to-v1.md`: confirm v0.9.6-beta shows "In progress", count is 10, list includes tadpole + agrias butterfly
- [ ] `public/version-history.html`: open in browser; confirm "ten hand-drawn icons" and 95.5% ACNH in the checklist
- [ ] Build passes: `npm run build`

---
_Generated by [Claude Code](https://claude.ai/code/session_01MByGyPSwBYUXqyNeQQPA62)_