### PR TITLE
doc-sync: remove dead file refs in .claude/rules/architecture.md; bump headers to v0.9.6-beta

### DIFF
--- a/.claude/rules/architecture.md
+++ b/.claude/rules/architecture.md
@@ -1,4 +1,4 @@
-# Architecture Reference (v0.9.5-beta)
+# Architecture Reference (v0.9.6-beta)
 
 ## Stack
 Vite + React 19 + TypeScript + Tailwind CSS v4 + Zustand (persist + non-persisted UI store) + React Router v6. Meadow design tokens (CSS custom properties in `src/index.css` `@theme`); Fraunces (display) + Inter (UI).
@@ -10,7 +10,6 @@ Vite + React 19 + TypeScript + Tailwind CSS v4 + Zustand (persist + non-persiste
 - `src/lib/uiStore.ts` — non-persisted Zustand store for transient UI state (`townManagerOpen`, `townManagerForceCreate`).
 - `src/lib/types.ts` — GameId union, `Town` (no longer has `playerName` — removed in Phase 4 / Decision 5), Game interface, GAMES registry, GAME_LIST.
 - `src/lib/constants.ts` — MONTH_NAMES, CATEGORY_LABELS, CATEGORY_ORDER, SEASONS.
-- `src/lib/colors.ts` — `meadow` token export (mirrors CSS custom properties), `fontStacks` for Fraunces/Inter, legacy `colors` retained until consumers retire.
 - `src/lib/categoryMeta.ts` — CATEGORY_META (label / Icon / file / data presence per game).
 - `src/lib/viewTypes.ts` — ViewId union and AllData shape. Phase 8 removed the `'search'` route.
 - `src/lib/storeMigrations.ts` — Zustand migrate callback v1→v2 (gameId backfill) and v2→v3 (hemisphere backfill).
@@ -39,9 +38,9 @@ Vite + React 19 + TypeScript + Tailwind CSS v4 + Zustand (persist + non-persiste
 ### Components — rows + panels
 - `src/components/CollectibleRow.tsx` — Phase 5 restyle. Monogram glyph, meta line with `·` separators, leaving/new pills, animated chevron. Stamps `data-row-id`. Donate UI lives in the expand panel only.
 - `src/components/ItemExpandPanel.tsx` — Phase 5 rebuild. Two-column grid: MonthGrid + stats stack (bells / shadow / hours / notes) + donate button.
-- `src/components/shared/` — DonateToggle, EmptyState, HabitatChip, MonthGrid (Phase 5 re-skin, accepts `current` prop), SearchBar (per-tab, used by CategoryTab). `CategoryProgress.tsx` is dead — file remains pending cleanup.
+- `src/components/shared/` — EmptyState, MonthGrid (Phase 5 re-skin, accepts `current` prop), SearchBar (per-tab, used by CategoryTab). DonateToggle, HabitatChip, and CategoryProgress.tsx deleted in #157 (zero importers after Phase 5/7/9 retirements).
 - `src/components/modals/` — DetailModal **retired in v0.9 (#81)**; file deleted. Art now uses the inline `ItemExpandPanel` like every other category.
-- `src/components/views/ActivityFeed.tsx` — recent donations list (consumed by HomeTab). `AnalyticsView` and `SectionCard` retired in Phase 9.
+- `src/components/views/ActivityFeed.tsx` — recent donations list (consumed by ACCanvas). `AnalyticsView` and `SectionCard` retired in Phase 9.
 - `src/components/search/GlobalSearchDropdown.tsx` — Phase 8 unified search dropdown (anchored under Home topbar). Grouped category results (5 groups for ACNL/ACNH, 4 elsewhere), keyboard nav (↑↓↵esc), search history at localStorage key `ac-curator-search-history` (max 8). Replaces GlobalSearchBar / GlobalSearchResults / SearchHistoryPopover.
 
 ### Data

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,4 +1,4 @@
-# Architecture Reference (v0.9.5-beta)
+# Architecture Reference (v0.9.6-beta)
 
 This document mirrors `.claude/rules/architecture.md` — the canonical copy that Claude Code sessions auto-load. They are kept in lockstep; if they diverge, the `.claude/rules/` copy wins. Update both together.
 


### PR DESCRIPTION
## Summary

Three stale entries in `.claude/rules/architecture.md` were introduced when PR #157 (dead-file cleanup, 2026-06-11) deleted files from the repo without updating this reference doc. Both architecture headers also still said `v0.9.5-beta`.

### What changed

**`.claude/rules/architecture.md`**

1. **`src/lib/colors.ts` entry removed** — file deleted in #157. The `meadow`/`colors`/`fontStacks` exports had zero importers; design tokens now live solely in `src/index.css` `@theme`.
2. **`src/components/shared/` list corrected** — DonateToggle, HabitatChip, and CategoryProgress.tsx removed from the listing (all deleted in #157 with zero importers). EmptyState, MonthGrid, and SearchBar remain.
3. **`ActivityFeed` consumer corrected** — was "consumed by HomeTab"; CLAUDE.md was already corrected to "consumed by ACCanvas" by #157 but this file was missed. Now consistent.
4. **Header bumped** — `v0.9.5-beta` → `v0.9.6-beta`.

**`docs/architecture.md`**

- Header bumped — `v0.9.5-beta` → `v0.9.6-beta` (per the "update both together" note in the file).

### Supersedes

The architecture-file portions of draft PR #149 (2026-05-29 doc-sync) are superseded by this PR. PR #149 proposed only the version header bumps in these two files; this PR includes those bumps plus the dead-file corrections that #149 predates. PR #149's remaining changes (CLAUDE.md v0.9.6 roadmap section and README.md) are not touched here.

### Not touched

- `CLAUDE.md` — v0.9.6 roadmap section still says "next milestone"; that correction remains in PR #149
- `version-history.html` — stale ACNH stats + hand-drawn count covered by PR #162
- All other files — no drift detected

## Test plan

- [ ] Verify `.claude/rules/architecture.md`: `colors.ts` line absent; `shared/` list shows only EmptyState, MonthGrid, SearchBar; ActivityFeed says "consumed by ACCanvas"; header reads v0.9.6-beta
- [ ] Verify `docs/architecture.md`: header reads v0.9.6-beta
- [ ] Confirm no build-impacting changes (doc-only PR)

---
_Generated by [Claude Code](https://claude.ai/code/session_01UApyeEnxFNiNhj5GeM7gKZ)_