### PR TITLE
doc-sync: remove stale modals/ directory entry from CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -94,9 +94,8 @@ src/
       SearchBar.tsx         # Per-tab inline search input (consumed by CategoryTab)
       # DonateToggle.tsx, HabitatChip.tsx, CategoryProgress.tsx — DELETED (dead code
       # cleanup, #157). All had zero importers after the Phase 5/7/9 retirements.
-    modals/
-      # DetailModal.tsx — RETIRED in v0.9 (#81). Was the bottom-sheet for the Art
-      # tab; art now uses the inline ItemExpandPanel like every other category.
+    # modals/ — directory removed. DetailModal.tsx was retired in v0.9 (#81); it
+    # was the bottom-sheet for the Art tab, replaced by the inline ItemExpandPanel.
     TownManager.tsx         # v0.9 Phase 4: right-side drawer (bottom sheet ≤720px) mounted
                             # at App layout level via useUIStore. Switch/edit/create/delete
                             # towns. Inline edit = name + (ACNH-only) hemisphere — game is


### PR DESCRIPTION
## Summary

Nightly doc-sync audit 2026-07-01 found one clear-drift correction.

`src/components/modals/` no longer exists on disk — `DetailModal.tsx` (its only file) was deleted in v0.9 (#81) when art moved to the inline `ItemExpandPanel`, and no other file was ever added to that directory. CLAUDE.md's `### File Structure` tree still listed `modals/` as a live directory node with a comment underneath, implying it's still part of the tree.

### What changed

**`CLAUDE.md` — `### File Structure` section**

Replaced the `modals/` directory node (with nested comment) with a single comment line at the same level as its sibling entries, matching the pattern already used for other deleted files (e.g. the `DonateToggle.tsx, HabitatChip.tsx, CategoryProgress.tsx — DELETED` line directly above it). The historical note about `DetailModal.tsx`'s retirement is preserved.

### Not touched

- All other drift found this run duplicates existing open draft PRs and was skipped (see tracker comment): #162 (version-history.html stats/table), #163 (architecture.md headers + dead-file refs), #164 (CLAUDE.md test-file entries)
- PRs #149 and #146 appear fully superseded — their proposed changes already exist on `development` — but are left open per the "never close" policy; noted in the tracker for human review
- No other file-structure drift found (verified every path in CLAUDE.md's tree and every backtick-quoted path in both architecture.md copies against the actual filesystem)

## Test plan

- [ ] Confirm `src/components/modals/` does not exist in the repo
- [ ] Confirm CLAUDE.md no longer lists it as a directory node
- [ ] Doc-only change — no build impact

---
_Generated by nightly doc-sync audit · 2026-07-01_

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q9DMHJMx6JhtbjGfG7Q1AY)_