### PR TITLE
doc-sync: add storeMigrations.test.ts + bootstrapMigration.test.ts to CLAUDE.md file structure

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -161,6 +161,8 @@ src/
     saveFile.test.ts        # Vitest tests for save-file schema + serialiser
     saveFileImport.test.ts  # Vitest tests for parser + validator
     saveFileReconcile.test.ts # Vitest tests for reconciler
+    storeMigrations.test.ts # Vitest tests for v1→v2 + v2→v3 store migrations (idempotency) (#151)
+    bootstrapMigration.test.ts # Vitest tests for one-time localStorage key rename (#151)
   test/
     setup.ts                # Vitest setup file
 public/data/acgcn/


### PR DESCRIPTION
## Summary

PR #151 (migration test coverage, merged 2026-06-11) added two new test files to `src/lib/`:

- `storeMigrations.test.ts` — 9 tests covering the v1→v2 donation lift + gameId backfill and the v2→v3 hemisphere backfill, including idempotency
- `bootstrapMigration.test.ts` — 5 tests covering the one-time localStorage key rename and its safe-delete guard (also fixed a bug where a corrupt `ac-web` value would trigger deletion of the only valid `ac-web:v1` copy)

Neither file was added to the `src/lib/` section of CLAUDE.md's file structure listing. This PR adds both entries alongside the existing test file entries (`store.test.ts`, `uiStore.test.ts`, etc.).

### What changed

**`CLAUDE.md` — `src/lib/` file structure section**

Added after `saveFileReconcile.test.ts`:
```
    storeMigrations.test.ts # Vitest tests for v1→v2 + v2→v3 store migrations (idempotency) (#151)
    bootstrapMigration.test.ts # Vitest tests for one-time localStorage key rename (#151)
```

### Not touched

- No other files changed
- The roadmap v0.9.6 "next milestone" language in CLAUDE.md is covered by existing draft PR #149
- `docs/architecture.md` + `.claude/rules/architecture.md` header + dead refs are covered by existing draft PR #163
- `public/version-history.html` stats are covered by existing draft PR #162

## Test plan

- [ ] Confirm `src/lib/storeMigrations.test.ts` exists on `development`
- [ ] Confirm `src/lib/bootstrapMigration.test.ts` exists on `development`
- [ ] Confirm both entries appear in the `src/lib/` block of CLAUDE.md
- [ ] Doc-only change — no build impact

---
_Generated by nightly doc-sync audit · 2026-06-23_

---
_Generated by [Claude Code](https://claude.ai/code/session_01U99yfMJMFrAebxMTByw2Cy)_