### PR TITLE
test: cover storeMigrations + bootstrapMigration; harden DI-6 (#151)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project are documented here.
 
 ## [Unreleased]
 
+### Added
+
+- **Migration test coverage** (#151) — added `storeMigrations.test.ts` (9 tests over the v1→v2 donation lift + gameId backfill and the v2→v3 hemisphere backfill, including idempotency) and `bootstrapMigration.test.ts` (5 tests over the one-time localStorage key rename). These guard the documented zero-data-loss path for pre-v0.7 users, which previously had no tests. Surfaced by the v0.9.6-beta codebase health audit (TEST-1)
+
 ### Changed
 
 - **Re-encoded oversized raster icons** (#152) — the raw wiki-scraped art and fossil `.jpg` icons under `public/icons/` shipped at full wiki resolution (e.g. `art/informative-statue.jpg` at 3.8 MB / 3665×4288) but render into 48–192px slots. Downsampled all 113 oversized art + fossil JPGs in place to ≤384px (mozjpeg q80) via a new `npm run icons:reencode` script: 14.85 MB → 1.31 MB (~91% smaller); the Art tab drops from ~11.5 MB to ~1.1 MB. Filenames and extensions are unchanged, so `manifest.json` stays valid and there is no app code change. Icon coverage unchanged (verified via `npm run audit:icons`). Surfaced by the v0.9.6-beta codebase health audit (PERF-1)
@@ -14,6 +18,7 @@ All notable changes to this project are documented here.
 
 ### Fixed
 
+- **bootstrapMigration no longer deletes the old key on a corrupt new key** (#151) — `bootstrapLocalStorageMigration` now removes `ac-web:v1` only once `ac-web` is present **and** parses as JSON. Previously a corrupted `ac-web` value would trigger deletion of the only remaining valid copy of pre-rename data. Surfaced by the v0.9.6-beta codebase health audit (DI-6)
 - **Import modal button contrast** (#153) — `.ac-im-cta` now uses `color: var(--surface)` instead of `var(--accent-ink)` on the moss-green background, lifting the import flow's primary CTA from ~2.7:1 to ~4.6:1 (AA). The destructive-confirm `.ac-im-cta-danger` now uses the danger-zone strong red (white-on-red ~6.4:1) instead of `--warn` (~3.8:1). Surfaced by the v0.9.6-beta codebase health audit (A11Y-1)
 
 ## [v0.9.6-beta] — 2026-05-24

--- a/src/lib/bootstrapMigration.test.ts
+++ b/src/lib/bootstrapMigration.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect } from 'vitest';
+import { bootstrapLocalStorageMigration } from './bootstrapMigration';
+
+const OLD_KEY = 'ac-web:v1';
+const NEW_KEY = 'ac-web';
+// localStorage is cleared between tests by src/test/setup.ts.
+
+describe('bootstrapLocalStorageMigration', () => {
+  it('copies the old key to the new key and removes the old key', () => {
+    const payload = JSON.stringify({ state: { towns: [] }, version: 1 });
+    localStorage.setItem(OLD_KEY, payload);
+
+    bootstrapLocalStorageMigration();
+
+    expect(localStorage.getItem(NEW_KEY)).toBe(payload);
+    expect(localStorage.getItem(OLD_KEY)).toBeNull();
+  });
+
+  it('does not overwrite an existing new key', () => {
+    const oldPayload = JSON.stringify({
+      state: { towns: ['old'] },
+      version: 1,
+    });
+    const newPayload = JSON.stringify({
+      state: { towns: ['new'] },
+      version: 3,
+    });
+    localStorage.setItem(OLD_KEY, oldPayload);
+    localStorage.setItem(NEW_KEY, newPayload);
+
+    bootstrapLocalStorageMigration();
+
+    expect(localStorage.getItem(NEW_KEY)).toBe(newPayload);
+    expect(localStorage.getItem(OLD_KEY)).toBeNull();
+  });
+
+  it('is a no-op when neither key exists', () => {
+    expect(() => bootstrapLocalStorageMigration()).not.toThrow();
+    expect(localStorage.getItem(NEW_KEY)).toBeNull();
+    expect(localStorage.getItem(OLD_KEY)).toBeNull();
+  });
+
+  it('does not destroy the old key when the new key is corrupt (DI-6)', () => {
+    const oldPayload = JSON.stringify({
+      state: { towns: ['real'] },
+      version: 1,
+    });
+    localStorage.setItem(OLD_KEY, oldPayload);
+    localStorage.setItem(NEW_KEY, '{ this is not valid json');
+
+    bootstrapLocalStorageMigration();
+
+    // The only valid copy of the user's data must survive.
+    expect(localStorage.getItem(OLD_KEY)).toBe(oldPayload);
+  });
+
+  it('removes the old key once a valid new key is present', () => {
+    localStorage.setItem(OLD_KEY, JSON.stringify({ state: {}, version: 1 }));
+    localStorage.setItem(NEW_KEY, JSON.stringify({ state: {}, version: 3 }));
+
+    bootstrapLocalStorageMigration();
+
+    expect(localStorage.getItem(OLD_KEY)).toBeNull();
+  });
+});

--- a/src/lib/bootstrapMigration.ts
+++ b/src/lib/bootstrapMigration.ts
@@ -11,8 +11,20 @@ export function bootstrapLocalStorageMigration(): void {
   if (old && !localStorage.getItem(NEW_KEY)) {
     localStorage.setItem(NEW_KEY, old);
   }
-  // Remove old key once new key is confirmed present
-  if (localStorage.getItem(NEW_KEY)) {
+  // Remove the old key only once the new key is present AND parseable. A
+  // corrupted 'ac-web' value must not trigger deletion of 'ac-web:v1' — that
+  // would destroy the only remaining valid copy of the user's pre-rename data.
+  const current = localStorage.getItem(NEW_KEY);
+  if (current !== null && isParseable(current)) {
     localStorage.removeItem(OLD_KEY);
+  }
+}
+
+function isParseable(value: string): boolean {
+  try {
+    JSON.parse(value);
+    return true;
+  } catch {
+    return false;
   }
 }

--- a/src/lib/storeMigrations.test.ts
+++ b/src/lib/storeMigrations.test.ts
@@ -1,0 +1,122 @@
+import { describe, it, expect } from 'vitest';
+import { migrateStore } from './storeMigrations';
+
+type AnyState = Record<string, unknown>;
+
+describe('migrateStore — v1 → v2 (gameId backfill + donation lift)', () => {
+  it('lifts donated/donatedAt from [townId][itemId] to [townId][ACGCN][itemId]', () => {
+    const v1: AnyState = {
+      towns: [{ id: 't1', name: 'Smashville' }],
+      donated: { t1: { 'sea-bass': true, koi: false } },
+      donatedAt: { t1: { 'sea-bass': '2026-01-02T00:00:00.000Z' } },
+    };
+
+    const out = migrateStore(v1, 1) as AnyState;
+
+    expect(out.donated).toEqual({
+      t1: { ACGCN: { 'sea-bass': true, koi: false } },
+    });
+    expect(out.donatedAt).toEqual({
+      t1: { ACGCN: { 'sea-bass': '2026-01-02T00:00:00.000Z' } },
+    });
+  });
+
+  it('backfills gameId = ACGCN on towns that lack one', () => {
+    const v1: AnyState = {
+      towns: [{ id: 't1', name: 'Smashville' }],
+      donated: {},
+      donatedAt: {},
+    };
+
+    const out = migrateStore(v1, 1) as AnyState;
+    const towns = out.towns as Array<Record<string, unknown>>;
+    expect(towns[0].gameId).toBe('ACGCN');
+  });
+
+  it('preserves an already-set gameId rather than overwriting it', () => {
+    const v1: AnyState = {
+      towns: [{ id: 't1', name: 'Leaf', gameId: 'ACNH' }],
+      donated: {},
+      donatedAt: {},
+    };
+
+    const out = migrateStore(v1, 1) as AnyState;
+    const towns = out.towns as Array<Record<string, unknown>>;
+    expect(towns[0].gameId).toBe('ACNH');
+  });
+
+  it('tolerates missing donated/donatedAt/towns', () => {
+    const out = migrateStore({}, 1) as AnyState;
+    expect(out.towns).toEqual([]);
+    expect(out.donated).toEqual({});
+    expect(out.donatedAt).toEqual({});
+  });
+});
+
+describe('migrateStore — v2 → v3 (hemisphere backfill)', () => {
+  it('backfills hemisphere = NH on towns that lack one', () => {
+    const v2: AnyState = {
+      towns: [
+        { id: 't1', name: 'A', gameId: 'ACGCN' },
+        { id: 't2', name: 'B', gameId: 'ACNH' },
+      ],
+    };
+
+    const out = migrateStore(v2, 2) as AnyState;
+    const towns = out.towns as Array<Record<string, unknown>>;
+    expect(towns.map(t => t.hemisphere)).toEqual(['NH', 'NH']);
+  });
+
+  it('preserves an explicitly-set SH hemisphere', () => {
+    const v2: AnyState = {
+      towns: [{ id: 't1', name: 'A', gameId: 'ACNH', hemisphere: 'SH' }],
+    };
+
+    const out = migrateStore(v2, 2) as AnyState;
+    const towns = out.towns as Array<Record<string, unknown>>;
+    expect(towns[0].hemisphere).toBe('SH');
+  });
+});
+
+describe('migrateStore — full v1 → v3 chain and idempotency', () => {
+  it('applies both the donation lift and hemisphere backfill from version 0/1', () => {
+    const v1: AnyState = {
+      towns: [{ id: 't1', name: 'A' }],
+      donated: { t1: { 'sea-bass': true } },
+      donatedAt: { t1: { 'sea-bass': '2026-01-02T00:00:00.000Z' } },
+    };
+
+    const out = migrateStore(v1, 0) as AnyState;
+    const towns = out.towns as Array<Record<string, unknown>>;
+    expect(towns[0].gameId).toBe('ACGCN');
+    expect(towns[0].hemisphere).toBe('NH');
+    expect(out.donated).toEqual({ t1: { ACGCN: { 'sea-bass': true } } });
+  });
+
+  it('is a no-op (other than identity) when already at the current version', () => {
+    const v3: AnyState = {
+      towns: [{ id: 't1', name: 'A', gameId: 'ACNH', hemisphere: 'SH' }],
+      donated: { t1: { ACNH: { 'sea-bass': true } } },
+      donatedAt: { t1: { ACNH: { 'sea-bass': '2026-01-02T00:00:00.000Z' } } },
+    };
+
+    const out = migrateStore(v3, 3) as AnyState;
+    expect(out.donated).toEqual(v3.donated);
+    expect(out.donatedAt).toEqual(v3.donatedAt);
+    expect(out.towns).toEqual(v3.towns);
+  });
+
+  it('re-running the migration on its own output does not double-lift donations', () => {
+    const v1: AnyState = {
+      towns: [{ id: 't1', name: 'A' }],
+      donated: { t1: { koi: true } },
+      donatedAt: {},
+    };
+
+    const once = migrateStore(v1, 1) as AnyState;
+    // Feeding the already-migrated state back through at the current version
+    // must not wrap it a second time (no [townId][ACGCN][ACGCN]).
+    const twice = migrateStore(once, 3) as AnyState;
+    expect(twice.donated).toEqual({ t1: { ACGCN: { koi: true } } });
+  });
+});


### PR DESCRIPTION
## Summary
Adds the missing test coverage for the documented zero-data-loss migration path (TEST-1 from the v0.9.6-beta codebase health audit). `storeMigrations.ts` and `bootstrapMigration.ts` protect every pre-v0.7 user's donation history but had **zero tests** — a regression would silently corrupt legacy data on next load with nothing to catch it.

- `src/lib/storeMigrations.test.ts` — 9 tests: the v1→v2 donation lift (`[townId][itemId]` → `[townId][ACGCN][itemId]`) + gameId backfill, the v2→v3 hemisphere backfill, preservation of already-set gameId/hemisphere, tolerance of missing maps, the full v1→v3 chain, and idempotency (re-running doesn't double-lift).
- `src/lib/bootstrapMigration.test.ts` — 5 tests: copy old→new, don't overwrite an existing new key, no-op when neither exists, removal once a valid new key is present, and the DI-6 regression below.

## Decisions
- **Included the DI-6 hardening** so the regression test is meaningful: `bootstrapLocalStorageMigration` now deletes `ac-web:v1` only once `ac-web` is present **and** parses as JSON. Previously a corrupted `ac-web` value would delete the only remaining valid copy of pre-rename data. The change is strictly safer (it only *keeps* the old key in the corrupt-new edge case) and additive otherwise — kept it in this PR rather than splitting, since it's small and the test depends on it.

## Test plan
- `npx vitest run src/lib/storeMigrations.test.ts src/lib/bootstrapMigration.test.ts` — 14/14 pass.
- `npm run build` (tsc + vite) — green.
- eslint + prettier clean on all touched files (also enforced by the pre-commit hook).

Closes #151
