### PR TITLE
doc-sync: bump version references v0.9.5-beta → v0.9.6-beta

### DIFF
--- a/.claude/rules/architecture.md
+++ b/.claude/rules/architecture.md
@@ -1,4 +1,4 @@
-# Architecture Reference (v0.9.5-beta)
+# Architecture Reference (v0.9.6-beta)
 
 ## Stack
 Vite + React 19 + TypeScript + Tailwind CSS v4 + Zustand (persist + non-persisted UI store) + React Router v6. Meadow design tokens (CSS custom properties in `src/index.css` `@theme`); Fraunces (display) + Inter (UI).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,7 +16,7 @@ See `docs/architecture.md` — deep architectural context (store schema, migrati
 ## Project Overview
 
 Animal Crossing multi-game companion web app. Tracks museum donations (fish, bugs, fossils, art) across multiple towns and games.
-Meadow design language (Fraunces + Inter, moss-green accent) as of v0.9. Current release: v0.9.5-beta (2026-05-10) — ACNL icon gap-fill (96.5% coverage, ACCF to 100%), three new hand-drawn icons (frog, robust cicada, brown cicada). Previous: v0.9.4-beta (silhouette rendering + ACWW gap-fill), v0.9.3-beta (JSON save-file round-trip), v0.9.2-beta (cross-game icon routing + first hand-drawn icons), v0.9.1-beta (ACGCN item icons), v0.9.0-beta (full UI revamp).
+Meadow design language (Fraunces + Inter, moss-green accent) as of v0.9. Current release: v0.9.6-beta (2026-05-28) — ACNH icon gap-fill (95.5% coverage), three new hand-drawn icons (goldfish, tadpole, agrias butterfly). Previous: v0.9.5-beta (ACNL icon gap-fill + three hand-drawn icons), v0.9.4-beta (silhouette rendering + ACWW gap-fill), v0.9.3-beta (JSON save-file round-trip), v0.9.2-beta (cross-game icon routing + first hand-drawn icons), v0.9.1-beta (ACGCN item icons), v0.9.0-beta (full UI revamp).
 Live at: https://animalcrossingwebapp.vercel.app | Dev preview: https://development-animalcrossingwebapp.vercel.app
 
 ## Commands
@@ -352,10 +352,11 @@ Do not add new top-level tabs without updating the tab switch in ACCanvas, the n
 - PR #130 — Polish nits: version-history headline (29 days), useIconChecker useMemo, test-stub cleanup (closes #124, #95, addresses #92 item 4)
 - PR #131 — sixth + seventh hand-drawn icons: robust cicada + brown cicada (bugs); 68 KB each at 768px
 
-### v0.9.6-beta — ACNH icon gap-fill (next milestone)
+### v0.9.6-beta — ACNH icon gap-fill + three hand-drawn icons — **shipped 2026-05-28**
 
-- Icon scrape + manifest for ACNH (103 unique items remain after cross-game uplift from v0.9.5)
-- Uses same algorithmic-resolver-plus-OVERRIDES pattern; resolver /Gallery deprioritization from #127 generalizes directly
+- PR #136 — eighth hand-drawn icon: goldfish (fish); replaces scraped placeholder; 768px export 88.9 KB
+- PR #140 — ACNH icon gap-fill: 88 wiki-scraped items; ACNH coverage 68.8% → 95.5% (315/330); 15 genuine gaps logged to `scripts/missing-acnh.txt`; resolver improvements: `a:sentence` probe + `c:search` deprioritizes furniture model pages
+- PR #144 — ninth + tenth hand-drawn icons: tadpole (fish) and agrias butterfly (bugs); manifest updated jpg → png for agrias butterfly
 
 ### v1.0 — Launch ready
 

--- a/README.md
+++ b/README.md
@@ -67,6 +67,6 @@ Museum data lives in `public/data/<game>/`:
 
 ## Version
 
-Current release: **v0.9.5-beta** (2026-05-10) — ACNL icon gap-fill (96.5% coverage, ACCF to 100%), three new hand-drawn icons (frog, robust cicada, brown cicada). Previous betas: **v0.9.4-beta** (silhouette rendering + ACWW icon gap-fill), **v0.9.3-beta** (JSON save-file round-trip + onboarding fixes), **v0.9.2-beta** (cross-game icon routing + first hand-drawn icons), **v0.9.1-beta** (ACGCN item icons), **v0.9.0-beta** (full UI revamp). Last stable on `main`: **v0.8.2-alpha**. See [CHANGELOG.md](CHANGELOG.md) for history and [docs/roadmap-to-v1.md](docs/roadmap-to-v1.md) for the path to v1.0.
+Current release: **v0.9.6-beta** (2026-05-28) — ACNH icon gap-fill (95.5% coverage), three new hand-drawn icons (goldfish, tadpole, agrias butterfly). Previous betas: **v0.9.5-beta** (ACNL icon gap-fill + three hand-drawn icons), **v0.9.4-beta** (silhouette rendering + ACWW icon gap-fill), **v0.9.3-beta** (JSON save-file round-trip + onboarding fixes), **v0.9.2-beta** (cross-game icon routing + first hand-drawn icons), **v0.9.1-beta** (ACGCN item icons). Last stable on `main`: **v0.8.2-alpha**. See [CHANGELOG.md](CHANGELOG.md) for history and [docs/roadmap-to-v1.md](docs/roadmap-to-v1.md) for the path to v1.0.
 
 Significant design decisions are logged in [docs/decisions.md](docs/decisions.md).

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,4 +1,4 @@
-# Architecture Reference (v0.9.5-beta)
+# Architecture Reference (v0.9.6-beta)
 
 This document mirrors `.claude/rules/architecture.md` — the canonical copy that Claude Code sessions auto-load. They are kept in lockstep; if they diverge, the `.claude/rules/` copy wins. Update both together.
 


### PR DESCRIPTION
## Summary

Nightly doc-sync audit 2026-05-29 found four clear-drift corrections across four files. All changes reflect the v0.9.6-beta release (tagged 2026-05-28, PR #145) that was not yet reflected in the living docs.

### What changed

**`README.md` — Version section**
- `v0.9.5-beta (2026-05-10)` → `v0.9.6-beta (2026-05-28)` with updated release summary (ACNH gap-fill, goldfish/tadpole/agrias butterfly)
- Previous-betas chain shifted forward: v0.9.5-beta added, v0.9.0-beta dropped to keep list length manageable

**`CLAUDE.md` — Project Overview + Roadmap**
- Current-release line updated to v0.9.6-beta (2026-05-28) with correct description
- v0.9.6-beta roadmap section converted from "next milestone" placeholder to a proper shipped entry listing PRs #136, #140, and #144 (consistent with the pattern used by every prior beta section)

**`docs/architecture.md` + `.claude/rules/architecture.md` — header version string**
- Both headers: `v0.9.5-beta` → `v0.9.6-beta`
- `docs/architecture.md` explicitly states "Update both together" — done

### Not touched

- `package.json` — already `0.9.6-beta` ✓
- `CHANGELOG.md` — `[Unreleased]` is empty, `[v0.9.6-beta]` section exists and is complete ✓
- `docs/roadmap-to-v1.md` — already shows v0.9.6-beta as Shipped 2026-05-27, hand-drawn count at 10/255 ✓
- `public/version-history.html` — updated as part of the release commit (commit `8994b87`) ✓

### Prior draft PR #146 (2026-05-25)

PR #146 proposed CHANGELOG/roadmap/version-history changes for work that was still unreleased at the time. Those changes were incorporated directly into the v0.9.6-beta release commit and PR #145. PR #146 is now largely superseded but has not been closed (per nightly-doc-sync policy: never close human-filed PRs).

### Ambiguous issue #143

Issue #143 asked whether PR #136 (goldfish) should be added to CLAUDE.md's v0.9.6-beta section before the release tagged. Now that v0.9.6-beta has shipped, the answer is clear — this PR's CLAUDE.md update covers it as part of the full shipped-section entry.

## Test plan

- [ ] `README.md`: confirm version line reads `v0.9.6-beta (2026-05-28)`
- [ ] `CLAUDE.md`: confirm Project Overview shows v0.9.6-beta; roadmap v0.9.6-beta section shows "shipped 2026-05-28" with PRs #136, #140, #144
- [ ] `docs/architecture.md`: confirm header reads `v0.9.6-beta`
- [ ] `.claude/rules/architecture.md`: confirm header reads `v0.9.6-beta`
- [ ] `npm run build` — no build-time issues from doc changes

---
_Generated by nightly doc-sync audit · 2026-05-29_

---
_Generated by [Claude Code](https://claude.ai/code/session_013csS8CMEwK4kJ9riekPwNN)_