### PR TITLE
doc-sync: fix ACNH coverage overstatement + stale main version

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,6 @@ Museum data lives in `public/data/<game>/`:
 
 ## Version
 
-Current release: **v0.9.6-beta** (2026-05-24) — ACNH icon gap-fill (95.5% coverage), hand-drawn goldfish/tadpole/agrias-butterfly icons. Previous betas: **v0.9.5-beta** (ACNL icon gap-fill, 96.5%; ACCF to 100%), **v0.9.4-beta** (silhouette rendering + ACWW icon gap-fill), **v0.9.3-beta** (JSON save-file round-trip + onboarding fixes), **v0.9.2-beta** (cross-game icon routing + first hand-drawn icons), **v0.9.1-beta** (ACGCN item icons), **v0.9.0-beta** (full UI revamp). Last stable on `main`: **v0.8.2-alpha**. See [CHANGELOG.md](CHANGELOG.md) for history and [docs/roadmap-to-v1.md](docs/roadmap-to-v1.md) for the path to v1.0.
+Current release: **v0.9.6-beta** (2026-05-24) — ACNH icon gap-fill (95.5% coverage), hand-drawn goldfish/tadpole/agrias-butterfly icons. Previous betas: **v0.9.5-beta** (ACNL icon gap-fill, 96.5%; ACCF to 100%), **v0.9.4-beta** (silhouette rendering + ACWW icon gap-fill), **v0.9.3-beta** (JSON save-file round-trip + onboarding fixes), **v0.9.2-beta** (cross-game icon routing + first hand-drawn icons), **v0.9.1-beta** (ACGCN item icons), **v0.9.0-beta** (full UI revamp). Last stable on `main`: **v0.9.6-beta**. See [CHANGELOG.md](CHANGELOG.md) for history and [docs/roadmap-to-v1.md](docs/roadmap-to-v1.md) for the path to v1.0.
 
 Significant design decisions are logged in [docs/decisions.md](docs/decisions.md).

--- a/docs/roadmap-to-v1.md
+++ b/docs/roadmap-to-v1.md
@@ -6,7 +6,7 @@ Last updated: **2026-05-27** (after v0.9.6-beta shipped).
 
 ## Where the project sits
 
-- **Current public release:** v0.9.6-beta — ACNH icon gap-fill (ACNH coverage to ~100%), two new hand-drawn icons (tadpole, agrias butterfly), doc syncs.
+- **Current public release:** v0.9.6-beta — ACNH icon gap-fill (95.5% coverage, 315/330), three new hand-drawn icons (goldfish, tadpole, agrias butterfly), doc syncs.
 - **Cadence:** roughly one focused beta every 2-4 days since v0.6 (April 2026). The path to v1.0 holds that pace.
 - **Principle:** one focused track per beta. Polish bundles ship as their own betas, not bundled with feature work.
 

--- a/public/version-history.html
+++ b/public/version-history.html
@@ -484,15 +484,15 @@
               <div class="tl-card-head">
                 <span class="version-badge">v0.9.6-beta</span>
                 <span class="version-title"
-                  >ACNH icon gap-fill + two hand-drawn icons</span
+                  >ACNH icon gap-fill + three hand-drawn icons</span
                 >
                 <span class="velocity-chip">17 days after v0.9.5</span>
               </div>
               <ul class="tl-bullets">
                 <li>
-                  ACNH icon gap-fill — 103 unique items scraped via the
+                  ACNH icon gap-fill — 88 wiki-scraped items added via the
                   algorithmic-resolver-plus-OVERRIDES pattern; ACNH icon
-                  coverage reaches ~100% after cross-game routing; resolver
+                  coverage reaches 95.5% (315/330) after cross-game routing; resolver
                   <code>/Gallery</code> deprioritization from v0.9.5 applied
                   directly
                 </li>
@@ -1555,8 +1555,8 @@
                 <td style="padding: 0.6rem 1rem">May 27</td>
                 <td style="padding: 0.6rem 1rem">17 days</td>
                 <td style="padding: 0.6rem 1rem">
-                  ACNH icon gap-fill (~100%) + two hand-drawn icons (tadpole,
-                  agrias butterfly) + doc syncs
+                  ACNH icon gap-fill (95.5%) + three hand-drawn icons
+                  (goldfish, tadpole, agrias butterfly) + doc syncs
                 </td>
               </tr>
               <tr style="border-top: 1px solid var(--border)">


### PR DESCRIPTION
## Summary

Nightly doc-sync audit 2026-07-06 found five clear-drift corrections across three files.

**ACNH coverage overstated as "~100%" (2 files, 3 spots).** `CHANGELOG.md`'s `[v0.9.6-beta]` entry and the published GitHub release both document ACNH icon coverage landing at **95.5% (315/330)** with **88** wiki-scraped items added (103 was the pre-work gap estimate carried over from the v0.9.5 planning section, not the actual scrape count — 88 scraped + 15 genuine gaps = 103). `docs/roadmap-to-v1.md` (line 9) and `public/version-history.html` (the v0.9.6-beta timeline card and its velocity-table row) still said "~100%" / "103 unique items scraped".

**Hand-drawn icon count undercounted (2 spots in version-history.html).** The v0.9.6-beta timeline card title and velocity-table row both said "two hand-drawn icons (tadpole, agrias butterfly)", omitting goldfish — self-contradicting the timeline card's own bullet two lines below, which correctly lists all three (goldfish 8th, tadpole 9th, agrias butterfly 10th).

**`README.md` — stale "Last stable on main" claim.** Said `v0.8.2-alpha`. `git tag --merged origin/main` confirms every v0.9.x beta through v0.9.6-beta has since merged and tagged on `main` (release-branch process per `docs/roadmap-to-v1.md`'s process invariants), so `main` is now at `v0.9.6-beta`.

### Not touched

- `CLAUDE.md` — already correct (a prior cleanup, PR #157/#159, fixed the version drift and dead-file references there)
- `CLAUDE.md`'s v0.9.6-beta Roadmap section still reads "(next milestone)" instead of "shipped" — this is covered by existing open draft PR #149, not duplicated here
- `.claude/rules/architecture.md` / `docs/architecture.md` header + dead-file refs — covered by existing open draft PR #163
- `CLAUDE.md` missing `storeMigrations.test.ts` / `bootstrapMigration.test.ts` entries — covered by existing open draft PR #164
- `CLAUDE.md`'s stale `modals/` directory node — covered by existing open draft PR #165
- `public/version-history.html`'s "Currently building" checklist (ACWW/ACNH stats, hand-drawn count) — covered by existing open draft PR #162
- No other drift found in `package.json`, `CHANGELOG.md`, or the architecture docs' file-path references (verified every backtick-quoted path against the filesystem)

## Test plan

- [ ] `docs/roadmap-to-v1.md` line 9 reads "95.5% coverage, 315/330" and "three new hand-drawn icons (goldfish, tadpole, agrias butterfly)"
- [ ] `public/version-history.html`: v0.9.6-beta timeline card title and bullet both say "three hand-drawn icons" / "95.5% (315/330)"; velocity table row matches
- [ ] `README.md`: "Last stable on `main`" reads `v0.9.6-beta`
- [ ] Doc-only change — no build impact

---
_Generated by nightly doc-sync audit · 2026-07-06_

---
_Generated by [Claude Code](https://claude.ai/code/session_01GRwmcv7coQteYTq3zfESaf)_