### PR TITLE
doc-sync: fix version-history.html table order, styling, and v0.9.6 stats

### DIFF
--- a/public/version-history.html
+++ b/public/version-history.html
@@ -1109,7 +1109,7 @@
               <div class="box">✓</div>
               <span class="text"
                 >ACWW icon coverage at 100% — 84 wiki-scraped items; ACCF 100%,
-                ACNL 96.5%, ACNH 68.8% via cross-game ID routing</span
+                ACNL 96.5%, ACNH 95.5% via cross-game ID routing + dedicated gap-fill (PR #140)</span
               >
             </div>
             <div class="check-item done">
@@ -1122,8 +1122,8 @@
             <div class="check-item done">
               <div class="box">✓</div>
               <span class="text"
-                >ACGCN item icons + cross-game routing + eight hand-drawn icons
-                (sea-bass, koi, ant, coelacanth, frog, robust cicada, brown cicada, goldfish)</span
+                >ACGCN item icons + cross-game routing + ten hand-drawn icons
+                (sea-bass, koi, ant, coelacanth, frog, robust cicada, brown cicada, goldfish, tadpole, agrias butterfly)</span
               >
             </div>
             <div class="check-item done">
@@ -1550,17 +1550,6 @@
                     font-weight: bold;
                   "
                 >
-                  v0.9.6-beta
-                </td>
-                <td style="padding: 0.6rem 1rem">May 27</td>
-                <td style="padding: 0.6rem 1rem">17 days</td>
-                <td style="padding: 0.6rem 1rem">
-                  ACNH icon gap-fill (~100%) + two hand-drawn icons (tadpole,
-                  agrias butterfly) + doc syncs
-                </td>
-              </tr>
-              <tr style="border-top: 1px solid var(--border)">
-                <td style="padding: 0.6rem 1rem">
                   v0.9.5-beta
                 </td>
                 <td style="padding: 0.6rem 1rem">May 10</td>
@@ -1568,6 +1557,23 @@
                 <td style="padding: 0.6rem 1rem">
                   ACNL icon gap-fill (96.5%) + ACCF 100% via cross-game +
                   three hand-drawn icons (frog, robust cicada, brown cicada)
+                </td>
+              </tr>
+              <tr style="border-top: 1px solid var(--border)">
+                <td
+                  style="
+                    padding: 0.6rem 1rem;
+                    color: var(--leaf);
+                    font-weight: bold;
+                  "
+                >
+                  v0.9.6-beta
+                </td>
+                <td style="padding: 0.6rem 1rem">May 27</td>
+                <td style="padding: 0.6rem 1rem">17 days</td>
+                <td style="padding: 0.6rem 1rem">
+                  ACNH icon gap-fill (~100%) + two hand-drawn icons (tadpole,
+                  agrias butterfly) + doc syncs
                 </td>
               </tr>
             </tbody>


### PR DESCRIPTION
## Summary

Three corrections to `public/version-history.html` detected by the 2026-06-13 nightly doc-sync audit:

1. **Table row order** — the v0.9.5-beta row appeared *after* v0.9.6-beta in the velocity table (wrong chronological order). Moved v0.9.5-beta above v0.9.6-beta.
2. **Missing row styling** — v0.9.5-beta lacked the `color: var(--leaf); font-weight: bold` styling applied to every other shipped-version row. Added.
3. **Stale stats in "Recently shipped" checklist:**
   - ACNH icon coverage: `68.8%` → `95.5% via cross-game ID routing + dedicated gap-fill (PR #140)` (reflects the v0.9.6-beta ACNH gap-fill)
   - Hand-drawn icon count: `eight` → `ten`, with tadpole and agrias butterfly added to the named list (both shipped in v0.9.6-beta)

No other files changed. No scope creep.

## Supersedes

PR #146 (2026-05-25 doc-sync) — that draft targeted the same file; this PR's corrections are a superset of what remained valid from that run. PR #146 can be closed once this merges.

## Test plan

- [ ] Visual spot-check: version-history.html loads; v0.9.5-beta row appears above v0.9.6-beta, both in leaf-green bold
- [ ] "Recently shipped" checklist: ACNH coverage reads 95.5%, hand-drawn count reads ten with full list
- [ ] No other pages affected (single-file change)

---
_Generated by [Claude Code](https://claude.ai/code/session_01HH3xhXugfd9wGojLmJH6mG)_