### PR TITLE
fix: raise import-modal button contrast to AA (#153)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project are documented here.
 
 ## [Unreleased]
 
+### Fixed
+
+- **Import modal button contrast** (#153) — `.ac-im-cta` now uses `color: var(--surface)` instead of `var(--accent-ink)` on the moss-green background, lifting the import flow's primary CTA from ~2.7:1 to ~4.6:1 (AA). The destructive-confirm `.ac-im-cta-danger` now uses the danger-zone strong red (white-on-red ~6.4:1) instead of `--warn` (~3.8:1). Surfaced by the v0.9.6-beta codebase health audit (A11Y-1)
+
 ## [v0.9.6-beta] — 2026-05-24
 
 ### Added

--- a/src/index.css
+++ b/src/index.css
@@ -1657,7 +1657,7 @@ body {
 .ac-im-cta {
   align-self: flex-start;
   background: var(--accent);
-  color: var(--accent-ink);
+  color: var(--surface);
   border: none; border-radius: 10px;
   padding: 10px 18px;
   font-weight: 600; font-size: 14px;
@@ -1677,7 +1677,7 @@ body {
 }
 .ac-im-cta-secondary:hover { background: var(--surface-alt); color: var(--ink); }
 .ac-im-cta-danger {
-  background: var(--warn);
+  background: oklch(0.5 0.14 25);
   color: #fff;
 }
 .ac-im-cta-danger:hover { opacity: 0.9; }


### PR DESCRIPTION
## Summary
Fixes the import-modal button contrast flagged by the v0.9.6-beta codebase health audit (A11Y-1). The import flow's primary CTA (`.ac-im-cta`) was the only accent button in the app coloured `accent-ink` on `accent` (~2.7:1, below AA). This switches it to `surface` (~4.6:1), matching every other accent button (`.ac-donate-btn`, `.ac-tm-primary`). The destructive-confirm `.ac-im-cta-danger` moves from `--warn` (white-on-clay ~3.8:1) to the existing danger-zone strong red (`oklch(0.5 0.14 25)`, ~6.4:1).

CSS-only, no behaviour change.

## Decisions
- Reused the existing `.ac-danger-btn-strong` red for the destructive confirm rather than introducing a new token, keeping the palette unchanged.

## Test plan
- `npm run build` — green.
- `npm test` — green (no test touches these tokens).
- Visual: import modal primary + destructive buttons now read as white-on-colour.

Closes #153
